### PR TITLE
feat: Pass mlflow_kwargs through to start_run

### DIFF
--- a/tests/test_base/test_mlflow_logging.py
+++ b/tests/test_base/test_mlflow_logging.py
@@ -2,8 +2,22 @@ import re
 
 import jax
 import jax.numpy as jnp
+import mlflow
 
 from adept import MlflowLoggingModule
+from adept.mlflow_logging import MLRunId
+
+
+def parse_unique_mlflow_run_id(capsys):
+    captured = capsys.readouterr()
+    pattern = r"""PRE_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, mlflow_run_id=(\w{32})
+POST_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, result=10.5, mlflow_run_id=(\w{32})
+"""
+    print(captured.out)
+    match = re.search(pattern, captured.out)
+    assert match is not None
+    assert match.group(1) == match.group(2)
+    return match.group(1)
 
 
 class ScaleAndAddModule(MlflowLoggingModule):
@@ -69,27 +83,14 @@ def test_pre_and_post_logging(capsys):
     saam = ScaleAndAddModule(True, 3.0)
     saam(2.0, b=4.5, mlflow_batch_num=0)
 
-    captured = capsys.readouterr()
-    pattern = r"""PRE_LOGGING | a=2.0, b=4.5, abs2\(s\)=9.0, mlflow_run_id=(\w{32})
-POST_LOGGING | a=2.0, b=4.5, abs2\(s\)=9.0, result=10.5, mlflow_run_id=(\w{32})
-"""
-    match = re.search(pattern, captured.out)
-    assert match is not None
-    assert match.group(1) == match.group(2)
+    parse_unique_mlflow_run_id(capsys)
 
 
 def test_pre_and_post_logging_grad(capsys):
     saam = ScaleAndAddModule(True, 3.0)
     jax.grad(saam)(2.0, b=4.5, mlflow_batch_num=0)
 
-    captured = capsys.readouterr()
-    pattern = r"""PRE_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, mlflow_run_id=(\w{32})
-POST_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, result=10.5, mlflow_run_id=(\w{32})
-"""
-    match = re.fullmatch(pattern, captured.out, re.MULTILINE)
-    assert match is not None
-    assert match.group(1) is not None
-    assert match.group(1) == match.group(2)
+    parse_unique_mlflow_run_id(capsys)
 
 
 def test_adroit_module_mlflow_with_vmap(capsys):
@@ -98,6 +99,93 @@ def test_adroit_module_mlflow_with_vmap(capsys):
     result = jax.vmap(saam)(2.0 * jnp.ones(3), mlflow_batch_num=jnp.arange(3), b=4.5 * jnp.ones(3))
 
     captured = capsys.readouterr()
+
+    pre_logging_pattern = r"PRE_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, mlflow_run_id=(\w{32})"
+    post_logging_pattern = r"POST_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, result=10.5, mlflow_run_id=(\w{32})"
+
+    pre_logging_matches = list(re.finditer(pre_logging_pattern, captured.out))
+    post_logging_matches = list(re.finditer(post_logging_pattern, captured.out))
+
+    assert len(pre_logging_matches) == 3
+    assert len(set([m.group(1) for m in pre_logging_matches])) == 3
+    assert len(post_logging_matches) == 3
+    assert len(set([m.group(1) for m in post_logging_matches])) == 3
+
+    assert set([m.group(1) for m in pre_logging_matches]) == set([m.group(1) for m in post_logging_matches])
+
+
+def test_mlflow_logging_module_in_manually_created_parent_run(capsys):
+    with mlflow.start_run() as parent_run:
+        saam = ScaleAndAddModule(True, 3.0)
+        parent_run_id = MLRunId(parent_run.info.run_id)
+        saam(2.0, b=4.5, mlflow_batch_num=0, mlflow_kwargs={"parent_run_id": parent_run_id})
+
+    run_id = parse_unique_mlflow_run_id(capsys)
+    child_runs = mlflow.search_runs(filter_string=f"attributes.run_id = '{run_id}'", output_format="list")
+    assert len(child_runs) == 1
+    assert child_runs[0].data.tags["mlflow.parentRunId"] == parent_run.info.run_id
+
+
+def test_adroit_module_base_call_mlflow_kwargs(capsys):
+    saam = ScaleAndAddModule(True, 3.0)
+
+    result = saam(
+        2.0,
+        b=4.5,
+        mlflow_batch_num=0,
+        mlflow_kwargs={"run_name": "ScaleAndAdd", "description": "really great", "tags": {"foo": "bar"}},
+    )
+    assert result == 10.5
+
+    run_id = parse_unique_mlflow_run_id(capsys)
+
+    runs = mlflow.search_runs(filter_string=f"attributes.run_id = '{run_id}'", output_format="list")
+    assert len(runs) == 1
+    assert runs[0].data.tags["foo"] == "bar"
+    assert runs[0].data.tags["mlflow.note.content"] == "really great"
+    assert runs[0].info.run_name == "ScaleAndAdd"
+
+
+class OuterScalingAndAddingModule(MlflowLoggingModule):
+    saam: ScaleAndAddModule
+    b: float
+
+    def setup(self, *args, **kwargs):
+        pass
+
+    def call(self, a, mlflow_run_id=None, **kwargs):
+        return self.saam(a, b=self.b, mlflow_kwargs={"parent_run_id": mlflow_run_id}, mlflow_batch_num=0)
+
+    def pre_logging(self, *args, **kwargs):
+        pass
+
+    def post_logging(self, *args, **kwargs):
+        pass
+
+
+def test_nested_mlflow_logging_modules(capsys):
+    saam = ScaleAndAddModule(True, 3.0)
+    b = 4.5
+    outer_module = OuterScalingAndAddingModule(True, saam, b)
+
+    outer_module(2.0, mlflow_batch_num=0)
+
+    child_run_id = parse_unique_mlflow_run_id(capsys)
+    child_runs = mlflow.search_runs(filter_string=f"attributes.run_id = '{child_run_id}'", output_format="list")
+    assert len(child_runs) == 1
+    assert child_runs[0].data.tags["mlflow.parentRunId"] is not None
+
+
+def test_nested_mlflow_logging_modules_vmap(capsys):
+    saam = ScaleAndAddModule(True, 3.0)
+    b = 4.5
+    outer_module = OuterScalingAndAddingModule(True, saam, b)
+
+    jax.vmap(outer_module)(2 * jnp.ones(3), mlflow_batch_num=jnp.arange(3))
+
+    captured = capsys.readouterr()
+
+    print(captured.out)
 
     pre_logging_pattern = r"PRE_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, mlflow_run_id=(\w{32})"
     post_logging_pattern = r"POST_LOGGING \| a=2.0, b=4.5, abs2\(s\)=9.0, result=10.5, mlflow_run_id=(\w{32})"


### PR DESCRIPTION
Allow passing the `run_name`, `parent_run_id`, and other arguments to `start_run`.