### PR TITLE
docs: add Vlasov 1D docstring coverage

### DIFF
--- a/adept/_vlasov1d/__init__.py
+++ b/adept/_vlasov1d/__init__.py
@@ -1,0 +1,1 @@
+"""Vlasov-1D solver implementation package."""

--- a/adept/_vlasov1d/datamodel.py
+++ b/adept/_vlasov1d/datamodel.py
@@ -1,3 +1,5 @@
+"""Pydantic configuration models for Vlasov-1D simulations."""
+
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -8,6 +10,8 @@ from adept.functions import EnvelopeConfig, SpaceTimeEnvelopeConfig
 # TODO(gh-250): refactor to use a nested SpaceTimeEnvelopeConfig instead of inlining
 # envelope fields. See https://github.com/ergodicio/adept/issues/250
 class SpeciesComponentConfig(BaseModel):
+    """Density and velocity-space parameters for one species density component."""
+
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     noise_seed: int
@@ -36,20 +40,27 @@ class SpeciesComponentConfig(BaseModel):
 
 
 class DensityConfig(BaseModel):
+    """Collection of species density components and quasineutrality setting."""
+
     model_config = ConfigDict(extra="allow")
 
     quasineutrality: bool
 
     def get_component(self, name: str) -> SpeciesComponentConfig:
+        """Return a named species density component as a validated config model."""
         return SpeciesComponentConfig.model_validate(self.model_extra[name])
 
 
 class UnitsConfig(BaseModel):
+    """Physical units used to construct the plasma normalization."""
+
     normalizing_temperature: str
     normalizing_density: str
 
 
 class GridConfig(BaseModel):
+    """Configuration-space and velocity-space grid parameters."""
+
     dt: float | str
     nx: int
     tmin: float | str = 0.0
@@ -64,6 +75,7 @@ class GridConfig(BaseModel):
     @field_validator("parallel", mode="before")
     @classmethod
     def validate_parallel(cls, v):
+        """Normalize and validate the optional parallelization axis list."""
         if v is False or v is None:
             return False
         if isinstance(v, (list, tuple)):
@@ -76,24 +88,32 @@ class GridConfig(BaseModel):
 
 
 class TimeSaveConfig(BaseModel):
+    """Temporal sampling configuration for saved quantities."""
+
     tmin: float | None = None
     tmax: float | None = None
     nt: int
 
 
 class SaveConfig(BaseModel):
+    """Top-level save configuration keyed by field, diagnostic, or species name."""
+
     model_config = ConfigDict(extra="allow")
 
     fields: dict[str, TimeSaveConfig]
 
 
 class IntensityWavelengthDriverConfig(BaseModel):
+    """Laser driver parameters specified by physical intensity and wavelength."""
+
     intensity: str
     wavelength: str
     leftgoing: bool = False
 
 
 class AKWDriverConfig(BaseModel):
+    """Laser driver parameters specified directly as amplitude, wavenumber, and frequency."""
+
     a0: float
     k0: float | None = None
     w0: float | None = None
@@ -101,23 +121,30 @@ class AKWDriverConfig(BaseModel):
 
     @model_validator(mode="after")
     def check_w_or_k(self) -> "AKWDriverConfig":
+        """Require enough information to infer both driver wavenumber and frequency."""
         if self.k0 is None and self.w0 is None:
             raise ValueError("You must specify at least one of k0 or w0.")
         return self
 
 
 class EMDriverConfig(BaseModel):
+    """One electromagnetic driver with parameters, envelope, and source geometry."""
+
     params: IntensityWavelengthDriverConfig | AKWDriverConfig
     envelope: SpaceTimeEnvelopeConfig
     source_type: Literal["extended", "point"] = "extended"
 
 
 class EMDriverSetConfig(BaseModel):
+    """Longitudinal and transverse electromagnetic driver collections."""
+
     ex: dict[str, EMDriverConfig]
     ey: dict[str, EMDriverConfig]
 
 
 class HouLiFilterConfig(BaseModel):
+    """Configuration for optional Hou-Li spectral filtering."""
+
     is_on: bool
     alpha: float = 36.0
     order: int = 36
@@ -125,6 +152,8 @@ class HouLiFilterConfig(BaseModel):
 
 
 class FokkerPlanckConfig(BaseModel):
+    """Configuration for optional Fokker-Planck collisions."""
+
     is_on: bool
     type: str
     time: EnvelopeConfig
@@ -132,6 +161,8 @@ class FokkerPlanckConfig(BaseModel):
 
 
 class KrookConfig(BaseModel):
+    """Configuration for optional Krook relaxation."""
+
     is_on: bool
     time: EnvelopeConfig
     space: EnvelopeConfig
@@ -149,6 +180,8 @@ class SpeciesConfig(BaseModel):
 
 
 class TermsConfig(BaseModel):
+    """Numerical term selections and optional physics operators."""
+
     field: str
     edfdv: str
     time: str
@@ -160,11 +193,15 @@ class TermsConfig(BaseModel):
 
 
 class MLFlowConfig(BaseModel):
+    """MLflow experiment and run naming configuration."""
+
     experiment: str
     run: str
 
 
 class DiagnosticsConfig(BaseModel):
+    """Optional diagnostic distribution-function save toggles."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     diag_vlasov_dfdt: bool = Field(default=False, alias="diag-vlasov-dfdt")
@@ -172,6 +209,8 @@ class DiagnosticsConfig(BaseModel):
 
 
 class Vlasov1DConfig(BaseModel):
+    """Validated top-level configuration for a Vlasov-1D ADEPT run."""
+
     units: UnitsConfig
     density: DensityConfig
     grid: GridConfig

--- a/adept/_vlasov1d/grid.py
+++ b/adept/_vlasov1d/grid.py
@@ -45,6 +45,7 @@ class Grid(eqx.Module):
         should_override_dt_for_em_waves: bool,
         beta: float,
     ):
+        """Build all spatial, temporal, and Fourier grid arrays from scalar inputs."""
         self.xmin = xmin
         self.xmax = xmax
         self.nx = nx

--- a/adept/_vlasov1d/helpers.py
+++ b/adept/_vlasov1d/helpers.py
@@ -1,3 +1,5 @@
+"""Initialization and post-processing helpers for Vlasov-1D simulations."""
+
 #  Copyright (c) Ergodic LLC 2023
 #  research@ergodic.io
 import os
@@ -23,10 +25,12 @@ from .. import patched_mlflow as mlflow
 
 
 def gamma_3_over_m(m):
+    """Evaluate Gamma(3 / m) for super-Gaussian normalization."""
     return gamma(3.0 / m)  # np.interp(m, m_ax, g_3_m)
 
 
 def gamma_5_over_m(m):
+    """Evaluate Gamma(5 / m) for super-Gaussian normalization."""
     return gamma(5.0 / m)  # np.interp(m, m_ax, g_5_m)
 
 
@@ -149,6 +153,7 @@ def _initialize_total_distribution_(cfg, simulation: Vlasov1DSimulation):
 
 
 def post_process(result: Solution, cfg: dict, td: str, args: dict):
+    """Write binary output and diagnostic plots from a completed Vlasov-1D solve."""
     t0 = time()
 
     # Get species names for directory creation

--- a/adept/_vlasov1d/modules.py
+++ b/adept/_vlasov1d/modules.py
@@ -1,3 +1,5 @@
+"""ADEPT module classes and config-to-simulation builders for Vlasov-1D."""
+
 #  Copyright (c) Ergodic LLC 2023
 #  research@ergodic.io
 
@@ -22,6 +24,7 @@ from adept.utils import filter_scalars
 
 
 def species_set_from_config(cfg: Vlasov1DConfig) -> list[Species]:
+    """Return explicit species or synthesize the legacy single-electron species."""
     if cfg.terms.species:
         return [Species.from_config(species_cfg) for species_cfg in cfg.terms.species]
     else:
@@ -89,15 +92,20 @@ def sim_from_config(
 
 
 class BaseVlasov1D(ADEPTModule):
+    """ADEPT module wrapper for configuring, running, and post-processing Vlasov-1D."""
+
     def __init__(self, cfg) -> None:
+        """Validate configuration and construct the Vlasov-1D simulation domain."""
         super().__init__(cfg)
         self.config_model = Vlasov1DConfig.model_validate(cfg)
         self.simulation = sim_from_config(self.config_model)
 
     def post_process(self, run_output: dict, td: str):
+        """Post-process a solver result into plots, netCDF files, and MLflow metrics."""
         return post_process(run_output["solver result"], self.cfg, td, self.args)
 
     def write_units(self) -> dict:
+        """Compute and attach physical normalization quantities to the run config."""
         norm = self.simulation.plasma_norm
         grid = self.simulation.grid
 
@@ -293,6 +301,7 @@ class BaseVlasov1D(ADEPTModule):
         self.args = {"drivers": self.simulation.drivers, "terms": self.cfg["terms"]}
 
     def init_diffeqsolve(self):
+        """Assemble Diffrax terms, solver, save functions, and solve time bounds."""
         self.cfg = get_save_quantities(self.cfg)
         grid = self.simulation.grid
         self.time_quantities = {"t0": 0.0, "t1": grid.tmax, "max_steps": grid.max_steps}
@@ -311,6 +320,7 @@ class BaseVlasov1D(ADEPTModule):
         )
 
     def __call__(self, trainable_modules: dict, args: dict | None = None):
+        """Run the configured Vlasov-1D solve and return the raw Diffrax result."""
         if args is None:
             args = self.args
         grid = self.simulation.grid

--- a/adept/_vlasov1d/simulation.py
+++ b/adept/_vlasov1d/simulation.py
@@ -1,3 +1,5 @@
+"""Domain objects that represent a configured Vlasov-1D simulation."""
+
 import math
 import warnings
 
@@ -30,6 +32,8 @@ from adept.normalization import UREG, PlasmaNormalization, normalize
 
 
 class EMDriver(eqx.Module):
+    """Normalized electromagnetic driver used by longitudinal or transverse sources."""
+
     a0: float
     k0: float
     w0: float
@@ -39,6 +43,7 @@ class EMDriver(eqx.Module):
 
     @staticmethod
     def from_config(cfg: EMDriverConfig, norm: PlasmaNormalization | None = None) -> "EMDriver":
+        """Convert user driver configuration into normalized solver parameters."""
         envelope = SpaceTimeEnvelopeFunction.from_config(cfg.envelope, norm)
 
         params = cfg.params
@@ -86,11 +91,14 @@ class EMDriver(eqx.Module):
 
 
 class EMDriverSet(eqx.Module):
+    """Container for longitudinal (Ex) and transverse (Ey) driver lists."""
+
     ex: list[EMDriver]
     ey: list[EMDriver]
 
     @staticmethod
     def from_config(cfg: EMDriverSetConfig, norm: PlasmaNormalization | None = None) -> "EMDriverSet":
+        """Build normalized Ex and Ey driver lists from configuration."""
         ex = [EMDriver.from_config(ex_cfg, norm) for ex_cfg in cfg.ex.values()]
         ey = [EMDriver.from_config(ey_cfg, norm) for ey_cfg in cfg.ey.values()]
         return EMDriverSet(ex, ey)
@@ -108,6 +116,7 @@ class Species(eqx.Module):
 
     @staticmethod
     def from_config(cfg: SpeciesConfig) -> "Species":
+        """Convert a species config into the immutable simulation species model."""
         return Species(
             name=cfg.name,
             mass=float(cfg.mass),
@@ -130,6 +139,7 @@ class SubspeciesDensityProfile(eqx.Module):
     noise_profile: NoiseProfile
 
     def __call__(self, x: jax.Array) -> jax.Array:
+        """Evaluate the noisy, optionally enveloped density profile at positions x."""
         profile = self.density(x)
         if self.envelope is not None:
             profile = self.envelope(x) * profile
@@ -222,6 +232,7 @@ class Vlasov1DSimulation:
         nu_fp_prof: SpaceTimeEnvelopeFunction | None = None,
         nu_K_prof: SpaceTimeEnvelopeFunction | None = None,
     ):
+        """Store normalized simulation inputs needed by the solver and module wrapper."""
         self.plasma_norm = plasma_norm
         self.grid = grid
         self.species = species
@@ -232,4 +243,5 @@ class Vlasov1DSimulation:
 
     @property
     def species_dict(self) -> dict[str, Species]:
+        """Map species names to their simulation species definitions."""
         return {s.name: s for s in self.species}

--- a/adept/_vlasov1d/solvers/__init__.py
+++ b/adept/_vlasov1d/solvers/__init__.py
@@ -1,0 +1,1 @@
+"""Time integrators and vector fields for the Vlasov-1D solver."""

--- a/adept/_vlasov1d/solvers/pushers/__init__.py
+++ b/adept/_vlasov1d/solvers/pushers/__init__.py
@@ -1,0 +1,1 @@
+"""Numerical pushers used by the Vlasov-1D vector field."""

--- a/adept/_vlasov1d/solvers/pushers/field.py
+++ b/adept/_vlasov1d/solvers/pushers/field.py
@@ -1,3 +1,5 @@
+"""Field drivers and field solvers for the Vlasov-1D system."""
+
 #  Copyright (c) Ergodic LLC 2023
 #  research@ergodic.io
 
@@ -12,6 +14,7 @@ class LongitudinalElectricFieldDriver:
     """Computes normalized E_tilde = ω * a0 * sin(kx - ωt) from EM drivers."""
 
     def __init__(self, xax, drivers: list[EMDriver]):
+        """Store the spatial axis and longitudinal driver list."""
         self.xax = xax
         self.drivers = drivers
 
@@ -23,6 +26,7 @@ class LongitudinalElectricFieldDriver:
         return factor * (ww + dw) * driver.a0 * jnp.sin(kk * self.xax - (ww + dw) * current_time)
 
     def __call__(self, t, args):
+        """Evaluate the total longitudinal driver field at time t."""
         total_de = jnp.zeros_like(self.xax)
         for pulse in self.drivers:
             total_de += self._single_driver_field(pulse, t)
@@ -47,6 +51,7 @@ class TransverseCurrentSourceDriver:
     """
 
     def __init__(self, xax, drivers: list[EMDriver], c: float = 0.0):
+        """Precompute point-source masks and scales for transverse drivers."""
         self.xax = xax
         self.drivers = drivers
         dx = float(xax[1] - xax[0])
@@ -79,6 +84,7 @@ class TransverseCurrentSourceDriver:
             return -factor * w_total**2 * driver.a0 * jnp.sin(kk * self.xax - w_total * current_time)
 
     def __call__(self, t, args):
+        """Evaluate the summed transverse current source at time t."""
         total = jnp.zeros_like(self.xax)
         for driver, mask, scale in zip(self.drivers, self.point_source_masks, self.point_source_scales, strict=True):
             total += self._single_driver_source(driver, mask, scale, t)
@@ -86,7 +92,10 @@ class TransverseCurrentSourceDriver:
 
 
 class WaveSolver:
+    """Finite-difference transverse wave-equation solver with absorbing boundaries."""
+
     def __init__(self, c: jnp.float64, dx: jnp.float64, dt: jnp.float64):
+        """Precompute constants for the second-order wave update."""
         super().__init__()
         self.dx = dx
         self.c = c
@@ -132,6 +141,7 @@ class WaveSolver:
         return jnp.concatenate([a_left, anew, a_right])
 
     def __call__(self, a: jnp.ndarray, aold: jnp.ndarray, djy_array: jnp.ndarray, electron_density: jnp.ndarray):
+        """Advance the vector potential one timestep or preserve it when waves are disabled."""
         if self.c > 0:
             d2dx2 = (a[:-2] - 2.0 * a[1:-1] + a[2:]) / self.dx**2.0
             # padded_a = jnp.concatenate([a[-1:], a, a[:1]])
@@ -343,6 +353,7 @@ class ElectricFieldSolver:
     """
 
     def __init__(self, cfg: dict, grid: Grid):
+        """Select and configure the electrostatic field solver requested by cfg."""
         super().__init__()
 
         species_grids = cfg["grid"]["species_grids"]

--- a/adept/_vlasov1d/solvers/pushers/vlasov.py
+++ b/adept/_vlasov1d/solvers/pushers/vlasov.py
@@ -1,3 +1,5 @@
+"""Vlasov advection pushers for the one-dimensional phase-space solver."""
+
 from collections.abc import Callable
 from functools import partial
 
@@ -12,6 +14,8 @@ from jax.sharding import PartitionSpec as P
 
 
 class VlasovExternalE(eqx.Module):
+    """Split Vlasov pusher for externally supplied electric fields."""
+
     x: jnp.ndarray
     v: jnp.ndarray
     f_interp: Callable
@@ -21,6 +25,7 @@ class VlasovExternalE(eqx.Module):
     interp_e: Callable
 
     def __init__(self, cfg, interp_e):
+        """Create interpolation helpers for x-advection and v-advection steps."""
         self.x = cfg["grid"]["x"]
         self.v = cfg["grid"]["v"]
         self.f_interp = partial(interp2d, x=self.x, y=self.v, period=cfg["grid"]["xmax"])
@@ -30,12 +35,14 @@ class VlasovExternalE(eqx.Module):
         self.interp_e = interp_e
 
     def step_vdfdx(self, t, f, frac_dt):
+        """Advect the distribution along x characteristics for a fractional step."""
         old_x = self.x[:, None] - self.v[None, :] * frac_dt * self.dt
         old_v = self.dummy_x[:, None] * self.v[None, :]
         new_f = self.f_interp(xq=old_x.flatten(), yq=old_v.flatten(), f=f)
         return jnp.reshape(new_f, (self.x.size, self.v.size))
 
     def step_edfdv(self, t, f, frac_dt):
+        """Advect the distribution along v characteristics using the external field."""
         interp_e = self.interp_e(self.dummy_x * t, self.x)
         old_v = self.v[None, :] + interp_e[:, None] * frac_dt * self.dt
         old_x = self.dummy_v * self.x[:, None]
@@ -43,6 +50,7 @@ class VlasovExternalE(eqx.Module):
         return jnp.reshape(new_f, (self.x.size, self.v.size))
 
     def __call__(self, t, y, args):
+        """Apply Strang splitting for one externally driven Vlasov step."""
         f = y["electron"]
 
         new_f = self.step_vdfdx(t, f, 0.5)
@@ -53,7 +61,10 @@ class VlasovExternalE(eqx.Module):
 
 
 class VelocityExponential:
+    """Spectral velocity-space advection under electric and ponderomotive forces."""
+
     def __init__(self, species_grids, species_params, parallel=False):
+        """Store per-species velocity grids and optional sharding metadata."""
         self.species_grids = species_grids
         self.species_params = species_params
         self.parallel = parallel
@@ -61,6 +72,7 @@ class VelocityExponential:
             self.mesh = Mesh(np.array(jax.devices()), ("device",))
 
     def push(self, f_dict, e, pond, dt):
+        """Apply the unsharded spectral velocity push to each species."""
         result = {}
         for species_name, f in f_dict.items():
             kv_real = self.species_grids[species_name]["kvr"]
@@ -79,6 +91,7 @@ class VelocityExponential:
         return result
 
     def __call__(self, f_dict, e, pond, dt):
+        """Dispatch the velocity push, optionally through shard_map."""
         if self.parallel:
             return shard_map(
                 self.push,
@@ -91,7 +104,10 @@ class VelocityExponential:
 
 
 class VelocityCubicSpline:
+    """Cubic-spline velocity-space advection under electric and ponderomotive forces."""
+
     def __init__(self, species_grids, species_params, parallel=False):
+        """Store per-species velocity grids, interpolation kernel, and sharding metadata."""
         self.species_grids = species_grids
         self.species_params = species_params
         self.interp = vmap(partial(interp1d, extrap=1.0e-30), in_axes=0)
@@ -100,6 +116,7 @@ class VelocityCubicSpline:
             self.mesh = Mesh(np.array(jax.devices()), ("device",))
 
     def push(self, f_dict, e, pond, dt):
+        """Apply the unsharded cubic-spline velocity push to each species."""
         result = {}
         for species_name, f in f_dict.items():
             v = self.species_grids[species_name]["v"]
@@ -114,6 +131,7 @@ class VelocityCubicSpline:
         return result
 
     def __call__(self, f_dict, e, pond, dt):
+        """Dispatch the cubic-spline velocity push, optionally through shard_map."""
         if self.parallel:
             return shard_map(
                 self.push,
@@ -145,6 +163,7 @@ class HouLiFilter:
     """
 
     def __init__(self, species_grids: dict, nx: int, alpha: float, order: int, dimensions: list[str]):
+        """Precompute x and v Fourier-space filter kernels for requested dimensions."""
         if "x" in dimensions:
             j_x = jnp.arange(nx // 2 + 1)
             eta_x = j_x / (nx // 2)
@@ -161,6 +180,7 @@ class HouLiFilter:
                 self.filters_v[species_name] = jnp.exp(-alpha * eta ** (2 * order))
 
     def __call__(self, f_dict: dict) -> dict:
+        """Apply configured Hou-Li filters to each species distribution."""
         result = {}
         for species_name, f in f_dict.items():
             filtered = f
@@ -177,7 +197,10 @@ class HouLiFilter:
 
 
 class SpaceExponential:
+    """Spectral configuration-space advection for each species."""
+
     def __init__(self, x, species_grids, parallel=False):
+        """Precompute x-space wavenumbers and optional velocity-axis sharding metadata."""
         self.kx_real = jnp.fft.rfftfreq(len(x), d=x[1] - x[0]) * 2 * jnp.pi
         self.species_grids = species_grids
         self.parallel = parallel
@@ -185,11 +208,13 @@ class SpaceExponential:
             self.mesh = Mesh(np.array(jax.devices()), ("device",))
 
     def push(self, f, v):
+        """Apply the spectral x-advection update for one species distribution."""
         return jnp.real(
             jnp.fft.irfft(jnp.exp(-1j * self.kx_real[:, None] * v[None, :]) * jnp.fft.rfft(f, axis=0), axis=0)
         )
 
     def __call__(self, f_dict, dt):
+        """Advect every species in configuration space for one timestep."""
         result = {}
         for species_name, f in f_dict.items():
             v = self.species_grids[species_name]["v"] * dt

--- a/adept/_vlasov1d/solvers/vector_field.py
+++ b/adept/_vlasov1d/solvers/vector_field.py
@@ -1,3 +1,5 @@
+"""Vector-field composition for Vlasov-1D Diffrax solves."""
+
 from jax import Array
 from jax import numpy as jnp
 
@@ -28,6 +30,7 @@ class TimeIntegrator:
     """
 
     def __init__(self, cfg: dict, grid: Grid):
+        """Construct shared field solver and Vlasov pushers from configuration."""
         self.field_solve = field.ElectricFieldSolver(cfg, grid)
         self.species_grids = cfg["grid"]["species_grids"]
         self.species_params = cfg["grid"]["species_params"]
@@ -36,6 +39,7 @@ class TimeIntegrator:
         self.vdfdx = vlasov.SpaceExponential(grid.x, self.species_grids, parallel=_is_parallel(parallel, "v"))
 
     def get_edfdv(self, cfg: dict, parallel):
+        """Return the configured velocity-space advection operator."""
         if cfg["terms"]["edfdv"] == "exponential":
             return vlasov.VelocityExponential(
                 self.species_grids, self.species_params, parallel=_is_parallel(parallel, "x")
@@ -63,6 +67,7 @@ class LeapfrogIntegrator(TimeIntegrator):
     """
 
     def __init__(self, cfg: dict, grid: Grid):
+        """Initialize leapfrog coefficients and shared pusher state."""
         super().__init__(cfg, grid)
         self.dt = grid.dt
         self.dt_array = self.dt * jnp.array([0.0, 1.0])
@@ -106,6 +111,7 @@ class SixthOrderHamIntegrator(TimeIntegrator):
     """
 
     def __init__(self, cfg: dict, grid: Grid):
+        """Initialize sixth-order Hamiltonian splitting coefficients."""
         super().__init__(cfg, grid)
         self.dt = grid.dt
 
@@ -197,6 +203,7 @@ class VlasovPoissonFokkerPlanck:
     """
 
     def __init__(self, cfg: dict, grid: Grid):
+        """Build the Vlasov-Poisson integrator, collisions, filters, and diagnostics."""
         self.dt = grid.dt
         if cfg["terms"]["time"] == "sixth":
             self.vlasov_poisson = SixthOrderHamIntegrator(cfg, grid)
@@ -227,6 +234,7 @@ class VlasovPoissonFokkerPlanck:
     def __call__(
         self, f_dict: dict, a: Array, prev_ex: Array, dex_array: Array, nu_fp: Array, nu_K: Array
     ) -> tuple[Array, dict, dict]:
+        """Advance Vlasov, collision, filter, and diagnostic terms for one timestep."""
         e, f_vlasov = self.vlasov_poisson(f_dict, a, dex_array, prev_ex)
 
         f_fp = self.fp(nu_fp, nu_K, f_vlasov, dt=self.dt)
@@ -266,6 +274,7 @@ class VlasovMaxwell:
         nu_fp_prof: SpaceTimeEnvelopeFunction | None = None,
         nu_K_prof: SpaceTimeEnvelopeFunction | None = None,
     ):
+        """Assemble the coupled electrostatic, transverse-wave, and driver operators."""
         self.cfg = cfg
         self.grid = grid
         self.nu_fp_prof = nu_fp_prof

--- a/adept/_vlasov1d/storage.py
+++ b/adept/_vlasov1d/storage.py
@@ -1,3 +1,5 @@
+"""Save-function construction and netCDF writers for Vlasov-1D output."""
+
 import os
 import warnings
 
@@ -115,11 +117,13 @@ def store_f(cfg: dict, this_t: dict, td: str, ys: dict) -> dict:
 
 
 def get_field_save_func(cfg):
+    """Build the Diffrax save callback for field and species moment snapshots."""
     if {"t"} == set(cfg["save"]["fields"].keys()):
         species_grids = cfg["grid"]["species_grids"]
         species_names = list(species_grids.keys())
 
         def fields_save_func(t, y, args):
+            """Compute field, moment, and ponderomotive quantities for one save time."""
             result = {}
 
             # Compute moments for each species
@@ -158,9 +162,11 @@ def get_field_save_func(cfg):
 
 
 def get_dist_save_func(axes, dist_save_config, dist_key):
+    """Build a save callback for full or interpolated distribution-function output."""
     if {"t"} == set(dist_save_config.keys()):
 
         def dist_save_func(t, y, args):
+            """Return the full distribution for this save point."""
             return y[dist_key]
 
     elif {"t", "x", "v"} == set(dist_save_config.keys()):
@@ -169,6 +175,7 @@ def get_dist_save_func(axes, dist_save_config, dist_key):
         out_shape = xq.shape
 
         def dist_save_func(t, y, args):
+            """Return the distribution interpolated on configured x-v sample points."""
             return interp2d(xq_flat, vq_flat, axes["x"], axes["v"], y[dist_key], method="linear").reshape(out_shape)
 
     elif {"t", "kx", "v"} == set(dist_save_config.keys()):
@@ -177,6 +184,7 @@ def get_dist_save_func(axes, dist_save_config, dist_key):
         out_shape = kxq.shape
 
         def dist_save_func(t, y, args):
+            """Return the distribution spectrum interpolated on configured kx-v points."""
             fkx = jnp.abs(jnp.fft.rfft(y[dist_key], axes=0))
             return interp2d(kxq_flat, vq_flat, axes["kx"], axes["v"], fkx, method="linear").reshape(out_shape)
 
@@ -275,10 +283,12 @@ def get_save_quantities(cfg: dict) -> dict:
 
 
 def get_default_save_func(cfg):
+    """Build the default scalar save callback for species moments and field energies."""
     species_grids = cfg["grid"]["species_grids"]
     species_names = list(species_grids.keys())
 
     def save(t, y, args):
+        """Compute scalar diagnostics at one solver save point."""
         scalars = {}
 
         # Compute scalars for each species

--- a/adept/vlasov1d.py
+++ b/adept/vlasov1d.py
@@ -1,1 +1,3 @@
+"""Public entry point for the Vlasov-1D ADEPT module."""
+
 from ._vlasov1d.modules import BaseVlasov1D


### PR DESCRIPTION
## Summary
- Add module, class, constructor, callable, and helper docstrings across the Vlasov 1D implementation package
- Cover Pydantic config models, simulation/domain objects, storage callbacks, vector-field composition, and numerical pushers
- Add a docstring to the public `adept.vlasov1d` entry point

## Verification
- `uvx ruff format adept/_vlasov1d adept/vlasov1d.py`
- `uvx ruff check adept/_vlasov1d adept/vlasov1d.py`
- AST docstring coverage scan over `adept/_vlasov1d` and `adept/vlasov1d.py`
- `uv run pytest tests/test_vlasov1d -q` → 80 passed, 7 deselected, 1 xpassed
