### PR TITLE
disable tqdm progress bar when not running in a TTY

### DIFF
--- a/adept/_spectrax1d/base_module.py
+++ b/adept/_spectrax1d/base_module.py
@@ -1,10 +1,11 @@
 """Base ADEPTModule wrapper for spectrax-based Hermite-Fourier Vlasov-Maxwell solver."""
 
 import os
+import sys
 
 import pint
 import xarray as xr
-from diffrax import ConstantStepSize, ODETerm, SaveAt, SubSaveAt, TqdmProgressMeter, diffeqsolve
+from diffrax import ConstantStepSize, NoProgressMeter, ODETerm, SaveAt, SubSaveAt, TqdmProgressMeter, diffeqsolve
 from jax import Array
 from jax import numpy as jnp
 
@@ -698,7 +699,7 @@ class BaseSpectrax1D(ADEPTModule):
             args=args,
             saveat=SaveAt(**self.diffeqsolve_quants["saveat"]),
             max_steps=self.time_quantities["max_steps"],
-            progress_meter=TqdmProgressMeter(),
+            progress_meter=TqdmProgressMeter() if sys.stdout.isatty() else NoProgressMeter(),
         )
 
         return {"solver result": sol}

--- a/adept/_vlasov1d/modules.py
+++ b/adept/_vlasov1d/modules.py
@@ -1,10 +1,11 @@
 #  Copyright (c) Ergodic LLC 2023
 #  research@ergodic.io
 
+import sys
 from dataclasses import asdict
 
 import numpy as np
-from diffrax import ODETerm, SaveAt, SubSaveAt, TqdmProgressMeter, diffeqsolve
+from diffrax import NoProgressMeter, ODETerm, SaveAt, SubSaveAt, TqdmProgressMeter, diffeqsolve
 from jax import numpy as jnp
 
 from adept import ADEPTModule
@@ -326,7 +327,9 @@ class BaseVlasov1D(ADEPTModule):
             y0=self.state,
             args=args,
             saveat=SaveAt(**self.diffeqsolve_quants["saveat"]),
-            progress_meter=TqdmProgressMeter(refresh_steps=grid.max_steps // 100),
+            progress_meter=TqdmProgressMeter(refresh_steps=grid.max_steps // 100)
+            if sys.stdout.isatty()
+            else NoProgressMeter(),
         )
 
         return {"solver result": solver_result}


### PR DESCRIPTION
The progress bar eats up an enormous number of tokens when run through claude's Bash tool.