### PR TITLE
fix(spectrax1d): separable per-axis Hou-Li filter

### DIFF
--- a/adept/_spectrax1d/vector_field.py
+++ b/adept/_spectrax1d/vector_field.py
@@ -155,12 +155,21 @@ class SpectraxVectorField:
 
     @staticmethod
     def _houli_filter(Nn: int, Nm: int, Np: int, strength: float, order: int) -> Array:
-        n = jnp.arange(Nn, dtype=jnp.float64)[None, None, :]
-        m = jnp.arange(Nm, dtype=jnp.float64)[None, :, None]
-        p = jnp.arange(Np, dtype=jnp.float64)[:, None, None]
-        h_max = jnp.sqrt((Nn - 1) ** 2 + (Nm - 1) ** 2 + (Np - 1) ** 2)
-        h = jnp.sqrt(n**2 + m**2 + p**2)
-        return jnp.exp(-strength * (h / h_max) ** order)
+        # Separable per-axis Hou-Li taper. Each axis gets its own 1D filter
+        # exp(-strength * (i/(N_axis-1))^order) so that anisotropic mode counts
+        # (e.g. Nn=64, Nm=4) still damp the top mode along every axis. The previous
+        # 3D-radial formula collapsed to ~1.0 along the short axis when h_max was
+        # dominated by the long axis, leaving no dealiasing there.
+        def axis_filter(N: int) -> Array:
+            if N <= 1:
+                return jnp.ones(N, dtype=jnp.float64)
+            i = jnp.arange(N, dtype=jnp.float64)
+            return jnp.exp(-strength * (i / (N - 1)) ** order)
+
+        fn = axis_filter(Nn)
+        fm = axis_filter(Nm)
+        fp = axis_filter(Np)
+        return fp[:, None, None] * fm[None, :, None] * fn[None, None, :]
 
     def _current(self, Ck: Array, q: float, alpha: Array, u: Array, Nn: int, Nm: int, Np: int) -> Array:
         C0 = Ck[0, 0, 0]


### PR DESCRIPTION
## Summary

The Hou-Li dealiasing filter in `SpectraxVectorField._houli_filter` is built as a single 3D radial taper, but the radius is normalized by the diagonal `h_max = √((Nn-1)² + (Nm-1)² + (Np-1)²)`. When mode counts are anisotropic (e.g. `Nn=64, Nm=4, Np=1`), `h_max` is dominated by the longest axis and the short axes never reach the filter knee — every mode on `m` and `p` sees `filter ≈ 1.0`.

Concretely with `Nn=16, Nm=4, Np=1, strength=36, order=36`:

| axis | top mode | h / h_max | filter |
|------|----------|-----------|--------|
| n    | n=15     | 0.98      | 2e-8   |
| m    | m=3      | 0.20      | 1.000  |
| p    | p=0      | 0         | 1.000  |

So the top `m` mode has zero damping. In SRS-like configurations where the Lorentz force pumps energy into the highest retained transverse Hermite mode, this leads to a numerical pile-up that eventually blows the run up. We hit this with `Nn=16, Nm=4, dt=0.1` at `1e15 W/cm²` on a 0.5 ps run — Ey grew cleanly to ~0.08 then went `NaN` at t ≈ 0.22 ps.

## Change

Replace the 3D-radial formula with a separable tensor product
`f_n(n) · f_m(m) · f_p(p)`, where each axis has its own 1D taper
`exp(-strength · (i/(N_axis-1))^order)`. The top mode on every axis is now
damped at the configured strength regardless of how the mode counts compare.

The 1-mode axis edge case (`N=1`) returns `[1.0]` to avoid the `0/0` in the normalization.

## Test plan

- [ ] existing spectrax-1d tests pass
- [ ] anisotropic config (`Nn ≫ Nm`) survives long-time integration without NaN
- [ ] symmetric config (`Nn=Nm=Np`) gives ≈ the same filter values as before at the corners (radial and separable taper agree on the diagonal up to small differences from the `i^order` vs `√(n²+m²)^order` shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)