### PR TITLE
chore: drop flatdict dependency

### DIFF
--- a/adept/_tf1d/storage.py
+++ b/adept/_tf1d/storage.py
@@ -2,8 +2,9 @@ import os
 
 import xarray as xr
 from diffrax import Solution
-from flatdict import FlatDict
 from matplotlib import pyplot as plt
+
+from adept.utils import flatten_dict
 
 
 def save_arrays(result: Solution, td: str, cfg: dict, label: str) -> xr.Dataset:
@@ -13,10 +14,10 @@ def save_arrays(result: Solution, td: str, cfg: dict, label: str) -> xr.Dataset:
     """
     if label is None:
         label = "x"
-        flattened_dict = dict(FlatDict(result.ys, delimiter="-"))
+        flattened_dict = flatten_dict(result.ys, delimiter="-")
         save_ax = cfg["grid"]["x"]
     else:
-        flattened_dict = dict(FlatDict(result.ys[label], delimiter="-"))
+        flattened_dict = flatten_dict(result.ys[label], delimiter="-")
         save_ax = cfg["save"][label]["ax"]
     data_vars = {
         k: xr.DataArray(v, coords=(("t", cfg["save"]["t"]["ax"]), (label, save_ax))) for k, v in flattened_dict.items()

--- a/adept/utils.py
+++ b/adept/utils.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 import boto3
 import botocore
 import equinox as eqx
-import flatdict
 import jax
 import yaml
 from mlflow.tracking import MlflowClient
@@ -16,8 +15,19 @@ from pint import Quantity
 from . import patched_mlflow as mlflow
 
 
+def flatten_dict(d, delimiter=".", _prefix=""):
+    items = {}
+    for k, v in d.items():
+        key = f"{_prefix}{delimiter}{k}" if _prefix else k
+        if isinstance(v, dict):
+            items.update(flatten_dict(v, delimiter, key))
+        else:
+            items[key] = v
+    return items
+
+
 def log_params(cfg):
-    flattened_dict = dict(flatdict.FlatDict(cfg, delimiter="."))
+    flattened_dict = flatten_dict(cfg, delimiter=".")
     num_entries = len(flattened_dict.keys())
 
     flattened_dict = {k: str(v) if isinstance(v, Quantity) else v for k, v in flattened_dict.items()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "tqdm",
     "xarray",
     "mlflow",
-    "flatdict",
+
     "h5netcdf",
     "optax",
     "boto3",

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,6 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "diffrax" },
-    { name = "flatdict" },
     { name = "h5netcdf" },
     { name = "interpax" },
     { name = "jax" },
@@ -77,8 +76,7 @@ requires-dist = [
     { name = "adept", marker = "extra == 'docs'" },
     { name = "adept", extras = ["docs"], marker = "extra == 'dev'" },
     { name = "boto3" },
-    { name = "diffrax", git = "https://github.com/patrick-kidger/diffrax.git?rev=dev" },
-    { name = "flatdict" },
+    { name = "diffrax" },
     { name = "h5netcdf" },
     { name = "interpax", git = "https://github.com/f0uriest/interpax.git" },
     { name = "jax" },
@@ -727,7 +725,7 @@ wheels = [
 [[package]]
 name = "diffrax"
 version = "0.7.0"
-source = { git = "https://github.com/patrick-kidger/diffrax.git?rev=dev#62bf87692e3b1a6e9b34b2c4398424e44d2cc8c7" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
     { name = "jax" },
@@ -736,6 +734,10 @@ dependencies = [
     { name = "optimistix" },
     { name = "typing-extensions" },
     { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/9e/d6081a1daf7a7b70f53ddac637bd2e6cd6fa91042ffd7b204741c0ce6d44/diffrax-0.7.0.tar.gz", hash = "sha256:f3bcc578cd92a9ca86fc6f5a54c1de76c1ba62f74de69b56002624bf205316f1", size = 151595, upload-time = "2025-03-14T03:52:22.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/1d/236424e689f62d7fe58f8b10f08c63a49c68efba087eabdd09198a9bbf38/diffrax-0.7.0-py3-none-any.whl", hash = "sha256:aa9645c40552f11a2d32042ef6b9fcd53c1f0f6bdbe32d37cb788669ca9910be", size = 193163, upload-time = "2025-03-14T03:52:20.943Z" },
 ]
 
 [[package]]
@@ -847,12 +849,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/70/74/0fc0fa68d62f21dae
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/af/72ad54402e599152de6d067324c46fe6a4f531c7c65baf7e96c63db55eaf/flask_cors-6.0.2-py3-none-any.whl", hash = "sha256:e57544d415dfd7da89a9564e1e3a9e515042df76e12130641ca6f3f2f03b699a", size = 13257, upload-time = "2025-12-12T20:31:41.3Z" },
 ]
-
-[[package]]
-name = "flatdict"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/0d/424de6e5612f1399ff69bf86500d6a62ff0a4843979701ae97f120c7f1fe/flatdict-4.0.1.tar.gz", hash = "sha256:cd32f08fd31ed21eb09ebc76f06b6bd12046a24f77beb1fd0281917e47f26742", size = 8341, upload-time = "2020-02-13T19:16:14.3Z" }
 
 [[package]]
 name = "flexcache"


### PR DESCRIPTION
flatdict is no longer maintained and requires setuptools which is no longer packaged with pip.