### PR TITLE
Add basic documentation for LLM agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# ADEPT
+
+The ADEPT repo is a collection of solvers for differentiable plasma physics.
+
+- @docs/ARCHITECTURE.md
+- @docs/RUNNING_A_SIM.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,8 @@
+# ADEPT Architecture
+
+- ADEPT solvers are packaged into `ADEPTModule`s and run via the `ergoExo`
+  Code pointer: `adept/_base_.py`
+- The `ergoExo` manages creation of an MLflow "run" and calls lifecycle methods on the `ADEPTModule` to perform logging of configuration, parameters, and run artifacts.
+  Code pointer: `adept/_base_.py: ergoExo#_setup_()`
+- The different `ADEPTModule`s are defined in subdirectories of `adept`, for example `_vlasov1d`, `_lpse2d`, etc.
+- `ADEPTModule`s wrap a `diffrax` differential equation solver. The RHS of the ODE (often a discretized PDE) is typically found in a file named `vector_field.py`, in the class `VectorField`. For example, the Vlasov1D RHS is defined in `adept/_vlasov1d/solvers/vector_field.py`.

--- a/docs/RUNNING_A_SIM.md
+++ b/docs/RUNNING_A_SIM.md
@@ -1,0 +1,13 @@
+# Running a simulation
+
+Simulations are defined by YAML config files.
+To run a single simulation,
+```
+uv run run.py --cfg path_to_my_config
+```
+
+## Module-Specific Configuration Reference
+
+- [Vlasov-1D](vlasov1d.md) - 1D Vlasov-Poisson/Maxwell solver with Fokker-Planck collisions
+- [Vlasov-2D](vlasov2d.md) - 2D2V Vlasov-Maxwell solver
+- [LPSE-2D (Envelope-2D)](lpse2d.md) - 2D laser-plasma envelope solver for TPD/SRS

--- a/docs/lpse2d.md
+++ b/docs/lpse2d.md
@@ -1,0 +1,477 @@
+# LPSE-2D (Envelope-2D) Configuration Reference
+
+This document describes how to construct a configuration file for the `envelope-2d` solver. This is a 2D laser-plasma simulation using envelope equations for electron plasma waves (EPW). It supports two-plasmon decay (TPD), stimulated Raman scattering (SRS), and other laser-plasma instabilities.
+
+## Top-Level Structure
+
+```yaml
+solver: envelope-2d
+
+units:
+  # Physical unit normalizations
+
+density:
+  # Density profile configuration
+
+grid:
+  # Simulation grid parameters
+
+save:
+  # Output configuration
+
+mlflow:
+  # Experiment tracking
+
+drivers:
+  # Laser and EPW drivers
+
+terms:
+  # Physics terms configuration
+```
+
+## units
+
+Physical unit normalizations. Note: This module uses different unit keys than the Vlasov modules.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `atomic number` | int | Atomic number of the ion species |
+| `envelope density` | float | Reference density as fraction of critical density |
+| `ionization state` | int | Ionization state Z |
+| `laser intensity` | string | Laser intensity with unit, e.g., `"3.5e+14W/cm^2"` |
+| `laser_wavelength` | string | Laser wavelength with unit, e.g., `"351nm"` |
+| `reference electron temperature` | string | Electron temperature with unit, e.g., `"2000.0eV"` |
+| `reference ion temperature` | string | Ion temperature with unit, e.g., `"1000eV"` |
+
+Example:
+```yaml
+units:
+  atomic number: 40
+  envelope density: 0.25
+  ionization state: 6
+  laser intensity: 1.5e+14W/cm^2
+  laser_wavelength: 351nm
+  reference electron temperature: 2000.0eV
+  reference ion temperature: 1000eV
+```
+
+## density
+
+Density profile configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `basis` | string | Profile type: `"uniform"` or `"linear"` |
+| `gradient scale length` | string | Scale length with unit (for `linear` basis) |
+| `max` | float | Maximum density fraction (for `linear` basis) |
+| `min` | float | Minimum density fraction (for `linear` basis) |
+| `noise` | object | Initial noise configuration |
+
+### noise
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `max` | float | Maximum noise amplitude |
+| `min` | float | Minimum noise amplitude |
+| `type` | string | `"uniform"` or `"normal"` |
+
+### Example: Uniform Density
+
+```yaml
+density:
+  basis: uniform
+  noise:
+    max: 1.0e-09
+    min: 1.0e-10
+    type: uniform
+```
+
+### Example: Linear Density Gradient
+
+```yaml
+density:
+  basis: linear
+  gradient scale length: 50um
+  max: 0.28
+  min: 0.18
+  noise:
+    max: 1.0e-09
+    min: 1.0e-10
+    type: uniform
+```
+
+Note: When using `linear` basis, the grid size is automatically computed from the gradient scale length and density range.
+
+## grid
+
+Simulation grid parameters. Note: Grid values use physical units as strings.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `boundary_abs_coeff` | float | Absorbing boundary coefficient |
+| `boundary_width` | string | Width of absorbing boundary layer with unit |
+| `low_pass_filter` | float | Low-pass filter cutoff as fraction of kmax (0-1) |
+| `dt` | string | Timestep with unit |
+| `dx` | string | Spatial resolution with unit |
+| `tmax` | string | End time with unit |
+| `tmin` | string | Start time with unit |
+| `ymax` | string | Domain maximum y with unit |
+| `ymin` | string | Domain minimum y with unit |
+
+Note: `nx` and `ny` are computed automatically from the grid parameters. The grid is optimized for FFT performance (sizes with small prime factors).
+
+Example:
+```yaml
+grid:
+  boundary_abs_coeff: 1.0e4
+  boundary_width: 1.5um
+  low_pass_filter: 0.66
+  dt: 0.010fs
+  dx: 40nm
+  tmax: 2ps
+  tmin: 0.0ns
+  ymax: 0.08um
+  ymin: -0.08um
+```
+
+## save
+
+Configures what data to save and at what times.
+
+### Structure
+
+```yaml
+save:
+  fields:
+    t:
+      dt: 100fs
+      tmax: 4ps
+      tmin: 0ps
+    x:
+      dx: 50nm
+    y:
+      dy: 50nm
+```
+
+### fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `t` | object | Temporal save configuration |
+| `x` | object | Optional spatial subsampling in x |
+| `y` | object | Optional spatial subsampling in y |
+
+#### t (temporal)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dt` | string | Time interval between saves, with unit |
+| `tmax` | string | End time for saving, with unit |
+| `tmin` | string | Start time for saving, with unit |
+
+#### x (optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dx` | string | Spatial resolution for saved data, with unit |
+
+#### y (optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dy` | string | Spatial resolution for saved data, with unit |
+
+## mlflow
+
+Experiment tracking configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `experiment` | string | MLflow experiment name |
+| `run` | string | MLflow run name |
+
+Example:
+```yaml
+mlflow:
+  experiment: tpd
+  run: srs-test
+```
+
+## drivers
+
+Laser and EPW drivers.
+
+### E0 - Pump Laser Driver
+
+The main laser pump for TPD/SRS simulations.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `envelope` | object | Spatiotemporal envelope |
+| `delta_omega_max` | float | Maximum frequency spread (optional) |
+| `num_colors` | int | Number of laser colors (optional) |
+| `shape` | string | Amplitude shape: `"uniform"` (optional) |
+
+#### envelope
+
+All values are strings with physical units.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tc` | string | Temporal center |
+| `tr` | string | Temporal rise time |
+| `tw` | string | Temporal width |
+| `xc` | string | Spatial center (x) |
+| `xr` | string | Spatial rise (x) |
+| `xw` | string | Spatial width (x) |
+| `yc` | string | Spatial center (y) |
+| `yr` | string | Spatial rise (y) |
+| `yw` | string | Spatial width (y) |
+
+Example:
+```yaml
+drivers:
+  E0:
+    delta_omega_max: 0.015
+    envelope:
+      tc: 200.25ps
+      tr: 0.1ps
+      tw: 400ps
+      xc: 50um
+      xr: 0.2um
+      xw: 1000um
+      yc: 50um
+      yr: 0.2um
+      yw: 1000um
+    num_colors: 1
+    shape: uniform
+```
+
+### E2 - EPW Driver (Optional)
+
+Direct EPW driver for seeding or testing.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `envelope` | object | Same structure as E0 envelope |
+| `a0` | float | Amplitude |
+| `k0` | float | Wavenumber |
+| `w0` | float | Frequency |
+
+Example:
+```yaml
+drivers:
+  E2:
+    envelope:
+      tw: 200fs
+      tr: 25fs
+      tc: 150fs
+      xw: 500um
+      xc: 10um
+      xr: 0.2um
+      yr: 0.2um
+      yc: 0um
+      yw: 50um
+    a0: 1000
+    k0: -10.0
+    w0: 20.0
+```
+
+## terms
+
+Physics terms configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `epw` | object | Electron plasma wave configuration |
+| `zero_mask` | bool | Whether to zero out k=0 mode |
+
+### epw
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `boundary` | object | Boundary conditions |
+| `damping` | object | Damping mechanisms |
+| `density_gradient` | bool | Include density gradient effects |
+| `linear` | bool | Linear mode (disables nonlinear coupling) |
+| `source` | object | Source terms |
+| `hyperviscosity` | object | Optional hyperviscosity for numerical stability |
+| `trapping` | object | Optional trapping model |
+| `kinetic real part` | bool | Include kinetic correction to real frequency |
+
+#### boundary
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `x` | string | `"periodic"` or `"absorbing"` |
+| `y` | string | `"periodic"` or `"absorbing"` |
+
+#### damping
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `collisions` | bool or float | Collisional damping. `true` computes from plasma parameters, or specify rate directly |
+| `landau` | bool | Include Landau damping |
+
+#### source
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `noise` | bool | Add random noise source |
+| `tpd` | bool | Include two-plasmon decay source |
+| `srs` | bool | Include stimulated Raman scattering source (optional) |
+
+#### hyperviscosity (optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `coeff` | float | Hyperviscosity coefficient |
+| `order` | int | Order of hyperviscosity (must be even) |
+
+#### trapping (optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `active` | bool | Enable trapping model |
+| `kld` | float | k * lambda_D parameter |
+| `nuee` | float | Electron-electron collision frequency |
+
+### Example: TPD Simulation
+
+```yaml
+terms:
+  epw:
+    boundary:
+      x: absorbing
+      y: periodic
+    damping:
+      collisions: 1.0
+      landau: true
+    density_gradient: true
+    linear: true
+    source:
+      noise: true
+      tpd: false
+      srs: true
+  zero_mask: true
+```
+
+### Example: Simple EPW Test
+
+```yaml
+terms:
+  epw:
+    boundary:
+      x: periodic
+      y: periodic
+    damping:
+      collisions: false
+      landau: false
+    density_gradient: false
+    linear: True
+    source:
+      noise: false
+      tpd: false
+  zero_mask: false
+```
+
+## Complete Example
+
+```yaml
+solver: envelope-2d
+
+units:
+  atomic number: 40
+  envelope density: 0.25
+  ionization state: 6
+  laser intensity: 1.5e+14W/cm^2
+  laser_wavelength: 351nm
+  reference electron temperature: 2000.0eV
+  reference ion temperature: 1000eV
+
+density:
+  basis: linear
+  gradient scale length: 50um
+  max: 0.28
+  min: 0.18
+  noise:
+    max: 1.0e-09
+    min: 1.0e-10
+    type: uniform
+
+grid:
+  boundary_abs_coeff: 1.0e4
+  boundary_width: 1.5um
+  low_pass_filter: 0.66
+  dt: 0.010fs
+  dx: 40nm
+  tmax: 2ps
+  tmin: 0.0ns
+  ymax: 0.08um
+  ymin: -0.08um
+
+mlflow:
+  experiment: tpd
+  run: my-simulation
+
+save:
+  fields:
+    t:
+      dt: 0.2ps
+      tmax: 2ps
+      tmin: 0ps
+    x:
+      dx: 50nm
+    y:
+      dy: 50nm
+
+drivers:
+  E0:
+    delta_omega_max: 0.015
+    envelope:
+      tc: 200.25ps
+      tr: 0.1ps
+      tw: 400ps
+      xc: 50um
+      xr: 0.2um
+      xw: 1000um
+      yc: 50um
+      yr: 0.2um
+      yw: 1000um
+    num_colors: 1
+    shape: uniform
+
+terms:
+  epw:
+    boundary:
+      x: absorbing
+      y: periodic
+    damping:
+      collisions: 1.0
+      landau: true
+    density_gradient: true
+    linear: true
+    source:
+      noise: true
+      tpd: false
+      srs: true
+  zero_mask: true
+```
+
+## Example Configurations
+
+### EPW Linear Propagation
+
+See `configs/envelope-2d/epw.yaml` - Simple EPW test without instabilities.
+
+### Landau Damping
+
+See `configs/envelope-2d/damping.yaml` - EPW with Landau damping and trapping model.
+
+### Two-Plasmon Decay
+
+See `configs/envelope-2d/tpd.yaml` - TPD simulation with linear density gradient.
+
+### SRS / Reflection
+
+See `configs/envelope-2d/reflection.yaml` - SRS simulation with kinetic corrections.

--- a/docs/vlasov1d.md
+++ b/docs/vlasov1d.md
@@ -1,0 +1,447 @@
+# Vlasov-1D Configuration Reference
+
+This document describes how to construct a configuration file for the `vlasov-1d` solver.
+
+## Top-Level Structure
+
+```yaml
+solver: vlasov-1d
+
+units:
+  # Physical unit normalizations
+
+density:
+  # Species definitions
+
+grid:
+  # Simulation grid parameters
+
+save:
+  # Output configuration
+
+mlflow:
+  # Experiment tracking
+
+drivers:
+  # External drivers
+
+diagnostics:
+  # Diagnostic outputs
+
+terms:
+  # Solver configuration
+```
+
+## units
+
+Physical unit normalizations for the simulation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `laser_wavelength` | string | Laser wavelength with unit, e.g., `"351nm"` |
+| `normalizing_temperature` | string | Reference temperature with unit, e.g., `"2000eV"` |
+| `normalizing_density` | string | Reference density with unit, e.g., `"1.5e21/cc"` |
+| `Z` | int | Ionization state |
+| `Zp` | int | Plasma Z |
+
+Example:
+```yaml
+units:
+  laser_wavelength: 351nm
+  normalizing_temperature: 2000eV
+  normalizing_density: 1.5e21/cc
+  Z: 10
+  Zp: 10
+```
+
+## density
+
+Species and density configuration. You can define multiple "species" by using keys prefixed with `species-`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `quasineutrality` | bool | Whether to enforce quasineutrality |
+
+### Species Definition
+
+Each species is defined with a key starting with `species-` (e.g., `species-background`, `species-beam`, `species-electron1`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `noise_seed` | int | Random seed for noise initialization |
+| `noise_type` | string | `"gaussian"` or `"uniform"` |
+| `noise_val` | float | Amplitude of noise |
+| `v0` | float | Drift velocity (normalized) |
+| `T0` | float | Temperature (normalized to `normalizing_temperature`) |
+| `m` | float | Exponent for super-Gaussian distribution. `2.0` is Maxwellian |
+| `basis` | string | Spatial profile type (see below) |
+
+#### Basis Types
+
+**`uniform`**: Constant density profile
+```yaml
+species-background:
+  basis: uniform
+  # No additional parameters required
+```
+
+**`sine`**: Sinusoidal density perturbation
+```yaml
+species-background:
+  basis: sine
+  baseline: 1.0        # Base density
+  amplitude: 1.0e-4    # Perturbation amplitude
+  wavenumber: 0.3      # Wavenumber of perturbation
+```
+
+**`tanh`**: Hyperbolic tangent profile (for density gradients)
+```yaml
+species-background:
+  basis: tanh
+  baseline: 0.001      # Minimum density
+  bump_or_trough: bump # "bump" or "trough"
+  center: 2000.0       # Profile center location
+  rise: 25.0           # Steepness of transition
+  bump_height: 0.999   # Height of bump/trough
+  width: 3900.0        # Width of profile
+```
+
+**`linear`**: Linear density gradient
+```yaml
+species-background:
+  basis: linear
+  center: 1000.0
+  width: 500.0
+  rise: 10.0
+  gradient scale length: "100um"  # Gradient scale length with units
+  val at center: 1.0              # Density value at center
+```
+
+**`exponential`**: Exponential density gradient
+```yaml
+species-background:
+  basis: exponential
+  center: 1000.0
+  width: 500.0
+  rise: 10.0
+  gradient scale length: "100um"
+  val at center: 1.0
+```
+
+### Multi-Species Example
+
+```yaml
+density:
+  quasineutrality: true
+  species-electron1:
+    noise_seed: 420
+    noise_type: gaussian
+    noise_val: 0.0
+    v0: -1.5
+    T0: 0.2
+    m: 2.0
+    basis: sine
+    baseline: 0.5
+    amplitude: 1.0e-4
+    wavenumber: 0.3
+  species-electron2:
+    noise_seed: 420
+    noise_type: gaussian
+    noise_val: 0.0
+    v0: 1.5
+    T0: 0.2
+    m: 2.0
+    basis: sine
+    baseline: 0.5
+    amplitude: -1.0e-4
+    wavenumber: 0.3
+```
+
+## grid
+
+Simulation grid parameters.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dt` | float | Timestep (normalized) |
+| `nv` | int | Number of velocity grid points |
+| `nx` | int | Number of spatial grid points |
+| `tmin` | float | Start time |
+| `tmax` | float | End time |
+| `vmax` | float | Maximum velocity extent |
+| `xmin` | float | Domain minimum x |
+| `xmax` | float | Domain maximum x |
+
+Example:
+```yaml
+grid:
+  dt: 0.1
+  nv: 256
+  nx: 32
+  tmin: 0.0
+  tmax: 100.0
+  vmax: 6.4
+  xmin: 0.0
+  xmax: 20.94
+```
+
+## save
+
+Configures what data to save and at what times.
+
+### Structure
+
+```yaml
+save:
+  fields:
+    t:
+      tmin: 0.0
+      tmax: 100.0
+      nt: 601
+  electron:
+    t:
+      tmin: 0.0
+      tmax: 100.0
+      nt: 11
+```
+
+| Save Key | Description |
+|----------|-------------|
+| `fields` | Electric and magnetic field data |
+| `electron` | Electron distribution function |
+| `diag-vlasov-dfdt` | Time derivative from Vlasov operator (optional) |
+| `diag-fp-dfdt` | Time derivative from Fokker-Planck operator (optional) |
+
+Each save key contains a `t` sub-key with:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tmin` | float | Start time for saving |
+| `tmax` | float | End time for saving |
+| `nt` | int | Number of save points |
+
+## mlflow
+
+Experiment tracking configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `experiment` | string | MLflow experiment name |
+| `run` | string | MLflow run name |
+
+Example:
+```yaml
+mlflow:
+  experiment: basic-epw-for-plots
+  run: nonlinear
+```
+
+## drivers
+
+External electromagnetic drivers. Both `ex` and `ey` are dictionaries of named drivers.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ex` | dict | Longitudinal electric field drivers |
+| `ey` | dict | Transverse electric field drivers (for electromagnetic simulations) |
+
+Each driver is identified by a string key (e.g., `"0"`, `"1"`) and has these parameters:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `a0` | float | Driver amplitude |
+| `k0` | float | Wavenumber |
+| `w0` | float | Frequency |
+| `dw0` | float | Frequency offset/chirp |
+| `t_center` | float | Temporal envelope center |
+| `t_rise` | float | Temporal envelope rise time |
+| `t_width` | float | Temporal envelope width |
+| `x_center` | float | Spatial envelope center |
+| `x_rise` | float | Spatial envelope rise distance |
+| `x_width` | float | Spatial envelope width |
+
+### Example: Single ex driver
+
+```yaml
+drivers:
+  ex:
+    '0':
+      a0: 1.e-2
+      k0: 0.3
+      w0: 1.1598
+      dw0: 0.0
+      t_center: 40.0
+      t_rise: 5.0
+      t_width: 30.0
+      x_center: 0.0
+      x_rise: 10.0
+      x_width: 4000000.0
+  ey: {}
+```
+
+### Example: Multiple ey drivers (SRS simulation)
+
+```yaml
+drivers:
+  ex: {}
+  ey:
+    '0':
+      a0: 1.0
+      k0: 1.0
+      w0: 2.79
+      dw0: 0.0
+      t_center: 4000.0
+      t_rise: 20.0
+      t_width: 7900.0
+      x_center: 50.0
+      x_rise: 0.1
+      x_width: 1.0
+    '1':
+      a0: 1.e-6
+      k0: 1.0
+      w0: 1.63
+      dw0: 0.0
+      t_center: 4000.0
+      t_rise: 20.0
+      t_width: 7900.0
+      x_center: 3950.0
+      x_rise: 0.1
+      x_width: 1.0
+```
+
+## diagnostics
+
+Enable/disable diagnostic outputs.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `diag-vlasov-dfdt` | bool | Save df/dt from Vlasov operator |
+| `diag-fp-dfdt` | bool | Save df/dt from Fokker-Planck operator |
+
+Example:
+```yaml
+diagnostics:
+  diag-vlasov-dfdt: False
+  diag-fp-dfdt: False
+```
+
+## terms
+
+Solver algorithm configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `field` | string | Electric field solver: `"poisson"`, `"ampere"`, or `"hampere"` |
+| `edfdv` | string | Velocity advection scheme: `"exponential"` or `"cubic-spline"` |
+| `time` | string | Time integrator: `"sixth"` (6th order Hamiltonian) or `"leapfrog"` |
+| `fokker_planck` | object | Fokker-Planck collision operator configuration |
+| `krook` | object | Krook collision operator configuration |
+
+### Field Solvers
+
+- `"poisson"`: Spectral Poisson solver (works with any time integrator)
+- `"ampere"`: Ampere solver (requires `"leapfrog"` time integrator)
+- `"hampere"`: Hamiltonian Ampere solver (requires `"leapfrog"` time integrator)
+
+### fokker_planck
+
+Fokker-Planck collision operator.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_on` | bool | Enable/disable |
+| `type` | string | Collision type: `"Dougherty"` |
+| `time` | object | Temporal profile |
+| `space` | object | Spatial profile |
+
+### krook
+
+Krook collision operator (relaxation towards Maxwellian).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_on` | bool | Enable/disable |
+| `time` | object | Temporal profile |
+| `space` | object | Spatial profile |
+
+### Profile Objects (time/space)
+
+Both `fokker_planck` and `krook` use profile objects to define spatiotemporal variation of collision frequency:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `baseline` | float | Base collision frequency |
+| `bump_or_trough` | string | `"bump"` or `"trough"` |
+| `center` | float | Profile center |
+| `rise` | float | Transition steepness |
+| `slope` | float | Linear slope (typically 0.0) |
+| `bump_height` | float | Height of bump/depth of trough |
+| `width` | float | Profile width |
+
+### Example: With Fokker-Planck collisions
+
+```yaml
+terms:
+  field: poisson
+  edfdv: cubic-spline
+  time: sixth
+  fokker_planck:
+    is_on: True
+    type: Dougherty
+    time:
+      baseline: 1.0e-5
+      bump_or_trough: bump
+      center: 0.0
+      rise: 25.0
+      slope: 0.0
+      bump_height: 0.0
+      width: 100000.0
+    space:
+      baseline: 1.0
+      bump_or_trough: bump
+      center: 0.0
+      rise: 25.0
+      slope: 0.0
+      bump_height: 0.0
+      width: 100000.0
+  krook:
+    is_on: False
+    time:
+      baseline: 1.0
+      bump_or_trough: bump
+      center: 0.0
+      rise: 25.0
+      slope: 0.0
+      bump_height: 0.0
+      width: 100000.0
+    space:
+      baseline: 1.0
+      bump_or_trough: bump
+      center: 0.0
+      rise: 25.0
+      slope: 0.0
+      bump_height: 0.0
+      width: 100000.0
+```
+
+## Complete Examples
+
+### Electron Plasma Wave (EPW)
+
+See `configs/vlasov-1d/epw.yaml` - driven electron plasma wave with Fokker-Planck collisions.
+
+### Bump-on-Tail Instability
+
+See `configs/vlasov-1d/bump-on-tail.yaml` - two-species configuration with beam distribution.
+
+### Two-Stream Instability
+
+See `configs/vlasov-1d/twostream.yaml` - counter-streaming electron beams.
+
+### Stimulated Raman Scattering (SRS)
+
+See `configs/vlasov-1d/srs.yaml` - electromagnetic simulation with `ey` drivers.
+
+### Nonlinear EPW with Initial Condition
+
+See `configs/vlasov-1d/nlepw-ic.yaml` - large-amplitude initial perturbation without external driver.

--- a/docs/vlasov2d.md
+++ b/docs/vlasov2d.md
@@ -1,0 +1,445 @@
+# Vlasov-2D Configuration Reference
+
+This document describes how to construct a configuration file for the `vlasov-2d` solver. This is a 2D2V (2 spatial dimensions, 2 velocity dimensions) Vlasov-Maxwell solver.
+
+## Top-Level Structure
+
+```yaml
+units:
+  # Physical unit normalizations
+
+density:
+  # Species definitions
+
+grid:
+  # Simulation grid parameters
+
+save:
+  # Output configuration
+
+mlflow:
+  # Experiment tracking
+
+drivers:
+  # External drivers
+
+krook:
+  # Krook collision operator
+
+solver:
+  # Solver algorithm configuration
+```
+
+## units
+
+Physical unit normalizations for the simulation. Same structure as vlasov-1d.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `laser_wavelength` | string | Laser wavelength with unit, e.g., `"351nm"` |
+| `normalizing_temperature` | string | Reference temperature with unit, e.g., `"2000eV"` |
+| `normalizing_density` | string | Reference density with unit, e.g., `"1.5e21/cc"` |
+| `Z` | int | Ionization state |
+| `Zp` | int | Plasma Z |
+
+Example:
+```yaml
+units:
+  laser_wavelength: 351nm
+  normalizing_temperature: 2000eV
+  normalizing_density: 1.5e21/cc
+  Z: 10
+  Zp: 10
+```
+
+## density
+
+Species and density configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `quasineutrality` | bool | Whether to enforce quasineutrality |
+
+### Species Definition
+
+Each species is defined with a key starting with `species-` (e.g., `species-background`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `noise_seed` | int | Random seed for noise initialization |
+| `noise_type` | string | `"gaussian"` or `"uniform"` |
+| `noise_val` | float | Amplitude of noise |
+| `v0` | float | Drift velocity (normalized) |
+| `T0` | float | Temperature (normalized to `normalizing_temperature`) |
+| `m` | float | Exponent for super-Gaussian distribution. `2.0` is Maxwellian |
+| `basis` | string | Spatial profile type. Currently only `"uniform"` is supported |
+| `space-profile` | object | Spatial profile configuration |
+
+#### space-profile
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `baseline` | float | Base density |
+| `bump_or_trough` | string | `"bump"` or `"trough"` |
+| `center` | float | Profile center |
+| `rise` | float | Transition steepness |
+| `slope` | float | Linear slope (typically 0.0) |
+| `wall_height` | float | Height of profile feature |
+| `width` | float | Profile width |
+
+Example:
+```yaml
+density:
+  quasineutrality: true
+  species-background:
+    noise_seed: 420
+    noise_type: gaussian
+    noise_val: 0.0
+    v0: 0.0
+    T0: 1.0
+    m: 2.0
+    basis: uniform
+    space-profile:
+      baseline: 1.0
+      bump_or_trough: bump
+      center: 0.0
+      rise: 25.0
+      slope: 0.0
+      wall_height: 0.0
+      width: 100000.0
+```
+
+## grid
+
+Simulation grid parameters for 2D2V phase space.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dt` | float | Timestep (normalized) |
+| `nx` | int | Number of spatial grid points in x |
+| `ny` | int | Number of spatial grid points in y |
+| `nvx` | int | Number of velocity grid points in vx |
+| `nvy` | int | Number of velocity grid points in vy |
+| `tmin` | float | Start time |
+| `tmax` | float | End time |
+| `vmax` | float | Maximum velocity extent (same for vx and vy) |
+| `xmin` | float | Domain minimum x |
+| `xmax` | float | Domain maximum x |
+| `ymin` | float | Domain minimum y |
+| `ymax` | float | Domain maximum y |
+
+Example:
+```yaml
+grid:
+  dt: 0.1
+  nx: 24
+  ny: 8
+  nvx: 128
+  nvy: 128
+  tmin: 0.0
+  tmax: 150.0
+  vmax: 6.4
+  xmin: 0.0
+  xmax: 20.94
+  ymin: -4.0
+  ymax: 4.0
+```
+
+## save
+
+Configures what data to save and at what times.
+
+### Structure
+
+```yaml
+save:
+  fields:
+    t:
+      tmin: 0.0
+      tmax: 150.0
+      nt: 301
+  electron:
+    t:
+      tmin: 0.0
+      tmax: 150.0
+      nt: 3
+```
+
+| Save Key | Description |
+|----------|-------------|
+| `fields` | Electric field (ex, ey), magnetic field (bz), and driver fields (dex, dey) |
+| `electron` | Electron distribution function |
+
+Each save key contains a `t` sub-key with:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tmin` | float | Start time for saving |
+| `tmax` | float | End time for saving |
+| `nt` | int | Number of save points |
+
+### Optional Spatial Subsampling
+
+Fields can optionally include spatial or spectral subsampling:
+
+```yaml
+save:
+  fields:
+    t:
+      tmin: 0.5
+      tmax: 99.0
+      nt: 64
+    x:
+      xmin: 0.5
+      xmax: 19.0
+      nx: 16
+    y:
+      ymin: -2.0
+      ymax: 2.0
+      ny: 2
+```
+
+## mlflow
+
+Experiment tracking configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `experiment` | string | MLflow experiment name |
+| `run` | string | MLflow run name |
+
+Example:
+```yaml
+mlflow:
+  experiment: ld-2d2v
+  run: envelope-driver-small-amp
+```
+
+## drivers
+
+External electromagnetic drivers. The `ex` driver includes y-dimension envelope parameters.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ex` | dict | Longitudinal electric field drivers |
+| `ey` | dict | Transverse electric field drivers (typically empty `{}`) |
+
+Each driver is identified by a string key (e.g., `"0"`) and has these parameters:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `a0` | float | Driver amplitude |
+| `k0` | float | Wavenumber |
+| `w0` | float | Frequency |
+| `dw0` | float | Frequency offset/chirp |
+| `t_center` | float | Temporal envelope center |
+| `t_rise` | float | Temporal envelope rise time |
+| `t_width` | float | Temporal envelope width |
+| `x_center` | float | Spatial envelope center (x) |
+| `x_rise` | float | Spatial envelope rise distance (x) |
+| `x_width` | float | Spatial envelope width (x) |
+| `y_center` | float | Spatial envelope center (y) |
+| `y_rise` | float | Spatial envelope rise distance (y) |
+| `y_width` | float | Spatial envelope width (y) |
+
+Example:
+```yaml
+drivers:
+  ex:
+    '0':
+      a0: 1.e-6
+      k0: 0.3
+      w0: 1.1598
+      dw0: 0.0
+      t_center: 30.0
+      t_rise: 5.0
+      t_width: 30.0
+      x_center: 0.0
+      x_rise: 10.0
+      x_width: 4000000.0
+      y_center: 0.0
+      y_rise: 10.0
+      y_width: 200.0
+  ey: {}
+```
+
+## krook
+
+Krook collision operator configuration (at top level, not under `terms`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `space-profile` | object | Spatial profile for collision frequency |
+| `time-profile` | object | Temporal profile for collision frequency |
+
+### Profile Objects
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `baseline` | float | Base collision frequency |
+| `bump_or_trough` | string | `"bump"` or `"trough"` |
+| `center` | float | Profile center |
+| `rise` | float | Transition steepness |
+| `slope` | float | Linear slope (typically 0.0) |
+| `wall_height` | float | Height of profile feature |
+| `width` | float | Profile width |
+
+Example:
+```yaml
+krook:
+  space-profile:
+    baseline: 0.0
+    bump_or_trough: bump
+    center: 2500
+    rise: 10.0
+    slope: 0.0
+    wall_height: 0.0
+    width: 48000000.0
+  time-profile:
+    baseline: 0.0
+    bump_or_trough: bump
+    center: 0.0
+    rise: 10.0
+    slope: 0.0
+    wall_height: 0.0
+    width: 100000.0
+```
+
+## solver
+
+Solver algorithm configuration. Note: This is structured differently from vlasov-1d.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dfdt` | string | Time integrator: `"leapfrog"` |
+| `edfdv` | string | Velocity advection scheme: `"exponential"` or `"center_difference"` |
+| `vdfdx` | string | Spatial advection scheme: `"exponential"` |
+| `field` | string | Field solver: `"ampere"` |
+| `fp_operator` | string | Fokker-Planck operator type: `"dougherty"` |
+| `num_unroll` | int | Number of steps to unroll for JIT compilation |
+| `push_f` | bool | Whether to push the distribution function |
+
+Example:
+```yaml
+solver:
+  dfdt: leapfrog
+  edfdv: exponential
+  vdfdx: exponential
+  field: ampere
+  fp_operator: dougherty
+  num_unroll: 32
+  push_f: True
+```
+
+## Complete Example
+
+```yaml
+units:
+  laser_wavelength: 351nm
+  normalizing_temperature: 2000eV
+  normalizing_density: 1.5e21/cc
+  Z: 10
+  Zp: 10
+
+density:
+  quasineutrality: true
+  species-background:
+    noise_seed: 420
+    noise_type: gaussian
+    noise_val: 0.0
+    v0: 0.0
+    T0: 1.0
+    m: 2.0
+    basis: uniform
+    space-profile:
+      baseline: 1.0
+      bump_or_trough: bump
+      center: 0.0
+      rise: 25.0
+      slope: 0.0
+      wall_height: 0.0
+      width: 100000.0
+
+grid:
+  dt: 0.1
+  nvx: 128
+  nvy: 128
+  nx: 24
+  ny: 8
+  tmin: 0.0
+  tmax: 150.0
+  vmax: 6.4
+  xmax: 20.94
+  xmin: 0.0
+  ymin: -4.0
+  ymax: 4.0
+
+save:
+  fields:
+    t:
+      tmin: 0.0
+      tmax: 150.0
+      nt: 301
+  electron:
+    t:
+      tmin: 0.0
+      tmax: 150.0
+      nt: 3
+
+krook:
+  space-profile:
+    baseline: 0.0
+    bump_or_trough: bump
+    center: 2500
+    rise: 10.0
+    slope: 0.0
+    wall_height: 0.0
+    width: 48000000.0
+  time-profile:
+    baseline: 0.0
+    bump_or_trough: bump
+    center: 0.0
+    rise: 10.0
+    slope: 0.0
+    wall_height: 0.0
+    width: 100000.0
+
+mlflow:
+  experiment: ld-2d2v
+  run: my-simulation
+
+drivers:
+  ex:
+    '0':
+      a0: 1.e-6
+      k0: 0.3
+      t_center: 30.0
+      t_rise: 5.0
+      t_width: 30.0
+      w0: 1.1598
+      dw0: 0.0
+      x_center: 0.0
+      x_rise: 10.0
+      x_width: 4000000.0
+      y_center: 0.0
+      y_rise: 10.0
+      y_width: 200.0
+  ey: {}
+
+solver:
+  dfdt: leapfrog
+  edfdv: exponential
+  fp_operator: dougherty
+  num_unroll: 32
+  field: ampere
+  vdfdx: exponential
+  push_f: True
+```
+
+## Example Configurations
+
+### Landau Damping (2D)
+
+See `configs/vlasov-2d/base.yaml` - 2D Landau damping simulation with small-amplitude driver.
+
+See `tests/test_vlasov2d/configs/damping.yaml` - Test configuration for Landau damping verification.


### PR DESCRIPTION
These markdown documents don't integrate yet into the ReadTheDocs build. RTD does support markdown, so we can explore that, or switch to a github pages approach.