### PR TITLE
fix(spectrax1d): make Hou-Li filter actually work on the Lawson path

### DIFF
--- a/adept/_spectrax1d/nonlinear_vector_field.py
+++ b/adept/_spectrax1d/nonlinear_vector_field.py
@@ -237,22 +237,31 @@ class NonlinearVectorField(eqx.Module):
 
         return (jnp.abs(ky) <= cy) & (jnp.abs(kx) <= cx) & (jnp.abs(kz) <= cz)
 
-    def _compute_houli_hermite_filter(self, Nn: int, Nm: int, Np: int, strength: float, order: int) -> Array:
-        """Compute Hou-Li exponential filter in Hermite space.
+    @staticmethod
+    def _compute_houli_hermite_filter(Nn: int, Nm: int, Np: int, strength: float, order: int) -> Array:
+        """Compute the separable per-axis Hou-Li exponential filter in Hermite space.
 
-        sigma(h) = exp(-strength * (h/h_max)^order)
+        Each axis gets its own 1D filter exp(-strength * (i/(N_axis-1))^order); the
+        full 3D filter is the outer product. The previous 3D-radial formula
+        (h = sqrt(n^2+m^2+p^2), h_max = sqrt((Nn-1)^2+(Nm-1)^2+(Np-1)^2)) collapsed
+        to ~1.0 along the short axis when h_max was dominated by the long axis —
+        e.g. with Nn=128, Nm=4, Np=1 the top m-mode (m=3) had h/h_max ≈ 3/127, so
+        exp(-strength * (3/127)^36) ≈ 1 and the m-axis was effectively unfiltered.
 
-        where h = sqrt(n^2 + m^2 + p^2) and h_max = sqrt((Nn-1)^2 + (Nm-1)^2 + (Np-1)^2).
-        The highest-index corner mode gets exactly exp(-strength); lower modes are less damped.
+        Matches the implementation already on the Dopri8 path
+        (vector_field.SpectraxVectorField._houli_filter, fixed in #274).
         """
-        n = jnp.arange(Nn)[None, None, :]
-        m = jnp.arange(Nm)[None, :, None]
-        p = jnp.arange(Np)[:, None, None]
 
-        h_max = jnp.sqrt((Nn - 1) ** 2 + (Nm - 1) ** 2 + (Np - 1) ** 2)
-        h = jnp.sqrt(n**2 + m**2 + p**2)
+        def axis_filter(N: int) -> Array:
+            if N <= 1:
+                return jnp.ones(N, dtype=jnp.float64)
+            i = jnp.arange(N, dtype=jnp.float64)
+            return jnp.exp(-strength * (i / (N - 1)) ** order)
 
-        return jnp.exp(-strength * (h / h_max) ** order)
+        fn = axis_filter(Nn)
+        fm = axis_filter(Nm)
+        fp = axis_filter(Np)
+        return fp[:, None, None] * fm[None, :, None] * fn[None, None, :]
 
     def _compute_plasma_current_single_species(
         self, Ck: Array, q: float, alpha: Array, u: Array, Nn: int, Nm: int, Np: int

--- a/adept/_spectrax1d/nonlinear_vector_field.py
+++ b/adept/_spectrax1d/nonlinear_vector_field.py
@@ -361,6 +361,15 @@ class NonlinearVectorField(eqx.Module):
                 m=mi_me,
             )
 
+        # Apply Hou-Li filter to the Hermite derivative at each RK sub-stage to
+        # attenuate the rate at which high-n modes are excited by the E·∂f/∂v
+        # nonlinearity inside the step. The split-step state filter in
+        # integrators.py still runs once per dt on top of this.
+        if self.use_hermite_filter:
+            dCk_electrons_dt = dCk_electrons_dt * self.hermite_filter_electrons[:, :, :, None, None, None]
+            if not self.static_ions:
+                dCk_ions_dt = dCk_ions_dt * self.hermite_filter_ions[:, :, :, None, None, None]
+
         # Apply density noise
         if self.noise_enabled:
             if self.noise_electrons_enabled:


### PR DESCRIPTION
## Summary
Two bugs in the Lawson-RK4 Hou-Li filtering that together left high Hermite-mode content uncontrolled, causing late-time Ex blow-ups in moderate-gradient SRS runs.

### Bug 1 — `_compute_houli_hermite_filter` still used the old 3D-radial form
#274 made the filter separable per Hermite axis on the Dopri8 path (`vector_field.SpectraxVectorField._houli_filter`) but `NonlinearVectorField._compute_houli_hermite_filter` (the Lawson path) was missed. With anisotropic mode counts (e.g. Nn=128, Nm=4, Np=1) the short axis was completely unfiltered:

```
top m-mode m=3:  h/h_max = 3/127  →  exp(-strength·(3/127)^36) ≈ 1
```

So the m-axis was effectively leak-free. Replaced with the outer-product axis_filter form already used in the Dopri8 path.

### Bug 2 — filter never applied inside the Lawson RHS
`NonlinearVectorField` *built* the filter at construction time but never multiplied `dCk/dt` by it inside `__call__`. The only Lawson-path filter application was the once-per-`dt` split-step state filter in `integrators.SplitStepDampingSolver._apply_damping`, which runs *after* the full 4-stage RK step. High-Hermite-mode content excited by the E·∂f/∂v nonlinearity inside a single step can grow faster than that once-per-step filter can catch.

Added the per-stage `dCk/dt *= filter` in `NonlinearVectorField.__call__`, mirroring the existing Dopri8-path pattern at `vector_field.py:242`.

### Symptoms in the wild
At pump 1.000e14 W/cm² on a 0.2 → 0.3 nc gradient ramp (Vlasov reference: clean run, 0.42% reflectivity, 5 ps tmax):
- Hermite Nn=16, dt=0.1/wp0:  Ex stays at ~3e-5 until t ≈ 4000 wp0⁻¹ (~0.75 ps), then ~80× blow-up → NaN by 1 ps.
- Hermite Nn=128, dt=0.1/wp0: blow-up *earlier*, at t ≈ 1100 wp0⁻¹ (~0.2 ps) — because more n-modes made the radial-formula filter even less effective on the m-axis.

Both runs FINISHED with all `final_*` field/probe metrics NaN.

## Test plan
- [ ] Re-run `sims/gradient-srs-hermite/config-pump1.000e14-1ps-amp1e-6.yaml` (Nn=16, dt=0.1, the failing case) and confirm Ex stays bounded for the full 1 ps.
- [ ] Spot-check `sims/srs-threshold-hermite/config-pump1.000e14.yaml` (Nn=16, Nm=4, flat plateau) hasn't drifted — the per-stage filter is conservative (it attenuates the rate of high-n excitation, doesn't dump dissipation into modes that aren't being driven).
- [ ] Dopri8-path runs untouched (this PR only edits `nonlinear_vector_field.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)