### PR TITLE
Exposed args to ErgoExo, provided _mflow_func abstraction

### DIFF
--- a/adept/vfp1d/base.py
+++ b/adept/vfp1d/base.py
@@ -25,8 +25,7 @@ class BaseVFP1D(ADEPTModule):
         Te = u.Quantity(self.cfg["units"]["reference electron temperature"]).to("eV")
         Ti = u.Quantity(self.cfg["units"]["reference ion temperature"]).to("eV")
         Z = self.cfg["units"]["Z"]
-        # Should we change this to reference electron density? or allow it to be user set?
-        n0 = u.Quantity("9.0663e21/cm^3")
+        n0 = u.Quantity(self.cfg["units"]["reference electron density"]).to("1/cm^3")
         ion_species = self.cfg["units"]["Ion"]
 
         wp0 = np.sqrt(n0 * csts.e.to("C") ** 2.0 / (csts.m_e * csts.eps0)).to("Hz")

--- a/adept/vfp1d/fokker_planck.py
+++ b/adept/vfp1d/fokker_planck.py
@@ -103,7 +103,7 @@ class FLMCollisions:
         self.dv = cfg["grid"]["dv"]
         self.Z = cfg["units"]["Z"]
 
-        r_e = 2.8179402894e-13
+        r_e = 2.8179402894e-13  # cm
         kp = np.sqrt(4 * np.pi * cfg["units"]["derived"]["n0"].to("1/cm^3").value * r_e)
         kpre = r_e * kp
         self.nuee_coeff = kpre * cfg["units"]["derived"]["logLambda_ee"]


### PR DESCRIPTION
ErgoExo now takes `args` as an additional argument to `__call__` and `value_and_grad`, enabling another way to "train" opposed to `modules`.

Abstracted `__call__` by adding `_mlflow_func` abstraction which could work for value_and_grad if we break backwards compatibility by changing return type slightly (e.g. packaging grad, val in a tuple), happy to discuss.