### PR TITLE
refactor(test): removed main method from tests + skpi tf1d res on cpu

### DIFF
--- a/tests/test_lpse2d/test_epw_frequency.py
+++ b/tests/test_lpse2d/test_epw_frequency.py
@@ -99,8 +99,3 @@ def _imaginary_part_():
 @pytest.mark.parametrize("test_func", [_real_part_, _imaginary_part_])
 def test_epw_frequency(test_func):
     test_func()
-
-
-if __name__ == "__main__":
-    test_epw_frequency(_real_part_)
-    test_epw_frequency(_imaginary_part_)

--- a/tests/test_lpse2d/test_tpd_threshold.py
+++ b/tests/test_lpse2d/test_tpd_threshold.py
@@ -58,7 +58,3 @@ def test_threshold():
         # np.testing.assert_allclose(actual, desired=It, rtol=0.25)  # it is 25% because of the resolution of the scan.
         # The test itself is not quite working but you can examine the results visually and they make sense,
         # so we are leaving it this way for now
-
-
-if __name__ == "__main__":
-    test_threshold()

--- a/tests/test_tf1d/test_against_vlasov.py
+++ b/tests/test_tf1d/test_against_vlasov.py
@@ -56,7 +56,3 @@ def test_single_resonance():
 
     np.testing.assert_almost_equal(vlasov_damping_rate, fluid_damping_rate, decimal=2)
     np.testing.assert_allclose(np.amax(nk1_fluid), np.amax(nk1_vlasov), rtol=0.05)
-
-
-if __name__ == "__main__":
-    test_single_resonance()

--- a/tests/test_tf1d/test_landau_damping.py
+++ b/tests/test_tf1d/test_landau_damping.py
@@ -65,7 +65,3 @@ def test_single_resonance():
         )
 
         np.testing.assert_almost_equal(measured_damping_rate, 2 * actual_damping_rate, decimal=2)
-
-
-if __name__ == "__main__":
-    test_single_resonance()

--- a/tests/test_tf1d/test_resonance.py
+++ b/tests/test_tf1d/test_resonance.py
@@ -66,8 +66,3 @@ def test_single_resonance(gamma):
     )
     measured_resonance = np.mean(freq[frslc])
     np.testing.assert_almost_equal(measured_resonance, actual_resonance, decimal=2)
-
-
-if __name__ == "__main__":
-    for gamma in ["kinetic", 3.0]:
-        test_single_resonance(gamma)

--- a/tests/test_tf1d/test_resonance_search.py
+++ b/tests/test_tf1d/test_resonance_search.py
@@ -60,6 +60,8 @@ def load_cfg(rand_k0, gamma, adjoint):
 @pytest.mark.parametrize("adjoint", ["Recursive", "Backsolve"])
 @pytest.mark.parametrize("gamma", ["kinetic", 3.0])
 def test_resonance_search(gamma, adjoint):
+    if not any(["gpu" == device.platform for device in devices()]):
+        pytest.skip("Takes too long without a GPU")
     mlflow.set_experiment("tf1d-resonance-search")
     with mlflow.start_run(run_name="res-search-opt", log_system_metrics=True) as mlflow_run:
         # sim_k0, actual_w0 = init_w0(gamma, adjoint)
@@ -93,11 +95,3 @@ def test_resonance_search(gamma, adjoint):
         print(f"{actual_w0=}, {float(params['w0'])=}")
 
         np.testing.assert_allclose(actual_w0, float(params["w0"]), rtol=0.03)
-
-
-if __name__ == "__main__":
-    for gamma, adjoint in product(["kinetic", 3.0], ["Recursive", "Backsolve"]):
-        if not any(["gpu" == device.platform for device in devices()]):
-            pytest.skip("Takes too long without a GPU")
-        else:
-            test_resonance_search(gamma, adjoint)

--- a/tests/test_vlasov1d/test_absorbing_wave.py
+++ b/tests/test_vlasov1d/test_absorbing_wave.py
@@ -74,7 +74,3 @@ def test_absorbing_boundaries():
     test_a = _run_({"a": a, "prev_a": a_old}, args)
 
     np.testing.assert_almost_equal(np.sum(np.square(test_a.ys["a"])), 0.0, decimal=8)
-
-
-if __name__ == "__main__":
-    test_absorbing_boundaries()

--- a/tests/test_vlasov1d/test_landau_damping.py
+++ b/tests/test_vlasov1d/test_landau_damping.py
@@ -83,7 +83,3 @@ def test_single_resonance(real_or_imag, time, field, edfdv):
             )
             measured_resonance = np.mean(freq[frslc])
             np.testing.assert_almost_equal(measured_resonance, actual_resonance, decimal=2)
-
-
-if __name__ == "__main__":
-    test_single_resonance(real_or_imag="real")

--- a/tests/test_vlasov2d/test_landau_damping.py
+++ b/tests/test_vlasov2d/test_landau_damping.py
@@ -86,7 +86,3 @@ def test_single_resonance(real_or_imag):
                     }
                 )
                 np.testing.assert_almost_equal(measured_resonance, actual_resonance, decimal=2)
-
-
-if __name__ == "__main__":
-    test_single_resonance(real_or_imag="real")


### PR DESCRIPTION
`if __name__ == "__main__"` is not necesssary with `pytest` it just searches for all functions beginning with `test_`. If you want to keep these for convenience feel free to close this PR. Also noticed that `test_tf1d/test_resonance_search` was not skipped as seemed to be desired when on `cpu`. I think this should address that too.