### PR TITLE
Forward extra state dict keys through spectrax1d solver

### DIFF
--- a/adept/_spectrax1d/exponential_operators.py
+++ b/adept/_spectrax1d/exponential_operators.py
@@ -339,11 +339,16 @@ class CombinedLinearExponential:
         Fk = self.maxwell.apply(Fk, s)
 
         # Pack back to float64 views
-        return {
+        out = {
             "Ck_electrons": Ck_e.view(jnp.float64),
             "Ck_ions": Ck_i.view(jnp.float64),
             "Fk": Fk.view(jnp.float64),
         }
+        # Forward any extra state keys (e.g. SSM hidden state) unchanged
+        for k in y:
+            if k not in out:
+                out[k] = y[k]
+        return out
 
 
 def build_combined_exponential(

--- a/adept/_spectrax1d/integrators.py
+++ b/adept/_spectrax1d/integrators.py
@@ -268,6 +268,11 @@ class SplitStepDampingSolver(AbstractSolver):
             Ck_i = y_damped["Ck_ions"].view(jnp.complex128)
             y_damped["Ck_ions"] = (Ck_i * self.hermite_filter_i[:, :, :, None, None, None]).view(jnp.float64)
 
+        # Forward any extra state keys (e.g. SSM hidden state) unchanged
+        for k in y:
+            if k not in y_damped:
+                y_damped[k] = y[k]
+
         return y_damped
 
     def func(self, terms, t0, y0, args):

--- a/adept/_spectrax1d/nonlinear_vector_field.py
+++ b/adept/_spectrax1d/nonlinear_vector_field.py
@@ -406,8 +406,14 @@ class NonlinearVectorField(eqx.Module):
 
         dFk_dt = jnp.concatenate([dEk_dt, dBk_dt], axis=0)
 
-        return {
+        out = {
             "Ck_electrons": dCk_electrons_dt.view(jnp.float64),
             "Ck_ions": dCk_ions_dt.view(jnp.float64),
             "Fk": dFk_dt.view(jnp.float64),
         }
+        # Zero derivatives for extra state keys (e.g. SSM hidden state,
+        # which is updated discretely by the closure solver, not the ODE RHS)
+        for k in y:
+            if k not in out:
+                out[k] = jnp.zeros_like(y[k])
+        return out


### PR DESCRIPTION
## Summary
- Three spectrax1d components (`CombinedLinearExponential.apply`, `SplitStepDampingSolver._apply_damping`, `NonlinearVectorField.__call__`) were hardcoded to return only `{Ck_electrons, Ck_ions, Fk}`, silently dropping any extra keys
- This makes it impossible to carry augmented state (e.g. an SSM hidden state for a learned closure) through the ODE integration
- Extra keys are now forwarded unchanged through the exponential operator and damping solver, and get `zeros_like` derivatives from the vector field (appropriate for state updated discretely by the solver, not the ODE RHS)

## Test plan
- [ ] Existing spectrax1d tests pass (no behavior change when no extra keys present)
- [ ] Verify augmented state key survives a full `diffeqsolve` integration
- [ ] Used by ergodicio/autoclosures#new SSM closure branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)