### PR TITLE
docs: update vlasov1d documentation for multispecies support

### DIFF
--- a/docs/source/solvers/vlasov1d/overview.md
+++ b/docs/source/solvers/vlasov1d/overview.md
@@ -16,6 +16,22 @@ where $f$ is the distribution function, $E$ is the electric field, $C(f)$ is the
 
 The distribution function is $f = f(t, x, v)$ and the electric field is $E = E(t, x)$.
 
+## Multispecies Support
+
+The solver supports multiple particle species (e.g., electrons and ions) evolving self-consistently under a shared electric field. Each species can have:
+
+- Independent charge and mass (determining the species-specific $q/m$ ratio)
+- Independent velocity grid parameters (`vmax`, `nv`)
+- Multiple density components
+
+For multispecies simulations, the Poisson equation sums over all species:
+
+$$
+\partial_x E = \sum_s q_s \int f_s \, dv_s
+$$
+
+See the [Configuration Reference](config.md#species-multispecies-configuration) for details on configuring multispecies simulations.
+
 These simulations can be initialized via perturbing the distribution function or the electric field.
 The electric field can be "driven" using $E_D$ which is a user defined function of time and space.
 

--- a/docs/source/usage/vlasov1d.md
+++ b/docs/source/usage/vlasov1d.md
@@ -23,7 +23,22 @@ $$
 C_K(f) = \nu_K (f - f_{Mx})
 $$
 
-The ions are static but an enterprising individual should be able to reuse the electron code for the ions.
+## Multispecies Support
+
+The solver supports multiple particle species (e.g., electrons and ions) with independent velocity grids and charge-to-mass ratios. In multispecies mode, the Poisson equation becomes:
+
+$$
+\partial_x E = \sum_s q_s \int f_s \, dv_s
+$$
+
+where the sum is over all species $s$, each with its own charge $q_s$ and distribution function $f_s(t, x, v)$.
+
+Each species can have:
+- Different charge and mass (and thus charge-to-mass ratio)
+- Independent velocity grid parameters (`vmax`, `nv`)
+- Multiple density components (e.g., background + beam for the same species)
+
+See the [Configuration Reference](../solvers/vlasov1d/config.md#species-multispecies-configuration) for details on configuring multispecies simulations.
 
 ## Things You Might Care About
 


### PR DESCRIPTION
## Summary

- Added documentation for the new `terms.species` configuration introduced in PR #175
- Updated `config.md` with multispecies configuration reference and ion acoustic wave example
- Updated `overview.md` and `vlasov1d.md` to describe multispecies capabilities
- Removed outdated "ions are static" statement from usage guide

## Changes

**`docs/source/solvers/vlasov1d/config.md`:**
- Added `species` field to the `terms` table
- New "species (Multispecies Configuration)" section with parameter table and example
- Updated `grid` section to note that `vmax`/`nv` are per-species in multispecies mode
- Added multispecies example to "Complete Examples" section

**`docs/source/solvers/vlasov1d/overview.md`:**
- Added "Multispecies Support" section

**`docs/source/usage/vlasov1d.md`:**
- Replaced outdated static ions note with "Multispecies Support" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)