### PR TITLE
Implemented an inialisation of local form of f10 by taking an artific…

### DIFF
--- a/adept/vfp1d/helpers.py
+++ b/adept/vfp1d/helpers.py
@@ -9,6 +9,7 @@ from scipy.special import gamma
 from astropy.units import Quantity as _Q
 from jax import numpy as jnp
 from adept._base_ import get_envelope
+
 # ideally this should be passed as as an argument and not re-initialised
 from adept.vfp1d.vector_field import OSHUN1D
 
@@ -112,7 +113,7 @@ def _initialize_distribution_(
     for ix, (tn, tt) in enumerate(zip(n_prof, T_prof)):
         # eq 4-51b in Shkarofsky
         # redundant
-        #single_dist = (2 * np.pi * tt * (vth**2.0 / 2)) ** -1.5 * np.exp(-(vax**2.0) / (2 * tt * (vth**2.0 / 2)))
+        # single_dist = (2 * np.pi * tt * (vth**2.0 / 2)) ** -1.5 * np.exp(-(vax**2.0) / (2 * tt * (vth**2.0 / 2)))
 
         # from Ridgers2008, allows initialisation as a super-Gaussian with temperature tt
         vth_x = np.sqrt(tt) * vth
@@ -212,18 +213,18 @@ def _initialize_total_distribution_(cfg, cfg_grid):
             # initialize f1 by taking a big time step while keeping f0 fix (essentailly sets electron inertia to 0)
             # I don't like having to reinitialise oshun to get helper functions, either we pass as an argument or refactor
             oshun = OSHUN1D(cfg)
-            big_dt = 1E12
+            big_dt = 1e12
             ni = prof_total["n"] / cfg["units"]["Z"]
             f10_star = -big_dt * oshun.v[None, :] * oshun.ddx(f0)
-            f10_from_adv = oshun.ei(Z= jnp.ones(cfg["grid"]["nx"]), ni=ni, f0=f0, f10=f10_star, dt=big_dt)
+            f10_from_adv = oshun.ei(Z=jnp.ones(cfg["grid"]["nx"]), ni=ni, f0=f0, f10=f10_star, dt=big_dt)
             jx_from_adv = oshun.calc_j(f10_from_adv)
 
             df0dv = oshun.ddv(f0)
-            f10_from_df0dv = oshun.ei(Z= jnp.ones(cfg["grid"]["nx"]), ni=ni, f0=f0, f10=df0dv, dt=big_dt)
+            f10_from_df0dv = oshun.ei(Z=jnp.ones(cfg["grid"]["nx"]), ni=ni, f0=f0, f10=df0dv, dt=big_dt)
             jx_from_df0dv = oshun.calc_j(f10_from_df0dv)
 
             # directly solve for ex field
-            e_tmp = - jx_from_adv / jx_from_df0dv
+            e_tmp = -jx_from_adv / jx_from_df0dv
 
             f10 += f10_from_adv + e_tmp[:, None] * f10_from_df0dv
 

--- a/adept/vfp1d/helpers.py
+++ b/adept/vfp1d/helpers.py
@@ -9,6 +9,8 @@ from scipy.special import gamma
 from astropy.units import Quantity as _Q
 from jax import numpy as jnp
 from adept._base_ import get_envelope
+# ideally this should be passed as as an argument and not re-initialised
+from adept.vfp1d.vector_field import OSHUN1D
 
 
 def gamma_3_over_m(m: float) -> Array:
@@ -92,7 +94,7 @@ def _initialize_distribution_(
     """
     Initializes a Maxwell-Boltzmann distribution
 
-    TODO: temperature and density pertubations
+    TODO: temperature and density pertubations (JPB - this is done right so can delete this line?)
 
     :param nx: size of grid in x (single int)
     :param nv: size of grid in v (single int)
@@ -106,11 +108,13 @@ def _initialize_distribution_(
     vax = np.linspace(dv / 2.0, vmax - dv / 2.0, nv)
 
     f = np.zeros([nx, nv])
+    # obviously not a bottleneck as initialisation, but this should be trivial to vectorize
     for ix, (tn, tt) in enumerate(zip(n_prof, T_prof)):
         # eq 4-51b in Shkarofsky
-        single_dist = (2 * np.pi * tt * (vth**2.0 / 2)) ** -1.5 * np.exp(-(vax**2.0) / (2 * tt * (vth**2.0 / 2)))
+        # redundant
+        #single_dist = (2 * np.pi * tt * (vth**2.0 / 2)) ** -1.5 * np.exp(-(vax**2.0) / (2 * tt * (vth**2.0 / 2)))
 
-        # from Ridgers2008
+        # from Ridgers2008, allows initialisation as a super-Gaussian with temperature tt
         vth_x = np.sqrt(tt) * vth
         alpha = np.sqrt(3.0 * gamma_3_over_m(m) / 2.0 / gamma_5_over_m(m))
         cst = m / (4 * np.pi * alpha**3.0 * gamma_3_over_m(m))
@@ -138,7 +142,8 @@ def _initialize_total_distribution_(cfg, cfg_grid):
     params = cfg["density"]
     prof_total = {"n": np.zeros([cfg_grid["nx"]]), "T": np.zeros([cfg_grid["nx"]])}
 
-    f = np.zeros([cfg_grid["nx"], cfg_grid["nv"]])
+    f0 = np.zeros([cfg_grid["nx"], cfg_grid["nv"]])
+    f10 = np.zeros([cfg_grid["nx"], cfg_grid["nv"]])
     species_found = False
     for name, species_params in cfg["density"].items():
         if name.startswith("species-"):
@@ -189,7 +194,7 @@ def _initialize_total_distribution_(cfg, cfg_grid):
             prof_total["n"] += profs["n"]
 
             # Distribution function
-            temp_f, _ = _initialize_distribution_(
+            temp_f0, _ = _initialize_distribution_(
                 nx=int(cfg_grid["nx"]),
                 nv=int(cfg_grid["nv"]),
                 v0=v0,
@@ -202,7 +207,26 @@ def _initialize_total_distribution_(cfg, cfg_grid):
                 noise_seed=int(species_params["noise_seed"]),
                 noise_type=species_params["noise_type"],
             )
-            f += temp_f
+            f0 += temp_f0
+
+            # initialize f1 by taking a big time step while keeping f0 fix (essentailly sets electron inertia to 0)
+            # I don't like having to reinitialise oshun to get helper functions, either we pass as an argument or refactor
+            oshun = OSHUN1D(cfg)
+            big_dt = 1E12
+            ni = prof_total["n"] / cfg["units"]["Z"]
+            f10_star = -big_dt * oshun.v[None, :] * oshun.ddx(f0)
+            f10_from_adv = oshun.ei(Z= jnp.ones(cfg["grid"]["nx"]), ni=ni, f0=f0, f10=f10_star, dt=big_dt)
+            jx_from_adv = oshun.calc_j(f10_from_adv)
+
+            df0dv = oshun.ddv(f0)
+            f10_from_df0dv = oshun.ei(Z= jnp.ones(cfg["grid"]["nx"]), ni=ni, f0=f0, f10=df0dv, dt=big_dt)
+            jx_from_df0dv = oshun.calc_j(f10_from_df0dv)
+
+            # directly solve for ex field
+            e_tmp = - jx_from_adv / jx_from_df0dv
+
+            f10 += f10_from_adv + e_tmp[:, None] * f10_from_df0dv
+
             species_found = True
         else:
             pass
@@ -210,4 +234,4 @@ def _initialize_total_distribution_(cfg, cfg_grid):
     if not species_found:
         raise ValueError("No species found! Check the config")
 
-    return f, prof_total["n"]
+    return f0, f10, prof_total["n"]

--- a/adept/vfp1d/vector_field.py
+++ b/adept/vfp1d/vector_field.py
@@ -98,6 +98,11 @@ class OSHUN1D:
 
         """
 
+        # Questions:
+        # Is there a better way to get ∆J/∆E? e.g. using jvp
+        # or at least reusing the two self.ei calls rather than running for a third time after?
+        # Also note that second order effects only come from v df0dx and f2 terms.
+
         # calculate j without any e field
         f10_after_coll = self.ei(Z=Z, ni=ni, f0=f0, f10=f10, dt=self.dt)
         j0 = self.calc_j(f10_after_coll)
@@ -105,7 +110,7 @@ class OSHUN1D:
         # get perturbation
         de = jnp.abs(e) * self.large_eps + self.eps
 
-        # calculate effect of dex
+        # calculate effect of dex (if we are doing it this way, would there be any harm using f0_after_dex too?)
         _, f10_after_dex = self.push_edfdv(f0, f10, de)
         f10_after_dex = self.ei(Z=Z, ni=ni, f0=f0, f10=f10_after_dex, dt=self.dt)
         jx_dx = self.calc_j(f10_after_dex)

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,5 +1,4 @@
-jaxlib==0.4.26
-jax==0.4.26
+jax[cpu]
 diffrax
 matplotlib
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jax[cpu]
+jax[cuda12]
 diffrax
 matplotlib
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-jaxlib==0.4.26+cuda12.cudnn89
-jax==0.4.26
+jax[cpu]
 diffrax
 matplotlib
 scipy


### PR DESCRIPTION
Implemented an initialisation of local form of f10 by taking an artificially large timestep while keeping f0 fixed. This is essentially equivalent to temporarily reducing the electron mass and thus the effect of electron inertia. I have tested this in an untracked adept notebook and seems to work well when using nuei_scaling. It is untested when including anisotropic ee collisions, but should work as well as the assumption that a tridiagonal representation of these is sufficient. If this turns out to not be the case we might have to use some iterative method or a dense matrix solve. Currently, this is hard-coded and should ideally be an option in the yaml file but I did not want to create an extra dependency in the yaml file and break any of your code, if you can advise how to add switches while maintaining backwards compatibility going forwards that would be much appreciated.

Also implemented an option to boost isotropic electron-electron collisions to reduce nonlocal effects and restore to Maxwellian quicker. Note that at low Z electron inertia effects may still be prominent as the boost not impact this. Again no switch has been provided and the relevant lines have been commented out.

Also moved anisotropic ee diag contributions in the self.ee if statement as there is no point calculating these if using nuei_scaling.

Note vector_field is no longer in sync with oshun.py, whereas previously they were identical. We should consider removing oshun.py.

Finally, a few minor comments/questions, some we have previously discussed.

Happy to take on any feedback, thanks! :-) JPB