### PR TITLE
chore: add mlruns directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,5 +125,8 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# mflow
+*mlruns/
+
 # Pyre type checker
 .pyre/


### PR DESCRIPTION
If simulations are run in the repo directory for testing these folders show up in `git status`. If we'd rather dissuade these being created in the repo in the first place, I'm happy to close.