### PR TITLE
chore: Don't pin lineax dep to latest commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
-    "lineax @ git+https://github.com/patrick-kidger/lineax.git",
+    "lineax",
     "diffrax @ git+https://github.com/patrick-kidger/diffrax.git@dev",
     "matplotlib",
     "scipy",


### PR DESCRIPTION
This fixes incompatible lineax/interpax dependencies that were preventing `uv add git+ssh://git@github.com/ergodicio/adept` from working.