### PR TITLE
feat: init diffeqsolve before state and args

### DIFF
--- a/adept/_base_.py
+++ b/adept/_base_.py
@@ -335,8 +335,8 @@ class ergoExo:
             with open(os.path.join(td, "array_config.pkl"), "wb") as fi:
                 pickle.dump(self.adept_module.cfg, fi)
 
-        self.adept_module.init_state_and_args()
         self.adept_module.init_diffeqsolve()
+        self.adept_module.init_state_and_args()
         modules = self.adept_module.init_modules()
 
         self.ran_setup = True


### PR DESCRIPTION
Hopefully this doesn't break anything. This is required to improve a lagradept refactor supporting hydro rework. Basically I need to be able to use methods of pushers that only get initialised in `init_diffeqsolve`. I don't think `init_diffeqsolve` should be depending on state or args, please let me know if this is assumption is wrong. If all fine I'd like to merge asap please. 🙏🏻 