### PR TITLE
Update test.yaml to not separately lint utils

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade black
         black --line-length 120 --check adept
-        black --line-length 120 --check utils
         python -m pip install --upgrade pytest wheel
         python -m pip install --upgrade -r requirements-cpu.txt
       


### PR DESCRIPTION
- `utils` was moved to `adept/`
- tests were not updated and are [failing](https://github.com/ergodicio/adept/actions/runs/10086093499)