### PR TITLE
deps: drop jpu, use pint directly

### DIFF
--- a/adept/normalization.py
+++ b/adept/normalization.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 
 import jax.numpy as jnp
-import jpu
+import pint
 
-UREG = jpu.UnitRegistry()
+UREG = pint.UnitRegistry()
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "pydantic",
     "scienceplots",
     "jax",
-    "jpu>=0.0.5",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,6 @@ dependencies = [
     { name = "h5netcdf" },
     { name = "interpax" },
     { name = "jax" },
-    { name = "jpu" },
     { name = "lineax" },
     { name = "matplotlib" },
     { name = "mlflow" },
@@ -83,7 +82,6 @@ requires-dist = [
     { name = "interpax", git = "https://github.com/f0uriest/interpax.git" },
     { name = "jax" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'gpu'" },
-    { name = "jpu", specifier = ">=0.0.5" },
     { name = "lineax" },
     { name = "matplotlib" },
     { name = "mlflow" },
@@ -1342,19 +1340,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
-]
-
-[[package]]
-name = "jpu"
-version = "0.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jax" },
-    { name = "pint" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/01/09/0664eb92c03d1e80e2b6fd852c76ed08cbbb9b96859534322906b34c5b6c/jpu-0.0.5.tar.gz", hash = "sha256:e0b7e879e5f56dbd2e496813aaae2da0ccb68120aba3f77cbbff0faa1456fc4b", size = 19026, upload-time = "2025-04-26T18:20:38.421Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/d4/ac67e27bd9a95c3839b5808239fa0ae6b925a130a9b89cfb4f0a5bb8b94e/jpu-0.0.5-py3-none-any.whl", hash = "sha256:89a4f35f96e8c49fe3be8813e2f3bf122dacf4386fb7471ed97ba1a41e3d31aa", size = 15946, upload-time = "2025-04-26T18:20:37.283Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `jpu` was used only in [adept/normalization.py](adept/normalization.py) for scalar plasma-normalization arithmetic — no `jpu.Quantity` ever wrapped a traced jax array (every `jnp.*` call already operates on `.magnitude` floats).
- It pinned an upper bound on `jax`. Swapping `UREG = jpu.UnitRegistry()` → `UREG = pint.UnitRegistry()` (pint is already a direct dep) removes the cap with no behavioral change.
- Drop `jpu>=0.0.5` from [pyproject.toml](pyproject.toml) and relock.

## Test plan
- [x] Smoke-test both normalization constructors (`electron_debye_normalization`, `laser_normalization`) plus `normalize`, `vth_norm`, `speed_of_light_norm`, `logLambda_ee`, `approximate_ee_collision_frequency` — all return the same values.
- [x] Import-check every solver helper that depends on `adept.normalization` (`_vlasov1d`, `_vlasov2d`, `_lpse2d`, `_spectrax1d`).
- [x] `pytest tests/test_vlasov1d/test_em_dispersion.py` passes.
- [x] `pre-commit` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)