### PR TITLE
feat: add Vlasov 2D distributed initialization

### DIFF
--- a/adept/_vlasov2d/datamodel.py
+++ b/adept/_vlasov2d/datamodel.py
@@ -53,6 +53,15 @@ class DensityConfig(BaseModel):
         return SpeciesComponentConfig.model_validate(self.model_extra[name])
 
 
+class DistributionShardingConfig(BaseModel):
+    """JAX sharding controls for distributed f(x, y, vx, vy) initialization."""
+
+    enabled: bool = False
+    mesh_axes: tuple[str, ...] = ("x",)
+    mesh_shape: tuple[int, ...] | None = None
+    partition: tuple[str | None, str | None, str | None, str | None] = ("x", None, None, None)
+
+
 class UnitsConfig(BaseModel):
     normalizing_temperature: str
     normalizing_density: str
@@ -74,6 +83,11 @@ class GridConfig(BaseModel):
     nvy: int | None = None
     vmax: float | None = None
     parallel: tuple[str, ...] | bool = False
+    distribution_sharding: DistributionShardingConfig = Field(
+        default_factory=DistributionShardingConfig, alias="distribution-sharding"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("parallel", mode="before")
     @classmethod

--- a/adept/_vlasov2d/distributed.py
+++ b/adept/_vlasov2d/distributed.py
@@ -101,8 +101,29 @@ def make_sharded_array(
 def reshard_for_global_axis_fft(array, dist: DistributionSharding, axis: int | str):
     """Reshard an array so a future global FFT has the transform axis local.
 
-    This is intentionally a small building block: pusher code can call this
-    before an FFT along x, y, vx, or vy. JAX will insert the necessary collective
-    communication for the reshard on multi-device meshes.
+    Returns a NamedSharding view in which `axis` is replicated across the mesh
+    so that a subsequent FFT along that axis is a local per-device op.
+
+    NOTE: prefer declaring `in_shardings`/`out_shardings` on a `jax.jit`-wrapped
+    pusher and letting XLA's SPMD partitioner insert the reshards automatically.
+    This helper is for code paths where the pusher is not inside a single `jit`
+    boundary, or where an explicit data-movement annotation is wanted. Inside a
+    `jit`, calling this can force a sync point that XLA would otherwise schedule
+    better.
     """
     return jax.device_put(array, dist.with_unsharded_axis(axis))
+
+
+def reshard_to_partitioned(array, dist: DistributionSharding):
+    """Reshard an array back to the canonical partitioned layout.
+
+    Symmetric to `reshard_for_global_axis_fft`: returns the input as a
+    NamedSharding view with the full `dist.partition` (e.g. ('x', None, None, None))
+    restored on every distribution axis. Use after a global-axis op (typically
+    an inverse FFT) to re-partition the array for the next stage.
+
+    Same NOTE applies as for `reshard_for_global_axis_fft`: when the surrounding
+    pusher is wrapped in `jax.jit` with declared shardings, XLA handles this
+    automatically and the explicit call becomes redundant.
+    """
+    return jax.device_put(array, dist.sharding)

--- a/adept/_vlasov2d/distributed.py
+++ b/adept/_vlasov2d/distributed.py
@@ -1,0 +1,108 @@
+"""Distributed initialization helpers for the Vlasov-2D distribution function."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+DISTRIBUTION_DIMS = ("x", "y", "vx", "vy")
+
+
+@dataclass(frozen=True)
+class DistributionSharding:
+    """Named sharding metadata for f(x, y, vx, vy) arrays."""
+
+    mesh: Mesh
+    partition: PartitionSpec
+    sharding: NamedSharding
+
+    def with_unsharded_axis(self, axis: int | str) -> NamedSharding:
+        """Return a NamedSharding with one logical distribution axis replicated."""
+        axis_index = DISTRIBUTION_DIMS.index(axis) if isinstance(axis, str) else axis
+        parts = list(self.partition)
+        parts[axis_index] = None
+        return NamedSharding(self.mesh, PartitionSpec(*parts))
+
+
+def _normalize_raw_config(raw: Any) -> dict:
+    if raw is None:
+        return {}
+    if hasattr(raw, "model_dump"):
+        return raw.model_dump()
+    return dict(raw)
+
+
+def _validate_partition(mesh_axes: Sequence[str], partition: Sequence[str | None]) -> None:
+    if len(partition) != len(DISTRIBUTION_DIMS):
+        raise ValueError(f"distribution partition must have four entries for {DISTRIBUTION_DIMS}, got {partition!r}")
+    unknown = {axis for axis in partition if axis is not None and axis not in mesh_axes}
+    if unknown:
+        raise ValueError(f"distribution partition uses mesh axes not present in mesh_axes: {sorted(unknown)}")
+
+
+def create_distribution_sharding(
+    raw_cfg: Any, devices: Sequence[jax.Device] | None = None
+) -> DistributionSharding | None:
+    """Create the NamedSharding requested by grid.distribution-sharding.
+
+    If mesh_shape is omitted, all visible devices are placed on the first mesh
+    axis. A single-device host still returns a NamedSharding, which lets tests
+    exercise the distributed initialization code path without multiple GPUs.
+    """
+    cfg = _normalize_raw_config(raw_cfg)
+    if not cfg.get("enabled", False):
+        return None
+
+    mesh_axes = tuple(cfg.get("mesh_axes") or cfg.get("mesh-axes") or ("x",))
+    mesh_shape = cfg.get("mesh_shape") or cfg.get("mesh-shape")
+    partition = tuple(cfg.get("partition") or ("x", None, None, None))
+    _validate_partition(mesh_axes, partition)
+
+    devices = list(devices) if devices is not None else list(jax.devices())
+    if not devices:
+        raise ValueError("No JAX devices are available for Vlasov-2D distribution sharding.")
+
+    if mesh_shape is None:
+        mesh_shape = (len(devices),) + (1,) * (len(mesh_axes) - 1)
+    else:
+        mesh_shape = tuple(int(v) for v in mesh_shape)
+
+    if len(mesh_shape) != len(mesh_axes):
+        raise ValueError(f"mesh_shape {mesh_shape!r} must have one entry per mesh axis {mesh_axes!r}.")
+    if int(np.prod(mesh_shape)) != len(devices):
+        raise ValueError(f"mesh_shape {mesh_shape!r} requires {int(np.prod(mesh_shape))} devices, got {len(devices)}.")
+
+    mesh = jax.make_mesh(mesh_shape, mesh_axes, devices=devices)
+    pspec = PartitionSpec(*partition)
+    return DistributionSharding(mesh=mesh, partition=pspec, sharding=NamedSharding(mesh, pspec))
+
+
+def make_sharded_array(
+    shape: tuple[int, ...],
+    sharding: NamedSharding,
+    callback: Callable[[tuple[slice, ...]], np.ndarray],
+    dtype: Any,
+):
+    """Create a globally shaped sharded JAX array from per-shard callbacks."""
+
+    def _callback(index):
+        if index is None:
+            index = tuple(slice(None) for _ in shape)
+        return np.asarray(callback(index), dtype=dtype)
+
+    return jax.make_array_from_callback(shape, sharding, _callback, dtype=dtype)
+
+
+def reshard_for_global_axis_fft(array, dist: DistributionSharding, axis: int | str):
+    """Reshard an array so a future global FFT has the transform axis local.
+
+    This is intentionally a small building block: pusher code can call this
+    before an FFT along x, y, vx, or vy. JAX will insert the necessary collective
+    communication for the reshard on multi-device meshes.
+    """
+    return jax.device_put(array, dist.with_unsharded_axis(axis))

--- a/adept/_vlasov2d/helpers.py
+++ b/adept/_vlasov2d/helpers.py
@@ -10,6 +10,7 @@ from jax import numpy as jnp
 from matplotlib import pyplot as plt
 from scipy.special import gamma
 
+from adept._vlasov2d.distributed import create_distribution_sharding, make_sharded_array
 from adept._vlasov2d.simulation import Vlasov2DSimulation
 from adept._vlasov2d.storage import store_f, store_fields
 
@@ -38,7 +39,26 @@ def _initialize_bi_supergaussian(
     dvy = 2.0 * vmax / nvy
     vxax = np.linspace(-vmax + dvx / 2.0, vmax - dvx / 2.0, nvx)
     vyax = np.linspace(-vmax + dvy / 2.0, vmax - dvy / 2.0, nvy)
+    f = _evaluate_bi_supergaussian_on_axes(vxax, vyax, v0x, v0y, T0, mass, supergaussian_order, vmax, n_prof)
+    return f, vxax, vyax
 
+
+def _evaluate_bi_supergaussian_on_axes(
+    vxax: np.ndarray,
+    vyax: np.ndarray,
+    v0x: float,
+    v0y: float,
+    T0: float,
+    mass: float,
+    supergaussian_order: float,
+    vmax: float,
+    n_prof: np.ndarray,
+):
+    """Evaluate a normalized separable bi-supergaussian on preselected velocity axes."""
+    nvx = vxax.size
+    nvy = vyax.size
+    dvx = 2.0 * vmax / nvx
+    dvy = 2.0 * vmax / nvy
     v_th = np.sqrt(T0 / mass)
     alpha = _gamma_ratio_alpha(supergaussian_order)
     scale = alpha * v_th
@@ -50,8 +70,71 @@ def _initialize_bi_supergaussian(
     fvy /= np.sum(fvy) * dvy
 
     fv = fvx[:, None] * fvy[None, :]
-    f = n_prof[:, :, None, None] * fv[None, None, :, :]
-    return f, vxax, vyax
+    return n_prof[:, :, None, None] * fv[None, None, :, :]
+
+
+def _slice_axis(axis, indexer) -> np.ndarray:
+    """Return a NumPy view/copy of a JAX axis for a make_array_from_callback index."""
+    return np.atleast_1d(np.asarray(axis[indexer]))
+
+
+def _component_density_on_slice(spec, x_slice: np.ndarray, y_slice: np.ndarray) -> np.ndarray:
+    """Evaluate one density component on an x-y shard."""
+    return np.asarray(spec.density_profile(jnp.asarray(x_slice), jnp.asarray(y_slice)))
+
+
+def _initialize_sharded_species_distribution(
+    species_cfg,
+    distribution_specs,
+    grid,
+    sharding,
+    dtype,
+):
+    """Create a sharded f(x, y, vx, vy) array without allocating the global array."""
+    for spec in distribution_specs:
+        noise = spec.density_profile.noise_profile
+        if noise.noise_type.casefold() != "none" and noise.noise_val != 0.0:
+            raise NotImplementedError(
+                "Distributed Vlasov-2D initialization currently requires deterministic density profiles "
+                "(set noise_type: none or noise_val: 0.0)."
+            )
+
+    vx_full = np.linspace(
+        -species_cfg.vmax + species_cfg.vmax / species_cfg.nvx,
+        species_cfg.vmax - species_cfg.vmax / species_cfg.nvx,
+        species_cfg.nvx,
+    )
+    vy_full = np.linspace(
+        -species_cfg.vmax + species_cfg.vmax / species_cfg.nvy,
+        species_cfg.vmax - species_cfg.vmax / species_cfg.nvy,
+        species_cfg.nvy,
+    )
+    shape = (grid.nx, grid.ny, species_cfg.nvx, species_cfg.nvy)
+
+    def _callback(index):
+        x_index, y_index, vx_index, vy_index = index
+        x_slice = _slice_axis(grid.x, x_index)
+        y_slice = _slice_axis(grid.y, y_index)
+        vx_slice = vx_full[vx_index]
+        vy_slice = vy_full[vy_index]
+
+        f_shard = np.zeros((x_slice.size, y_slice.size, vx_slice.size, vy_slice.size), dtype=dtype)
+        for spec in distribution_specs:
+            nprof = _component_density_on_slice(spec, x_slice, y_slice)
+            f_shard += _evaluate_bi_supergaussian_on_axes(
+                vx_slice,
+                vy_slice,
+                v0x=spec.v0x,
+                v0y=spec.v0y,
+                T0=spec.T0,
+                mass=species_cfg.mass,
+                supergaussian_order=spec.supergaussian_order,
+                vmax=species_cfg.vmax,
+                n_prof=nprof,
+            ).astype(dtype, copy=False)
+        return f_shard
+
+    return make_sharded_array(shape, sharding, _callback, dtype=dtype), vx_full, vy_full
 
 
 def _initialize_total_distribution_(cfg: dict, simulation: Vlasov2DSimulation):
@@ -59,6 +142,8 @@ def _initialize_total_distribution_(cfg: dict, simulation: Vlasov2DSimulation):
     grid = simulation.grid
     species_distributions = {}
     species_found = False
+    sharding_cfg = cfg.get("grid", {}).get("distribution_sharding") or cfg.get("grid", {}).get("distribution-sharding")
+    dist_sharding = create_distribution_sharding(sharding_cfg)
 
     for species_cfg in simulation.species:
         name = species_cfg.name
@@ -68,28 +153,41 @@ def _initialize_total_distribution_(cfg: dict, simulation: Vlasov2DSimulation):
         mass = species_cfg.mass
 
         n_prof_species = np.zeros([grid.nx, grid.ny])
-        f_species = np.zeros([grid.nx, grid.ny, nvx, nvy])
+        f_species = None
         vxax = np.zeros(nvx)
         vyax = np.zeros(nvy)
 
         for spec in simulation.species_distributions[name]:
             nprof = np.array(spec.density_profile(grid.x, grid.y))
             n_prof_species += nprof
-            f_one, vxax, vyax = _initialize_bi_supergaussian(
-                nx=grid.nx,
-                ny=grid.ny,
-                nvx=nvx,
-                nvy=nvy,
-                v0x=spec.v0x,
-                v0y=spec.v0y,
-                T0=spec.T0,
-                mass=mass,
-                supergaussian_order=spec.supergaussian_order,
-                vmax=vmax,
-                n_prof=nprof,
-            )
-            f_species += f_one
             species_found = True
+
+        if dist_sharding is None:
+            f_species = np.zeros([grid.nx, grid.ny, nvx, nvy])
+            for spec in simulation.species_distributions[name]:
+                nprof = np.array(spec.density_profile(grid.x, grid.y))
+                f_one, vxax, vyax = _initialize_bi_supergaussian(
+                    nx=grid.nx,
+                    ny=grid.ny,
+                    nvx=nvx,
+                    nvy=nvy,
+                    v0x=spec.v0x,
+                    v0y=spec.v0y,
+                    T0=spec.T0,
+                    mass=mass,
+                    supergaussian_order=spec.supergaussian_order,
+                    vmax=vmax,
+                    n_prof=nprof,
+                )
+                f_species += f_one
+        else:
+            f_species, vxax, vyax = _initialize_sharded_species_distribution(
+                species_cfg,
+                simulation.species_distributions[name],
+                grid,
+                dist_sharding.sharding,
+                dtype=n_prof_species.dtype,
+            )
 
         species_distributions[name] = (n_prof_species, f_species, vxax, vyax)
 

--- a/adept/_vlasov2d/helpers.py
+++ b/adept/_vlasov2d/helpers.py
@@ -157,15 +157,18 @@ def _initialize_total_distribution_(cfg: dict, simulation: Vlasov2DSimulation):
         vxax = np.zeros(nvx)
         vyax = np.zeros(nvy)
 
-        for spec in simulation.species_distributions[name]:
+        # Compute each component's density profile once and reuse below.
+        component_specs = simulation.species_distributions[name]
+        component_nprofs = []
+        for spec in component_specs:
             nprof = np.array(spec.density_profile(grid.x, grid.y))
+            component_nprofs.append(nprof)
             n_prof_species += nprof
             species_found = True
 
         if dist_sharding is None:
             f_species = np.zeros([grid.nx, grid.ny, nvx, nvy])
-            for spec in simulation.species_distributions[name]:
-                nprof = np.array(spec.density_profile(grid.x, grid.y))
+            for spec, nprof in zip(component_specs, component_nprofs, strict=True):
                 f_one, vxax, vyax = _initialize_bi_supergaussian(
                     nx=grid.nx,
                     ny=grid.ny,
@@ -183,7 +186,7 @@ def _initialize_total_distribution_(cfg: dict, simulation: Vlasov2DSimulation):
         else:
             f_species, vxax, vyax = _initialize_sharded_species_distribution(
                 species_cfg,
-                simulation.species_distributions[name],
+                component_specs,
                 grid,
                 dist_sharding.sharding,
                 dtype=n_prof_species.dtype,

--- a/adept/_vlasov2d/modules.py
+++ b/adept/_vlasov2d/modules.py
@@ -95,6 +95,7 @@ class BaseVlasov2D(ADEPTModule):
         super().__init__(cfg)
         self.config_model = Vlasov2DConfig.model_validate(cfg)
         self.simulation = sim_from_config(self.config_model)
+        self._initial_distribution = None
 
     def post_process(self, run_output: dict, td: str):
         return post_process(run_output["solver result"], self.cfg, td, self.args)
@@ -153,6 +154,7 @@ class BaseVlasov2D(ADEPTModule):
         cfg_grid.update(asdict(grid))
 
         dist_result = _initialize_total_distribution_(self.cfg, self.simulation)
+        self._initial_distribution = dist_result
         cfg_grid["species_distributions"] = dist_result
 
         cfg_grid["species_grids"] = {}
@@ -199,11 +201,13 @@ class BaseVlasov2D(ADEPTModule):
 
     def init_state_and_args(self) -> dict:
         grid = self.simulation.grid
-        dist_result = _initialize_total_distribution_(self.cfg, self.simulation)
+        dist_result = self._initial_distribution
+        if dist_result is None:
+            dist_result = _initialize_total_distribution_(self.cfg, self.simulation)
 
         state: dict = {}
         for s_name, (_n, f_s, _vx, _vy) in dist_result.items():
-            state[s_name] = jnp.array(f_s)
+            state[s_name] = jnp.asarray(f_s)
 
         # initial fields from Poisson on initial charge density
         poisson = InitialPoissonSolver(self.simulation.grid.kx, self.simulation.grid.ky)

--- a/docs/source/solvers/vlasov2d/config.md
+++ b/docs/source/solvers/vlasov2d/config.md
@@ -60,10 +60,40 @@ grid:
   ymin: -10.0
   ymax: 10.0
   parallel: false
+  distribution-sharding:
+    enabled: false
+    mesh_axes: ["x"]
+    mesh_shape: [1]
+    partition: ["x", null, null, null]
 ```
 
 `dt` will be capped to `0.5 * min(dx, dy) / c_norm` whenever any EM driver is
 enabled (Maxwell CFL).
+
+`distribution-sharding` enables distributed initialization of the global
+`f(x, y, vx, vy)` arrays. When enabled, the solver uses JAX
+`make_array_from_callback` to materialize each device's shard directly instead
+of allocating the full distribution on the host first. The `partition` tuple is
+ordered as `[x, y, vx, vy]` and each entry must either be `null` or a name from
+`mesh_axes`.
+
+For example, a two-dimensional spatial mesh over all visible devices can be
+configured as:
+
+```yaml
+grid:
+  distribution-sharding:
+    enabled: true
+    mesh_axes: ["x", "y"]
+    mesh_shape: [4, 2]
+    partition: ["x", "y", null, null]
+```
+
+If `mesh_shape` is omitted, all visible JAX devices are placed on the first mesh
+axis. Sharded initialization currently requires deterministic density profiles:
+set `noise_type: none` or `noise_val: 0.0`. The sharding helper also exposes a
+reshard primitive for future distributed FFT pushers to make a transform axis
+local before an exponential step.
 
 ## `density`
 

--- a/tests/test_vlasov2d/test_distributed_init.py
+++ b/tests/test_vlasov2d/test_distributed_init.py
@@ -1,0 +1,137 @@
+"""Tests for distributed Vlasov-2D distribution initialization."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+from jax.sharding import NamedSharding
+
+from adept._vlasov2d.datamodel import Vlasov2DConfig
+from adept._vlasov2d.distributed import create_distribution_sharding, reshard_for_global_axis_fft
+from adept._vlasov2d.helpers import _initialize_total_distribution_
+from adept._vlasov2d.modules import sim_from_config
+
+
+def _base_cfg() -> dict:
+    return {
+        "solver": "vlasov-2d",
+        "units": {
+            "normalizing_temperature": "2000eV",
+            "normalizing_density": "1.5e21/cc",
+        },
+        "density": {
+            "quasineutrality": True,
+            "species-background": {
+                "noise_seed": 1,
+                "noise_type": "none",
+                "noise_val": 0.0,
+                "v0x": 0.1,
+                "v0y": -0.2,
+                "T0": 1.0,
+                "m": 2.0,
+                "basis": "sine",
+                "baseline": 1.0,
+                "amplitude": 1.0e-3,
+                "wavenumber-x": 0.3,
+                "wavenumber-y": 0.2,
+            },
+        },
+        "grid": {
+            "dt": 0.1,
+            "nx": 8,
+            "ny": 6,
+            "nvx": 10,
+            "nvy": 12,
+            "tmin": 0.0,
+            "tmax": 1.0,
+            "vmax": 6.0,
+            "xmin": 0.0,
+            "xmax": 20.94,
+            "ymin": -10.0,
+            "ymax": 10.0,
+        },
+        "terms": {
+            "edfdv": "exponential",
+            "vdfdx": "exponential",
+            "fokker_planck": {"is_on": False},
+            "krook": {"is_on": False},
+            "hou_li_filter": {"is_on": False},
+        },
+        "drivers": {"ex": {}, "ey": {}},
+        "save": {"fields": {"t": {"nt": 2}}},
+        "mlflow": {"experiment": "test-vlasov2d", "run": "distributed-init"},
+    }
+
+
+def test_sharded_distribution_initializer_matches_host_initializer():
+    cfg = _base_cfg()
+    sim = sim_from_config(Vlasov2DConfig.model_validate(cfg))
+    full = _initialize_total_distribution_(cfg, sim)
+
+    sharded_cfg = deepcopy(cfg)
+    sharded_cfg["grid"]["distribution-sharding"] = {
+        "enabled": True,
+        "mesh_axes": ["x"],
+        "mesh_shape": [1],
+        "partition": ["x", None, None, None],
+    }
+    sharded = _initialize_total_distribution_(sharded_cfg, sim)
+
+    n_full, f_full, vx_full, vy_full = full["electron"]
+    n_sharded, f_sharded, vx_sharded, vy_sharded = sharded["electron"]
+
+    assert isinstance(f_sharded.sharding, NamedSharding)
+    assert f_sharded.shape == f_full.shape
+    np.testing.assert_allclose(n_sharded, n_full)
+    np.testing.assert_allclose(vx_sharded, vx_full)
+    np.testing.assert_allclose(vy_sharded, vy_full)
+    np.testing.assert_allclose(np.asarray(f_sharded), f_full, rtol=1e-6, atol=1e-7)
+
+
+def test_distribution_sharding_can_derive_fft_resharding():
+    dist = create_distribution_sharding(
+        {
+            "enabled": True,
+            "mesh_axes": ["x"],
+            "mesh_shape": [1],
+            "partition": ["x", None, None, None],
+        }
+    )
+
+    assert dist is not None
+    fft_sharding = dist.with_unsharded_axis("x")
+    assert isinstance(fft_sharding, NamedSharding)
+    assert fft_sharding.spec[0] is None
+
+
+def test_distribution_sharding_rejects_unknown_partition_axis():
+    with pytest.raises(ValueError, match="mesh axes"):
+        create_distribution_sharding(
+            {
+                "enabled": True,
+                "mesh_axes": ["x"],
+                "mesh_shape": [1],
+                "partition": ["not-a-mesh-axis", None, None, None],
+            }
+        )
+
+
+def test_reshard_for_global_axis_fft_preserves_values():
+    cfg = _base_cfg()
+    cfg["grid"]["distribution-sharding"] = {
+        "enabled": True,
+        "mesh_axes": ["x"],
+        "mesh_shape": [1],
+        "partition": ["x", None, None, None],
+    }
+    sim = sim_from_config(Vlasov2DConfig.model_validate(cfg))
+    dist_result = _initialize_total_distribution_(cfg, sim)
+    _, f_sharded, _, _ = dist_result["electron"]
+    dist = create_distribution_sharding(cfg["grid"]["distribution-sharding"])
+
+    local_for_x_fft = reshard_for_global_axis_fft(f_sharded, dist, "x")
+
+    np.testing.assert_allclose(np.asarray(local_for_x_fft), np.asarray(f_sharded))
+    assert local_for_x_fft.sharding.spec[0] is None

--- a/tests/test_vlasov2d/test_distributed_init.py
+++ b/tests/test_vlasov2d/test_distributed_init.py
@@ -9,7 +9,11 @@ import pytest
 from jax.sharding import NamedSharding
 
 from adept._vlasov2d.datamodel import Vlasov2DConfig
-from adept._vlasov2d.distributed import create_distribution_sharding, reshard_for_global_axis_fft
+from adept._vlasov2d.distributed import (
+    create_distribution_sharding,
+    reshard_for_global_axis_fft,
+    reshard_to_partitioned,
+)
 from adept._vlasov2d.helpers import _initialize_total_distribution_
 from adept._vlasov2d.modules import sim_from_config
 
@@ -135,3 +139,23 @@ def test_reshard_for_global_axis_fft_preserves_values():
 
     np.testing.assert_allclose(np.asarray(local_for_x_fft), np.asarray(f_sharded))
     assert local_for_x_fft.sharding.spec[0] is None
+
+
+def test_reshard_to_partitioned_round_trips_axis_replication():
+    cfg = _base_cfg()
+    cfg["grid"]["distribution-sharding"] = {
+        "enabled": True,
+        "mesh_axes": ["x"],
+        "mesh_shape": [1],
+        "partition": ["x", None, None, None],
+    }
+    sim = sim_from_config(Vlasov2DConfig.model_validate(cfg))
+    dist_result = _initialize_total_distribution_(cfg, sim)
+    _, f_sharded, _, _ = dist_result["electron"]
+    dist = create_distribution_sharding(cfg["grid"]["distribution-sharding"])
+
+    replicated = reshard_for_global_axis_fft(f_sharded, dist, "x")
+    repartitioned = reshard_to_partitioned(replicated, dist)
+
+    np.testing.assert_allclose(np.asarray(repartitioned), np.asarray(f_sharded))
+    assert repartitioned.sharding.spec == dist.partition


### PR DESCRIPTION
## Summary
- Add `grid.distribution-sharding` config for Vlasov-2D distribution initialization
- Add JAX `NamedSharding` helpers and `make_array_from_callback` machinery to initialize global `f(x, y, vx, vy)` arrays shard-by-shard
- Cache the initialized distribution between solver-quantity setup and state initialization to avoid double allocation
- Add reshard helper for future global-axis FFT/all-to-all pusher work
- Document the new sharding block in the Vlasov-2D config reference

## Notes
- Existing behavior is unchanged unless `grid.distribution-sharding.enabled` is true
- Sharded initialization currently requires deterministic density profiles (`noise_type: none` or `noise_val: 0.0`) because the existing noise profile is shape-seeded and would otherwise repeat per shard
- This PR lays down initialization and sharding metadata machinery; the exponential pusher/all-to-all FFT conversion can build on the included `reshard_for_global_axis_fft` helper

## Verification
- `uvx ruff format adept/_vlasov2d tests/test_vlasov2d/test_distributed_init.py`
- `uvx ruff check adept/_vlasov2d tests/test_vlasov2d/test_distributed_init.py`
- `uv run pytest tests/test_vlasov2d/test_distributed_init.py -q` → 4 passed
- Attempted `uv run pytest tests/test_vlasov2d -q`; existing long solver case was still CPU-bound after ~20 minutes, so I stopped it after the targeted tests had passed
