### PR TITLE
feat: native 1D Hermite-Poisson solver (_hermite_poisson_1d)

### DIFF
--- a/adept/__init__.py
+++ b/adept/__init__.py
@@ -1,3 +1,3 @@
 from ._base_ import ADEPTModule, ergoExo  # noqa: I001
 from .mlflow_logging import MlflowLoggingModule
-from . import lpse2d, vlasov1d, vlasov2d
+from . import hermite_poisson_1d, lpse2d, vlasov1d, vlasov2d

--- a/adept/_hermite_poisson_1d/__init__.py
+++ b/adept/_hermite_poisson_1d/__init__.py
@@ -1,0 +1,3 @@
+from .modules import BaseHermitePoisson1D
+
+__all__ = ["BaseHermitePoisson1D"]

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -312,6 +312,21 @@ class BaseHermitePoisson1D(ADEPTModule):
         modes = jnp.fft.fftfreq(Nx) * Nx
         mask23 = jnp.abs(modes) <= (Nx // 3)
 
+        # Per-step stochastic Ex force noise (vlasov1d stochastic_noise parity).
+        # Schema: stochastic_noise: {enabled, amplitude, seed}. Spatial weighting
+        # = n_e(x)/max(n_e) from the initial electron state, so moats see ~nothing.
+        sn_cfg = self.cfg.get("stochastic_noise", {})
+        if sn_cfg.get("enabled", False):
+            noise_amplitude = float(sn_cfg["amplitude"])
+            noise_seed = int(sn_cfg.get("seed", 0))
+            Ck_e0 = self.state["Ck_electrons"].view(jnp.complex128)
+            n_e_prof = (alpha_e ** 3) * jnp.fft.ifft(Ck_e0[0], norm="forward").real
+            noise_spatial_profile = n_e_prof / jnp.max(n_e_prof)
+        else:
+            noise_amplitude = 0.0
+            noise_seed = 0
+            noise_spatial_profile = None
+
         # Poisson solver
         poisson = PoissonSolver1D(
             one_over_kx=one_over_kx,
@@ -347,6 +362,9 @@ class BaseHermitePoisson1D(ADEPTModule):
             sponge_plasma=sponge_plasma,
             sponge_fields=sponge_fields,
             mask23=mask23,
+            noise_amplitude=noise_amplitude,
+            noise_seed=noise_seed,
+            noise_spatial_profile=noise_spatial_profile,
         )
 
         # Configure save quantities

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -188,6 +188,17 @@ class BaseHermitePoisson1D(ADEPTModule):
         Ck_e = Ck_e.at[0, 0].set(n0_e / (alpha_e ** 3))
         Ck_i = Ck_i.at[0, 0].set(n0_i / (alpha_i ** 3))
 
+        # Optional single-mode electron density perturbation (for dispersion tests):
+        # density.perturbation: {mode: int m, amplitude: float eps}
+        #   → n_e(x) = n0 * (1 + eps * cos(2*pi*m*x/Lx))
+        pert = self.cfg.get("density", {}).get("perturbation", None)
+        if pert:
+            mode = int(pert["mode"])
+            eps = float(pert["amplitude"])
+            half = 0.5 * eps * n0_e / (alpha_e ** 3)
+            Ck_e = Ck_e.at[0, mode].set(half)
+            Ck_e = Ck_e.at[0, -mode].set(half)
+
         self.state = {
             "Ck_electrons": Ck_e.view(jnp.float64),
             "Ck_ions": Ck_i.view(jnp.float64),

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -286,6 +286,10 @@ class BaseHermitePoisson1D(ADEPTModule):
         linear_i = LinearExp1D(free_stream_i, diag_i)
         combined_exp = CombinedLinearExp1D(linear_e, linear_i, static_ions=static_ions)
 
+        # 2/3-rule dealiasing mask for the quadratic F*C product
+        modes = jnp.fft.fftfreq(Nx) * Nx
+        mask23 = jnp.abs(modes) <= (Nx // 3)
+
         # Poisson solver
         poisson = PoissonSolver1D(
             one_over_kx=one_over_kx,
@@ -320,6 +324,7 @@ class BaseHermitePoisson1D(ADEPTModule):
             static_ions=static_ions,
             sponge_plasma=sponge_plasma,
             sponge_fields=sponge_fields,
+            mask23=mask23,
         )
 
         # Configure save quantities

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -10,7 +10,8 @@ State dict:
   a:            (Nx+2,)  vector potential with ghost cells
   prev_a:       (Nx+2,)  previous-step a
   e:            (Nx,)    electrostatic field (diagnostics)
-  da:           (Nx+2,)  last wave-equation source term
+  da:           (Nx+2,)  last wave-equation (ey) source term
+  de:           (Nx,)    last external longitudinal (ex) driver field (diagnostics)
 
 Config keys expected in cfg["physics"]:
   alpha_e (float), alpha_i (float), mi_me (float), Lx (float),
@@ -37,6 +38,7 @@ from adept._hermite_poisson_1d.vector_field import (
     FreeStreamingExp1D,
     HermitePoisson1DVectorField,
     LinearExp1D,
+    LongitudinalElectricFieldDriver,
     PoissonSolver1D,
     TransverseWaveDriver,
 )
@@ -156,7 +158,7 @@ class BaseHermitePoisson1D(ADEPTModule):
         one_over_kx = np.zeros(Nx, dtype=np.float64)
         one_over_kx[1:] = 1.0 / np.asarray(kx_1d[1:])
         one_over_kx = jnp.array(one_over_kx)
-        kx_sq = kx_1d ** 2
+        kx_sq = kx_1d**2
 
         # Ladder operators
         sqrt_n_minus_e = jnp.sqrt(jnp.arange(Nn_e, dtype=jnp.float64))
@@ -207,8 +209,8 @@ class BaseHermitePoisson1D(ADEPTModule):
         # C_0(kx) = FFT(n(x) / alpha^3); equilibrium: n(x) = n0 → C_0(kx=0) = n0/alpha^3
         Ck_e = jnp.zeros((Nn_e, Nx), dtype=jnp.complex128)
         Ck_i = jnp.zeros((Nn_i, Nx), dtype=jnp.complex128)
-        Ck_e = Ck_e.at[0, 0].set(n0_e / (alpha_e ** 3))
-        Ck_i = Ck_i.at[0, 0].set(n0_i / (alpha_i ** 3))
+        Ck_e = Ck_e.at[0, 0].set(n0_e / (alpha_e**3))
+        Ck_i = Ck_i.at[0, 0].set(n0_i / (alpha_i**3))
 
         # Optional single-mode electron density perturbation (for dispersion tests):
         # density.perturbation: {mode: int m, amplitude: float eps}
@@ -217,7 +219,7 @@ class BaseHermitePoisson1D(ADEPTModule):
         if pert:
             mode = int(pert["mode"])
             eps = float(pert["amplitude"])
-            half = 0.5 * eps * n0_e / (alpha_e ** 3)
+            half = 0.5 * eps * n0_e / (alpha_e**3)
             Ck_e = Ck_e.at[0, mode].set(half)
             Ck_e = Ck_e.at[0, -mode].set(half)
 
@@ -228,6 +230,7 @@ class BaseHermitePoisson1D(ADEPTModule):
             "prev_a": jnp.zeros(Nx + 2),
             "e": jnp.zeros(Nx),
             "da": jnp.zeros(Nx + 2),
+            "de": jnp.zeros(Nx),
         }
         self.args = {}
 
@@ -273,7 +276,7 @@ class BaseHermitePoisson1D(ADEPTModule):
             Ck_i = self.state["Ck_ions"].view(jnp.complex128)
             n0_i = float(physics.get("n0_i", 1.0))
             # Build ion density profile from initial Ck_i
-            n_i_prof = (alpha_i ** 3) * jnp.fft.ifft(Ck_i[0], norm="forward").real
+            n_i_prof = (alpha_i**3) * jnp.fft.ifft(Ck_i[0], norm="forward").real
             static_ion_density = n_i_prof
         else:
             static_ion_density = None
@@ -315,10 +318,12 @@ class BaseHermitePoisson1D(ADEPTModule):
 
         free_stream_e = FreeStreamingExp1D(Nn_e, alpha_e, u_e, Lx, kx_1d)
         free_stream_i = FreeStreamingExp1D(Nn_i, alpha_i, u_i, Lx, kx_1d)
-        diag_e = DiagonalExp1D(nu=nu, col_1d=col_e, D=D, kx_sq_1d=kx_sq,
-                               hou_li_strength=hl_strength, hou_li_col_1d=hou_li_col_e)
-        diag_i = DiagonalExp1D(nu=nu, col_1d=col_i, D=D, kx_sq_1d=kx_sq,
-                               hou_li_strength=hl_strength, hou_li_col_1d=hou_li_col_i)
+        diag_e = DiagonalExp1D(
+            nu=nu, col_1d=col_e, D=D, kx_sq_1d=kx_sq, hou_li_strength=hl_strength, hou_li_col_1d=hou_li_col_e
+        )
+        diag_i = DiagonalExp1D(
+            nu=nu, col_1d=col_i, D=D, kx_sq_1d=kx_sq, hou_li_strength=hl_strength, hou_li_col_1d=hou_li_col_i
+        )
         linear_e = LinearExp1D(free_stream_e, diag_e)
         linear_i = LinearExp1D(free_stream_i, diag_i)
         combined_exp = CombinedLinearExp1D(linear_e, linear_i, static_ions=static_ions)
@@ -335,7 +340,7 @@ class BaseHermitePoisson1D(ADEPTModule):
             noise_amplitude = float(sn_cfg["amplitude"])
             noise_seed = int(sn_cfg.get("seed", 0))
             Ck_e0 = self.state["Ck_electrons"].view(jnp.complex128)
-            n_e_prof = (alpha_e ** 3) * jnp.fft.ifft(Ck_e0[0], norm="forward").real
+            n_e_prof = (alpha_e**3) * jnp.fft.ifft(Ck_e0[0], norm="forward").real
             noise_spatial_profile = n_e_prof / jnp.max(n_e_prof)
         else:
             noise_amplitude = 0.0
@@ -357,12 +362,18 @@ class BaseHermitePoisson1D(ADEPTModule):
         ey_cfg = self.cfg.get("drivers", {}).get("ey", {})
         ey_driver = TransverseWaveDriver(x_a, ey_cfg)
 
+        # Longitudinal (Ex) field driver — prescribed Ex added to the velocity-space
+        # force, on the interior x grid (no ghost cells).
+        ex_cfg = self.cfg.get("drivers", {}).get("ex", {})
+        ex_driver = LongitudinalElectricFieldDriver(grid["x"], ex_cfg)
+
         # Assemble top-level vector field (discrete-map via Stepper)
         vector_field = HermitePoisson1DVectorField(
             combined_exp=combined_exp,
             poisson=poisson,
             wave_solver=wave_solver,
             ey_driver=ey_driver,
+            ex_driver=ex_driver,
             sqrt_n_minus_e=sqrt_n_minus_e,
             sqrt_n_minus_i=sqrt_n_minus_i,
             alpha_e=alpha_e,
@@ -496,9 +507,13 @@ class BaseHermitePoisson1D(ADEPTModule):
                             arr_plot = np.where(np.isfinite(arr), arr, np.nan)
                             fig, axes = plt.subplots(1, 2, figsize=(10, 4), tight_layout=True)
                             axes[0].plot(t_arr_def, arr_plot)
-                            axes[0].set_xlabel("t"); axes[0].set_ylabel(name); axes[0].grid(alpha=0.3)
+                            axes[0].set_xlabel("t")
+                            axes[0].set_ylabel(name)
+                            axes[0].grid(alpha=0.3)
                             axes[1].semilogy(t_arr_def, np.abs(arr_plot) + 1e-30)
-                            axes[1].set_xlabel("t"); axes[1].set_ylabel(f"|{name}|"); axes[1].grid(alpha=0.3)
+                            axes[1].set_xlabel("t")
+                            axes[1].set_ylabel(f"|{name}|")
+                            axes[1].grid(alpha=0.3)
                             fig.savefig(os.path.join(plots_dir, f"scalar-{name}.png"), bbox_inches="tight")
                         except Exception as e:
                             print(f"post_process: scalar plot for {name} failed: {e}")

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -283,16 +283,31 @@ class BaseHermitePoisson1D(ADEPTModule):
         u_i = 0.0
         D = float(physics.get("D", 0.0))
 
-        # Hou-Li filter: exp(-strength * (n/Nn)^order * s) per Lawson substep.
-        # Read from drivers.hermite_filter (same key used by kinetic_srs subclass).
+        # Hermite-mode absorber applied as exp(-strength * col(n) * s) per Lawson
+        # substep. Read from drivers.hermite_filter (same key used by the
+        # kinetic_srs subclass). Two profiles:
+        #   profile="houli" (default): col = (n/Nn)^order — truncation-edge filter.
+        #   profile="knee":            col = 0.5*(1+tanh((n - n_knee)/width)) —
+        #     a scale-selective absolute-n step: ~0 below n_knee, ~1 above. Unlike
+        #     (n/Nn)^order it can separate the resonant EPW mode (n~vphi^2/2) from
+        #     the filamentation cascade just above it, which sit at nearby n/Nn
+        #     when Nn is large. Pair with a low Lenard-Bernstein nu so the
+        #     resonance is preserved while the n>n_knee cascade is damped.
         hl_cfg = self.cfg.get("drivers", {}).get("hermite_filter", {})
         if hl_cfg and hl_cfg.get("enabled", True):
             hl_strength = float(hl_cfg.get("strength", 0.0))
-            hl_order = float(hl_cfg.get("order", 8))
-            n_e_norm = jnp.arange(Nn_e, dtype=jnp.float64) / max(Nn_e - 1, 1)
-            n_i_norm = jnp.arange(Nn_i, dtype=jnp.float64) / max(Nn_i - 1, 1)
-            hou_li_col_e = n_e_norm ** hl_order
-            hou_li_col_i = n_i_norm ** hl_order
+            profile = str(hl_cfg.get("profile", "houli"))
+            n_e = jnp.arange(Nn_e, dtype=jnp.float64)
+            n_i = jnp.arange(Nn_i, dtype=jnp.float64)
+            if profile == "knee":
+                n_knee = float(hl_cfg.get("n_knee", 45.0))
+                width = float(hl_cfg.get("width", 8.0))
+                hou_li_col_e = 0.5 * (1.0 + jnp.tanh((n_e - n_knee) / width))
+                hou_li_col_i = 0.5 * (1.0 + jnp.tanh((n_i - n_knee) / width))
+            else:
+                hl_order = float(hl_cfg.get("order", 8))
+                hou_li_col_e = (n_e / max(Nn_e - 1, 1)) ** hl_order
+                hou_li_col_i = (n_i / max(Nn_i - 1, 1)) ** hl_order
         else:
             hl_strength = 0.0
             hou_li_col_e = None

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -398,17 +398,25 @@ class BaseHermitePoisson1D(ADEPTModule):
                 ds = store_fields_timeseries(self.cfg, fields_dict, t_arr, binary_dir, x)
                 datasets["fields"] = ds
 
-                # Spacetime plots
+                # Spacetime plots. Sanitize inf -> nan (matplotlib masks nan but
+                # its log tickers crash on inf) and never let a plotting failure
+                # take down the netCDF/metric upload for a blown-up run — those
+                # are exactly the runs whose diagnostics we need most.
                 for field_name, arr in fields_dict.items():
                     if arr.ndim == 2:
-                        fig, ax = plt.subplots(figsize=(9, 5), tight_layout=True)
-                        im = ax.pcolormesh(x, t_arr, arr, shading="auto", cmap="RdBu_r")
-                        plt.colorbar(im, ax=ax)
-                        ax.set_xlabel("x [norm]")
-                        ax.set_ylabel("t [norm]")
-                        ax.set_title(field_name)
-                        fig.savefig(os.path.join(plots_dir, f"spacetime-{field_name}.png"), bbox_inches="tight")
-                        plt.close(fig)
+                        try:
+                            arr_plot = np.where(np.isfinite(arr), arr, np.nan)
+                            fig, ax = plt.subplots(figsize=(9, 5), tight_layout=True)
+                            im = ax.pcolormesh(x, t_arr, arr_plot, shading="auto", cmap="RdBu_r")
+                            plt.colorbar(im, ax=ax)
+                            ax.set_xlabel("x [norm]")
+                            ax.set_ylabel("t [norm]")
+                            ax.set_title(field_name)
+                            fig.savefig(os.path.join(plots_dir, f"spacetime-{field_name}.png"), bbox_inches="tight")
+                        except Exception as e:
+                            print(f"post_process: spacetime plot for {field_name} failed: {e}")
+                        finally:
+                            plt.close("all")
 
             elif k in ("hermite", "distribution"):
                 for species, ck_arr in data.items():
@@ -422,14 +430,20 @@ class BaseHermitePoisson1D(ADEPTModule):
 
                 for name, arr in scalars.items():
                     if arr.ndim == 1:
-                        metrics[f"final_{name}"] = float(arr[-1])
-                        fig, axes = plt.subplots(1, 2, figsize=(10, 4), tight_layout=True)
-                        axes[0].plot(t_arr_def, arr)
-                        axes[0].set_xlabel("t"); axes[0].set_ylabel(name); axes[0].grid(alpha=0.3)
-                        axes[1].semilogy(t_arr_def, np.abs(arr) + 1e-30)
-                        axes[1].set_xlabel("t"); axes[1].set_ylabel(f"|{name}|"); axes[1].grid(alpha=0.3)
-                        fig.savefig(os.path.join(plots_dir, f"scalar-{name}.png"), bbox_inches="tight")
-                        plt.close(fig)
+                        final_val = float(arr[-1])
+                        metrics[f"final_{name}"] = final_val if np.isfinite(final_val) else float("nan")
+                        try:
+                            arr_plot = np.where(np.isfinite(arr), arr, np.nan)
+                            fig, axes = plt.subplots(1, 2, figsize=(10, 4), tight_layout=True)
+                            axes[0].plot(t_arr_def, arr_plot)
+                            axes[0].set_xlabel("t"); axes[0].set_ylabel(name); axes[0].grid(alpha=0.3)
+                            axes[1].semilogy(t_arr_def, np.abs(arr_plot) + 1e-30)
+                            axes[1].set_xlabel("t"); axes[1].set_ylabel(f"|{name}|"); axes[1].grid(alpha=0.3)
+                            fig.savefig(os.path.join(plots_dir, f"scalar-{name}.png"), bbox_inches="tight")
+                        except Exception as e:
+                            print(f"post_process: scalar plot for {name} failed: {e}")
+                        finally:
+                            plt.close("all")
 
         if "default" in sol.ts:
             metrics["n_timesteps"] = len(sol.ts["default"])

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -51,6 +51,27 @@ def _safe_col_1d(Nn: int) -> jnp.ndarray:
     return jnp.where(Nn > 3, term / denom, jnp.zeros(Nn, dtype=jnp.float64))
 
 
+def _collision_profile(Nn: int, model: str) -> jnp.ndarray:
+    """Per-mode collision profile col[n]; damping applied as exp(-nu*col[n]*dt).
+
+    "hypercollision" (default): cubic n(n-1)(n-2), normalized to 1 at n=Nn-1 —
+        negligible below n ~ 0.7*Nn; a truncation-edge absorber only.
+    "lenard-bernstein": col[n] = n for n >= 3, zero for n = 0, 1, 2 —
+        the LB spectrum (Hermite functions are LB eigenfunctions with
+        eigenvalue -nu*n) with the standard conserving truncation: damping
+        is gated off the first three moments so the operator conserves
+        density, momentum, and energy exactly (cf. Parker & Dellar 2015).
+        Acts smoothly at all kinetic scales including the Landau-resonance
+        band without imposing drag on the EPW's fluid content.
+    """
+    if model == "lenard-bernstein":
+        n = jnp.arange(Nn, dtype=jnp.float64)
+        return jnp.where(n >= 3, n, 0.0)
+    if model == "hypercollision":
+        return _safe_col_1d(Nn)
+    raise ValueError(f"Unknown physics.collision_model {model!r}; use 'hypercollision' or 'lenard-bernstein'")
+
+
 class BaseHermitePoisson1D(ADEPTModule):
     """1D Hermite-Poisson base solver in skin-depth units."""
 
@@ -141,9 +162,10 @@ class BaseHermitePoisson1D(ADEPTModule):
         sqrt_n_minus_e = jnp.sqrt(jnp.arange(Nn_e, dtype=jnp.float64))
         sqrt_n_minus_i = jnp.sqrt(jnp.arange(Nn_i, dtype=jnp.float64))
 
-        # Collision vectors (hypercollisional)
-        col_e = _safe_col_1d(Nn_e)
-        col_i = _safe_col_1d(Nn_i)
+        # Collision vectors (model selected by physics.collision_model)
+        collision_model = str(physics.get("collision_model", "hypercollision"))
+        col_e = _collision_profile(Nn_e, collision_model)
+        col_i = _collision_profile(Nn_i, collision_model)
 
         # Real-space x-axis (no ghost cells)
         x = jnp.linspace(0.0, Lx, Nx, endpoint=False)

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -1,0 +1,409 @@
+"""Base ADEPTModule for the 1D Hermite-Poisson solver.
+
+Normalization: skin-depth units (x0 = c/wp0, t0 = 1/wp0, v0 = c).
+  - alpha_e = vth_e / c,  alpha_i = vth_i / c
+  - c_light = 1.0  (speed of light normalized to 1)
+
+State dict:
+  Ck_electrons: (Nn_e, Nx) complex, stored as float64 view
+  Ck_ions:      (Nn_i, Nx) complex, stored as float64 view
+  a:            (Nx+2,)  vector potential with ghost cells
+  prev_a:       (Nx+2,)  previous-step a
+  e:            (Nx,)    electrostatic field (diagnostics)
+  da:           (Nx+2,)  last wave-equation source term
+
+Config keys expected in cfg["physics"]:
+  alpha_e (float), alpha_i (float), mi_me (float), Lx (float),
+  nu (float), Omega_ce_tau (float), static_ions (bool),
+  n0_e (float, default 1.0), n0_i (float, default 1.0), c_light (float, default 1.0)
+
+Config keys expected in cfg["grid"]:
+  Nn (int, electron Hermite modes), Ni (int, ion Hermite modes, default 2),
+  Nx (int, optional — computed from Lx if missing), tmax (float), dt (float, optional)
+"""
+
+import os
+import sys
+
+import numpy as np
+from diffrax import ConstantStepSize, NoProgressMeter, ODETerm, SaveAt, SubSaveAt, TqdmProgressMeter, diffeqsolve
+from jax import numpy as jnp
+
+from adept._base_ import ADEPTModule, Stepper
+from adept._hermite_poisson_1d.storage import get_save_quantities, store_ck_timeseries, store_fields_timeseries
+from adept._hermite_poisson_1d.vector_field import (
+    CombinedLinearExp1D,
+    DiagonalExp1D,
+    FreeStreamingExp1D,
+    HermitePoisson1DVectorField,
+    LinearExp1D,
+    PoissonSolver1D,
+    TransverseWaveDriver,
+)
+from adept._vlasov1d.solvers.pushers.field import WaveSolver
+
+
+def _safe_col_1d(Nn: int) -> jnp.ndarray:
+    """Hypercollisional damping vector: col[n] = n*(n-1)*(n-2) / ((Nn-1)(Nn-2)(Nn-3))."""
+    n = jnp.arange(Nn, dtype=jnp.float64)
+    term = n * (n - 1) * (n - 2)
+    denom = (Nn - 1) * (Nn - 2) * (Nn - 3) if Nn > 3 else 1.0
+    return jnp.where(Nn > 3, term / denom, jnp.zeros(Nn, dtype=jnp.float64))
+
+
+class BaseHermitePoisson1D(ADEPTModule):
+    """1D Hermite-Poisson base solver in skin-depth units."""
+
+    def __init__(self, cfg: dict) -> None:
+        super().__init__(cfg)
+
+    # ------------------------------------------------------------------
+    # Lifecycle: write_units
+    # ------------------------------------------------------------------
+
+    def write_units(self) -> dict:
+        """Return normalization constants already present in cfg["units"]["derived"]."""
+        return self.cfg.get("units", {}).get("derived", {})
+
+    # ------------------------------------------------------------------
+    # Lifecycle: get_derived_quantities
+    # ------------------------------------------------------------------
+
+    def get_derived_quantities(self) -> None:
+        """Compute dt, nt, max_steps from wave-CFL or user dt."""
+        physics = self.cfg["physics"]
+        grid = self.cfg["grid"]
+
+        Lx = float(physics["Lx"])
+        c_light = float(physics.get("c_light", 1.0))
+
+        # Grid resolution
+        if "Nx" not in grid or grid["Nx"] is None:
+            # Default: ~1 spatial cell per unit length, minimum 32
+            Nx = max(32, int(np.ceil(Lx)))
+            grid["Nx"] = Nx
+        Nx = int(grid["Nx"])
+        dx = Lx / Nx
+        grid["dx"] = dx
+
+        tmax = float(grid["tmax"])
+
+        # Timestep: limited by wave CFL if c_light > 0
+        dt_cfl = 0.9 * dx / c_light if c_light > 0 else float("inf")
+        user_dt = grid.get("dt", None)
+        if isinstance(user_dt, (int, float)) and user_dt > 0:
+            dt = float(user_dt)
+        else:
+            dt = dt_cfl
+        grid["dt"] = dt
+
+        nt = int(tmax / dt) + 1
+        grid["nt"] = nt
+        grid["tmax"] = dt * nt  # snap tmax to exact multiple
+        grid["max_steps"] = nt + 4
+
+        # Populate save t defaults
+        for save_cfg in self.cfg.get("save", {}).values():
+            if isinstance(save_cfg, dict) and "t" in save_cfg:
+                t_cfg = save_cfg["t"]
+                t_cfg.setdefault("tmin", 0.0)
+                t_cfg.setdefault("tmax", grid["tmax"])
+
+        self.cfg["grid"] = grid
+
+    # ------------------------------------------------------------------
+    # Lifecycle: get_solver_quantities
+    # ------------------------------------------------------------------
+
+    def get_solver_quantities(self) -> None:
+        """Build k-space arrays, collision matrices, and sponge profiles."""
+        physics = self.cfg["physics"]
+        grid = self.cfg["grid"]
+
+        Lx = float(physics["Lx"])
+        Nx = int(grid["Nx"])
+        dx = float(grid["dx"])
+
+        alpha_e = float(physics["alpha_e"])
+        alpha_i = float(physics["alpha_i"])
+
+        Nn_e = int(grid.get("Nn", 128))
+        Nn_i = int(grid.get("Ni", 2))
+
+        # Wavenumber arrays (physical units: 1/(c/wp0))
+        kx_1d = jnp.fft.fftfreq(Nx) * Nx * 2 * jnp.pi / Lx  # shape (Nx,)
+        one_over_kx = np.zeros(Nx, dtype=np.float64)
+        one_over_kx[1:] = 1.0 / np.asarray(kx_1d[1:])
+        one_over_kx = jnp.array(one_over_kx)
+        kx_sq = kx_1d ** 2
+
+        # Ladder operators
+        sqrt_n_minus_e = jnp.sqrt(jnp.arange(Nn_e, dtype=jnp.float64))
+        sqrt_n_minus_i = jnp.sqrt(jnp.arange(Nn_i, dtype=jnp.float64))
+
+        # Collision vectors (hypercollisional)
+        col_e = _safe_col_1d(Nn_e)
+        col_i = _safe_col_1d(Nn_i)
+
+        # Real-space x-axis (no ghost cells)
+        x = jnp.linspace(0.0, Lx, Nx, endpoint=False)
+        # Extended x with ghost cells for wave solver
+        x_a = jnp.concatenate([jnp.array([x[0] - dx]), x, jnp.array([x[-1] + dx])])
+
+        grid["kx_1d"] = kx_1d
+        grid["one_over_kx"] = one_over_kx
+        grid["kx_sq"] = kx_sq
+        grid["sqrt_n_minus_e"] = sqrt_n_minus_e
+        grid["sqrt_n_minus_i"] = sqrt_n_minus_i
+        grid["col_e"] = col_e
+        grid["col_i"] = col_i
+        grid["x"] = x
+        grid["x_a"] = x_a
+        grid["Nn_e"] = Nn_e
+        grid["Nn_i"] = Nn_i
+
+        self.cfg["grid"] = grid
+
+    # ------------------------------------------------------------------
+    # Lifecycle: init_state_and_args
+    # ------------------------------------------------------------------
+
+    def init_state_and_args(self) -> None:
+        """Initialize state dict and args."""
+        physics = self.cfg["physics"]
+        grid = self.cfg["grid"]
+
+        alpha_e = float(physics["alpha_e"])
+        alpha_i = float(physics["alpha_i"])
+        Nn_e = int(grid["Nn_e"])
+        Nn_i = int(grid["Nn_i"])
+        Nx = int(grid["Nx"])
+        n0_e = float(physics.get("n0_e", 1.0))
+        n0_i = float(physics.get("n0_i", 1.0))
+
+        # Initialize Hermite coefficient arrays
+        # C_0(kx) = FFT(n(x) / alpha^3); equilibrium: n(x) = n0 → C_0(kx=0) = n0/alpha^3
+        Ck_e = jnp.zeros((Nn_e, Nx), dtype=jnp.complex128)
+        Ck_i = jnp.zeros((Nn_i, Nx), dtype=jnp.complex128)
+        Ck_e = Ck_e.at[0, 0].set(n0_e / (alpha_e ** 3))
+        Ck_i = Ck_i.at[0, 0].set(n0_i / (alpha_i ** 3))
+
+        self.state = {
+            "Ck_electrons": Ck_e.view(jnp.float64),
+            "Ck_ions": Ck_i.view(jnp.float64),
+            "a": jnp.zeros(Nx + 2),
+            "prev_a": jnp.zeros(Nx + 2),
+            "e": jnp.zeros(Nx),
+            "da": jnp.zeros(Nx + 2),
+        }
+        self.args = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle: init_diffeqsolve
+    # ------------------------------------------------------------------
+
+    def init_diffeqsolve(self) -> None:
+        """Assemble the HermitePoisson1DVectorField and configure diffeqsolve."""
+        physics = self.cfg["physics"]
+        grid = self.cfg["grid"]
+
+        alpha_e = float(physics["alpha_e"])
+        alpha_i = float(physics["alpha_i"])
+        mi_me = float(physics.get("mi_me", 1836.0))
+        nu = float(physics.get("nu", 0.0))
+        Omega_ce_tau = float(physics.get("Omega_ce_tau", 1.0))
+        c_light = float(physics.get("c_light", 1.0))
+        static_ions = bool(physics.get("static_ions", False))
+        Lx = float(physics["Lx"])
+
+        Nn_e = int(grid["Nn_e"])
+        Nn_i = int(grid["Nn_i"])
+        Nx = int(grid["Nx"])
+        dx = float(grid["dx"])
+        dt = float(grid["dt"])
+
+        kx_1d = grid["kx_1d"]
+        one_over_kx = grid["one_over_kx"]
+        kx_sq = grid["kx_sq"]
+        sqrt_n_minus_e = grid["sqrt_n_minus_e"]
+        sqrt_n_minus_i = grid["sqrt_n_minus_i"]
+        col_e = grid["col_e"]
+        col_i = grid["col_i"]
+        x_a = grid["x_a"]
+
+        # Sponge profiles (optional)
+        sponge_plasma = grid.get("sponge_plasma", None)
+        sponge_fields = grid.get("sponge_fields", None)
+
+        # Static ion density (for Poisson when static_ions=True)
+        if static_ions:
+            Ck_i = self.state["Ck_ions"].view(jnp.complex128)
+            n0_i = float(physics.get("n0_i", 1.0))
+            # Build ion density profile from initial Ck_i
+            n_i_prof = (alpha_i ** 3) * jnp.fft.ifft(Ck_i[0], norm="forward").real
+            static_ion_density = n_i_prof
+        else:
+            static_ion_density = None
+
+        # Build per-species linear exponential operators
+        u_e = 0.0  # no drift in base class
+        u_i = 0.0
+        D = float(physics.get("D", 0.0))
+
+        free_stream_e = FreeStreamingExp1D(Nn_e, alpha_e, u_e, Lx, kx_1d)
+        free_stream_i = FreeStreamingExp1D(Nn_i, alpha_i, u_i, Lx, kx_1d)
+        diag_e = DiagonalExp1D(nu=nu, col_1d=col_e, D=D, kx_sq_1d=kx_sq)
+        diag_i = DiagonalExp1D(nu=nu, col_1d=col_i, D=D, kx_sq_1d=kx_sq)
+        linear_e = LinearExp1D(free_stream_e, diag_e)
+        linear_i = LinearExp1D(free_stream_i, diag_i)
+        combined_exp = CombinedLinearExp1D(linear_e, linear_i, static_ions=static_ions)
+
+        # Poisson solver
+        poisson = PoissonSolver1D(
+            one_over_kx=one_over_kx,
+            alpha_e=alpha_e,
+            alpha_i=alpha_i,
+            static_ion_density=static_ion_density,
+        )
+
+        # Wave solver (c_light > 0 → EM waves; = 0 → frozen a)
+        wave_solver = WaveSolver(c=c_light, dx=dx, dt=dt)
+
+        # Transverse wave source driver
+        ey_cfg = self.cfg.get("drivers", {}).get("ey", {})
+        ey_driver = TransverseWaveDriver(x_a, ey_cfg)
+
+        # Assemble top-level vector field (discrete-map via Stepper)
+        vector_field = HermitePoisson1DVectorField(
+            combined_exp=combined_exp,
+            poisson=poisson,
+            wave_solver=wave_solver,
+            ey_driver=ey_driver,
+            sqrt_n_minus_e=sqrt_n_minus_e,
+            sqrt_n_minus_i=sqrt_n_minus_i,
+            alpha_e=alpha_e,
+            alpha_i=alpha_i,
+            q_e=-1.0,
+            q_i=1.0,
+            mi_me=mi_me,
+            Omega_ce_tau=Omega_ce_tau,
+            dx=dx,
+            dt=dt,
+            static_ions=static_ions,
+            sponge_plasma=sponge_plasma,
+            sponge_fields=sponge_fields,
+        )
+
+        # Configure save quantities
+        self.cfg = get_save_quantities(self.cfg)
+
+        tmax = float(grid["tmax"])
+        max_steps = int(grid["max_steps"])
+
+        subsaves = {}
+        for k, v in self.cfg["save"].items():
+            if isinstance(v, dict) and "t" in v and "func" in v:
+                subsaves[k] = SubSaveAt(ts=v["t"]["ax"], fn=v["func"])
+
+        self.time_quantities = {"t0": 0.0, "t1": tmax, "max_steps": max_steps}
+        self.diffeqsolve_quants = {
+            "terms": ODETerm(vector_field),
+            "solver": Stepper(),
+            "saveat": {"subs": subsaves},
+        }
+
+    # ------------------------------------------------------------------
+    # Lifecycle: __call__
+    # ------------------------------------------------------------------
+
+    def __call__(self, trainable_modules: dict, args: dict | None = None) -> dict:
+        if args is None:
+            args = self.args
+        grid = self.cfg["grid"]
+
+        sol = diffeqsolve(
+            terms=self.diffeqsolve_quants["terms"],
+            solver=self.diffeqsolve_quants["solver"],
+            stepsize_controller=ConstantStepSize(),
+            t0=self.time_quantities["t0"],
+            t1=self.time_quantities["t1"],
+            dt0=float(grid["dt"]),
+            y0=self.state,
+            args=args,
+            saveat=SaveAt(**self.diffeqsolve_quants["saveat"]),
+            max_steps=self.time_quantities["max_steps"],
+            progress_meter=TqdmProgressMeter() if sys.stdout.isatty() else NoProgressMeter(),
+        )
+        return {"solver result": sol}
+
+    # ------------------------------------------------------------------
+    # Lifecycle: post_process
+    # ------------------------------------------------------------------
+
+    def post_process(self, run_output: dict, td: str) -> dict:
+        """Save outputs to netCDF and produce basic spacetime plots."""
+        import matplotlib.pyplot as plt
+
+        sol = run_output["solver result"]
+        binary_dir = os.path.join(td, "binary")
+        plots_dir = os.path.join(td, "plots")
+        os.makedirs(binary_dir, exist_ok=True)
+        os.makedirs(plots_dir, exist_ok=True)
+
+        grid = self.cfg["grid"]
+        x = np.asarray(grid["x"])
+
+        datasets = {}
+        metrics = {"simulation_completed": True}
+
+        if hasattr(sol, "stats") and sol.stats is not None:
+            for stat_key in ("num_steps", "num_accepted_steps", "num_rejected_steps"):
+                if stat_key in sol.stats:
+                    metrics[stat_key] = int(sol.stats[stat_key])
+
+        for k in sol.ys.keys():
+            t_arr = np.asarray(sol.ts[k])
+            data = sol.ys[k]
+
+            if k == "fields":
+                fields_dict = {name: np.asarray(arr) for name, arr in data.items()}
+                ds = store_fields_timeseries(self.cfg, fields_dict, t_arr, binary_dir, x)
+                datasets["fields"] = ds
+
+                # Spacetime plots
+                for field_name, arr in fields_dict.items():
+                    if arr.ndim == 2:
+                        fig, ax = plt.subplots(figsize=(9, 5), tight_layout=True)
+                        im = ax.pcolormesh(x, t_arr, arr, shading="auto", cmap="RdBu_r")
+                        plt.colorbar(im, ax=ax)
+                        ax.set_xlabel("x [norm]")
+                        ax.set_ylabel("t [norm]")
+                        ax.set_title(field_name)
+                        fig.savefig(os.path.join(plots_dir, f"spacetime-{field_name}.png"), bbox_inches="tight")
+                        plt.close(fig)
+
+            elif k in ("hermite", "distribution"):
+                for species, ck_arr in data.items():
+                    Ck = np.asarray(ck_arr)
+                    ds = store_ck_timeseries(self.cfg, species, Ck, t_arr, binary_dir)
+                    datasets[f"hermite_{species}"] = ds
+
+            elif k == "default":
+                scalars = {name: np.asarray(arr) for name, arr in data.items()}
+                t_arr_def = t_arr
+
+                for name, arr in scalars.items():
+                    if arr.ndim == 1:
+                        metrics[f"final_{name}"] = float(arr[-1])
+                        fig, axes = plt.subplots(1, 2, figsize=(10, 4), tight_layout=True)
+                        axes[0].plot(t_arr_def, arr)
+                        axes[0].set_xlabel("t"); axes[0].set_ylabel(name); axes[0].grid(alpha=0.3)
+                        axes[1].semilogy(t_arr_def, np.abs(arr) + 1e-30)
+                        axes[1].set_xlabel("t"); axes[1].set_ylabel(f"|{name}|"); axes[1].grid(alpha=0.3)
+                        fig.savefig(os.path.join(plots_dir, f"scalar-{name}.png"), bbox_inches="tight")
+                        plt.close(fig)
+
+        if "default" in sol.ts:
+            metrics["n_timesteps"] = len(sol.ts["default"])
+
+        return {"metrics": metrics, "datasets": datasets}

--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -250,10 +250,27 @@ class BaseHermitePoisson1D(ADEPTModule):
         u_i = 0.0
         D = float(physics.get("D", 0.0))
 
+        # Hou-Li filter: exp(-strength * (n/Nn)^order * s) per Lawson substep.
+        # Read from drivers.hermite_filter (same key used by kinetic_srs subclass).
+        hl_cfg = self.cfg.get("drivers", {}).get("hermite_filter", {})
+        if hl_cfg and hl_cfg.get("enabled", True):
+            hl_strength = float(hl_cfg.get("strength", 0.0))
+            hl_order = float(hl_cfg.get("order", 8))
+            n_e_norm = jnp.arange(Nn_e, dtype=jnp.float64) / max(Nn_e - 1, 1)
+            n_i_norm = jnp.arange(Nn_i, dtype=jnp.float64) / max(Nn_i - 1, 1)
+            hou_li_col_e = n_e_norm ** hl_order
+            hou_li_col_i = n_i_norm ** hl_order
+        else:
+            hl_strength = 0.0
+            hou_li_col_e = None
+            hou_li_col_i = None
+
         free_stream_e = FreeStreamingExp1D(Nn_e, alpha_e, u_e, Lx, kx_1d)
         free_stream_i = FreeStreamingExp1D(Nn_i, alpha_i, u_i, Lx, kx_1d)
-        diag_e = DiagonalExp1D(nu=nu, col_1d=col_e, D=D, kx_sq_1d=kx_sq)
-        diag_i = DiagonalExp1D(nu=nu, col_1d=col_i, D=D, kx_sq_1d=kx_sq)
+        diag_e = DiagonalExp1D(nu=nu, col_1d=col_e, D=D, kx_sq_1d=kx_sq,
+                               hou_li_strength=hl_strength, hou_li_col_1d=hou_li_col_e)
+        diag_i = DiagonalExp1D(nu=nu, col_1d=col_i, D=D, kx_sq_1d=kx_sq,
+                               hou_li_strength=hl_strength, hou_li_col_1d=hou_li_col_i)
         linear_e = LinearExp1D(free_stream_e, diag_e)
         linear_i = LinearExp1D(free_stream_i, diag_i)
         combined_exp = CombinedLinearExp1D(linear_e, linear_i, static_ions=static_ions)

--- a/adept/_hermite_poisson_1d/storage.py
+++ b/adept/_hermite_poisson_1d/storage.py
@@ -1,0 +1,169 @@
+"""
+Storage / save functions for the 1D Hermite-Poisson module.
+
+State keys: Ck_electrons (Nn_e, Nx) complex viewed as float64,
+            Ck_ions (Nn_i, Nx) complex viewed as float64,
+            a (Nx+2,), prev_a (Nx+2,), e (Nx,), da (Nx+2,).
+
+Supported cfg["save"] keys:
+  "fields"  → {e, a, da} spacetime arrays
+  "hermite" → {electrons, ions} Hermite-Fourier coefficient timeseries
+  "default" → scalar energy diagnostics (always added automatically)
+"""
+
+import os
+
+import numpy as np
+import xarray as xr
+from jax import numpy as jnp
+
+
+# ---------------------------------------------------------------------------
+# Save functions (called by diffrax SubSaveAt at specified timesteps)
+# ---------------------------------------------------------------------------
+
+
+def get_fields_save_func():
+    """Save electrostatic field e and vector potential a interior."""
+
+    def fields_save_func(t, y, args):
+        return {
+            "e": y["e"],
+            "a": y["a"][1:-1],
+            "da": y["da"][1:-1],
+        }
+
+    return fields_save_func
+
+
+def get_hermite_save_func():
+    """Save Hermite-Fourier coefficients for both species."""
+
+    def hermite_save_func(t, y, args):
+        return {
+            "electrons": y["Ck_electrons"].view(jnp.complex128),
+            "ions": y["Ck_ions"].view(jnp.complex128),
+        }
+
+    return hermite_save_func
+
+
+def get_default_save_func(alpha_e: float, alpha_i: float):
+    """Save scalar diagnostics: field energies and density extrema."""
+    alpha_e = float(alpha_e)
+    alpha_i = float(alpha_i)
+
+    def default_save_func(t, y, args):
+        Ck_e = y["Ck_electrons"].view(jnp.complex128)
+        Ck_i = y["Ck_ions"].view(jnp.complex128)
+        n_e = (alpha_e ** 3) * jnp.fft.ifft(Ck_e[0], norm="forward").real
+        n_i = (alpha_i ** 3) * jnp.fft.ifft(Ck_i[0], norm="forward").real
+        e = y["e"]
+        a = y["a"][1:-1]
+        return {
+            "e_energy": jnp.sum(e ** 2),
+            "a_energy": jnp.sum(a ** 2),
+            "n_e_max": jnp.max(n_e),
+            "n_e_min": jnp.min(n_e),
+            "n_i_max": jnp.max(n_i),
+            "Ck_e_max": jnp.max(jnp.abs(Ck_e)),
+        }
+
+    return default_save_func
+
+
+# ---------------------------------------------------------------------------
+# Configure save axes and attach save functions
+# ---------------------------------------------------------------------------
+
+
+def get_save_quantities(cfg: dict) -> dict:
+    """Attach save axes and save functions to cfg["save"].
+
+    Called by BaseHermitePoisson1D.init_diffeqsolve() before building
+    SubSaveAt objects. Modifies cfg in-place and returns it.
+
+    Supported save keys: "fields", "hermite", "default".
+    All others are passed through unchanged.
+    """
+    grid = cfg["grid"]
+    physics = cfg.get("physics", {})
+
+    tmax = float(grid["tmax"])
+    nt = int(grid["nt"])
+    alpha_e = float(physics.get("alpha_e", physics.get("alpha_s", [0.05])[0]))
+    alpha_i = float(physics.get("alpha_i", physics.get("alpha_s", [0.05, 0.05, 0.05, 0.001])[3]
+                                if len(physics.get("alpha_s", [])) > 3 else 0.001))
+
+    for save_key, save_cfg in cfg.get("save", {}).items():
+        if not isinstance(save_cfg, dict):
+            continue
+        # Build time axis from t sub-dict
+        if "t" in save_cfg and isinstance(save_cfg["t"], dict):
+            t_cfg = save_cfg["t"]
+            if "ax" not in t_cfg:
+                t_cfg["ax"] = np.linspace(
+                    float(t_cfg.get("tmin", 0.0)),
+                    float(t_cfg.get("tmax", tmax)),
+                    int(t_cfg.get("nt", nt)),
+                )
+
+        if "func" in save_cfg:
+            continue  # already set by caller (e.g. probe diagnostics)
+
+        if save_key == "fields":
+            save_cfg["func"] = get_fields_save_func()
+        elif save_key in ("hermite", "distribution"):
+            save_cfg["func"] = get_hermite_save_func()
+
+    # Always ensure a "default" scalar-diagnostics save
+    if "save" not in cfg:
+        cfg["save"] = {}
+    if "default" not in cfg["save"]:
+        cfg["save"]["default"] = {"t": {"ax": np.linspace(0.0, tmax, nt)}}
+    elif "t" not in cfg["save"]["default"]:
+        cfg["save"]["default"]["t"] = {"ax": np.linspace(0.0, tmax, nt)}
+    elif "ax" not in cfg["save"]["default"]["t"]:
+        cfg["save"]["default"]["t"]["ax"] = np.linspace(0.0, tmax, nt)
+
+    cfg["save"]["default"]["func"] = get_default_save_func(alpha_e, alpha_i)
+
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Post-processing storage helpers
+# ---------------------------------------------------------------------------
+
+
+def store_fields_timeseries(
+    cfg: dict, fields_dict: dict, t_array: np.ndarray, binary_dir: str, x: np.ndarray
+) -> xr.Dataset:
+    """Save {e, a, da} spacetime data to netCDF."""
+    das = {
+        k: xr.DataArray(np.asarray(v), coords=[("t", t_array), ("x", x)], name=k)
+        for k, v in fields_dict.items()
+        if np.asarray(v).ndim == 2
+    }
+    ds = xr.Dataset(das)
+    ds.to_netcdf(os.path.join(binary_dir, f"fields-t={round(float(t_array[-1]), 4)}.nc"))
+    return ds
+
+
+def store_ck_timeseries(
+    cfg: dict, species: str, Ck_array: np.ndarray, t_array: np.ndarray, binary_dir: str
+) -> xr.Dataset:
+    """Save Hermite-Fourier coefficients (Nn, Nx) complex over time to netCDF.
+
+    Ck_array shape: (nt, Nn, Nx).
+    """
+    Nx = Ck_array.shape[-1]
+    Nn = Ck_array.shape[-2]
+    kx = np.fft.fftshift(np.fft.fftfreq(Nx, d=1.0 / Nx))
+    Ck_shifted = np.fft.fftshift(Ck_array, axes=-1)
+    ds = xr.Dataset(
+        {f"Ck_{species}": (["t", "n", "kx"], Ck_shifted)},
+        coords={"t": t_array, "n": np.arange(Nn), "kx": kx},
+    )
+    ds.to_netcdf(os.path.join(binary_dir, f"Ck_{species}-t={round(float(t_array[-1]), 4)}.nc"))
+    return ds

--- a/adept/_hermite_poisson_1d/storage.py
+++ b/adept/_hermite_poisson_1d/storage.py
@@ -3,10 +3,10 @@ Storage / save functions for the 1D Hermite-Poisson module.
 
 State keys: Ck_electrons (Nn_e, Nx) complex viewed as float64,
             Ck_ions (Nn_i, Nx) complex viewed as float64,
-            a (Nx+2,), prev_a (Nx+2,), e (Nx,), da (Nx+2,).
+            a (Nx+2,), prev_a (Nx+2,), e (Nx,), da (Nx+2,), de (Nx,).
 
 Supported cfg["save"] keys:
-  "fields"  → {e, a, da} spacetime arrays
+  "fields"  → {e, a, da, de} spacetime arrays
   "hermite" → {electrons, ions} Hermite-Fourier coefficient timeseries
   "default" → scalar energy diagnostics (always added automatically)
 """
@@ -17,21 +17,23 @@ import numpy as np
 import xarray as xr
 from jax import numpy as jnp
 
-
 # ---------------------------------------------------------------------------
 # Save functions (called by diffrax SubSaveAt at specified timesteps)
 # ---------------------------------------------------------------------------
 
 
 def get_fields_save_func():
-    """Save electrostatic field e and vector potential a interior."""
+    """Save electrostatic field e, vector potential a interior, and drivers da/de."""
 
     def fields_save_func(t, y, args):
-        return {
+        out = {
             "e": y["e"],
             "a": y["a"][1:-1],
             "da": y["da"][1:-1],
         }
+        if "de" in y:
+            out["de"] = y["de"]  # external longitudinal (ex) driver field, (Nx,)
+        return out
 
     return fields_save_func
 
@@ -56,13 +58,13 @@ def get_default_save_func(alpha_e: float, alpha_i: float):
     def default_save_func(t, y, args):
         Ck_e = y["Ck_electrons"].view(jnp.complex128)
         Ck_i = y["Ck_ions"].view(jnp.complex128)
-        n_e = (alpha_e ** 3) * jnp.fft.ifft(Ck_e[0], norm="forward").real
-        n_i = (alpha_i ** 3) * jnp.fft.ifft(Ck_i[0], norm="forward").real
+        n_e = (alpha_e**3) * jnp.fft.ifft(Ck_e[0], norm="forward").real
+        n_i = (alpha_i**3) * jnp.fft.ifft(Ck_i[0], norm="forward").real
         e = y["e"]
         a = y["a"][1:-1]
         return {
-            "e_energy": jnp.sum(e ** 2),
-            "a_energy": jnp.sum(a ** 2),
+            "e_energy": jnp.sum(e**2),
+            "a_energy": jnp.sum(a**2),
             "n_e_max": jnp.max(n_e),
             "n_e_min": jnp.min(n_e),
             "n_i_max": jnp.max(n_i),
@@ -92,8 +94,12 @@ def get_save_quantities(cfg: dict) -> dict:
     tmax = float(grid["tmax"])
     nt = int(grid["nt"])
     alpha_e = float(physics.get("alpha_e", physics.get("alpha_s", [0.05])[0]))
-    alpha_i = float(physics.get("alpha_i", physics.get("alpha_s", [0.05, 0.05, 0.05, 0.001])[3]
-                                if len(physics.get("alpha_s", [])) > 3 else 0.001))
+    alpha_i = float(
+        physics.get(
+            "alpha_i",
+            physics.get("alpha_s", [0.05, 0.05, 0.05, 0.001])[3] if len(physics.get("alpha_s", [])) > 3 else 0.001,
+        )
+    )
 
     for save_key, save_cfg in cfg.get("save", {}).items():
         if not isinstance(save_cfg, dict):

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -72,7 +72,13 @@ class FreeStreamingExp1D:
     Prediagonalizes the symmetric tridiagonal streaming matrix T where
         T[n, n+1] = T[n+1, n] = sqrt((n+1)/2)   (+ diagonal drift/alpha term)
     and stores V (eigenvectors) and eigenvalues so that
-        exp(-i*kx*alpha/Lx * T * s) = V * diag(exp(prefactor * kx * eigenvalues * s)) * V^T.
+        exp(-i*kx*alpha * T * s) = V * diag(exp(prefactor * kx * eigenvalues * s)) * V^T.
+
+    kx_1d must already be in physical units (2*pi*fftfreq(Nx)*Nx/Lx) — the same
+    array modules.py builds and also feeds to the Poisson solver and the
+    hyper-diffusion term. (An earlier version divided by Lx again here, making
+    free-streaming Lx-times too slow; caught by
+    tests/test_hermite_poisson_1d/test_landau_damping.py.)
     """
 
     def __init__(self, Nn: int, alpha: float, u: float, Lx: float, kx_1d: Array):
@@ -81,10 +87,11 @@ class FreeStreamingExp1D:
             Nn: Number of Hermite modes.
             alpha: Thermal velocity (vth/c in skin-depth units).
             u: Drift velocity (usually 0).
-            Lx: Domain length in normalized units.
-            kx_1d: 1D wavenumber array, shape (Nx,), values 2*pi*fftfreq(Nx)*Nx.
+            Lx: Domain length in normalized units (unused; kept for API stability).
+            kx_1d: 1D wavenumber array, shape (Nx,), physical units
+                   (2*pi*fftfreq(Nx)*Nx/Lx).
         """
-        self.prefactor = -1j * float(alpha) / float(Lx)
+        self.prefactor = -1j * float(alpha)
         self.kx_1d = kx_1d
 
         if Nn == 1:
@@ -265,9 +272,15 @@ def _hermite_e_coupling(
 ) -> Array:
     """Compute E-field (+ ponderomotive) coupling term for one species.
 
-    dCk_n/dt|E = (q/m) * Omega_ce_tau * FFT[sqrt(n)*sqrt(2)/alpha * F(x) * C[n+1](x)]
+    dCk_n/dt|E = (q/m) * Omega_ce_tau * FFT[sqrt(2n)/alpha * F(x) * C[n-1](x)]
 
-    where C[n+1] means the real-space coefficient at mode n+1 (zero-padded at Nn).
+    where C[n-1] means the real-space coefficient at mode n-1 (zero row at n=0).
+    This is the AW-Hermite force term of Parker & Dellar (2015) eq. 3.11:
+    differentiation raises the Hermite-function index, so E·∂_v f projects onto
+    mode n from mode n-1. Matches the validated spectrax1d term
+    (sqrt_n_minus · √2/α · F · shift_multi(C, dn=-1), where dn=-1 yields C[n-1]).
+    A uniform E applied to a Maxwellian (only C_0 ≠ 0) must drive current:
+    dC_1/dt = (q/m)·√2/α·E·C_0.
 
     Args:
         Ck: (Nn, Nx) complex, in k-space.
@@ -281,14 +294,14 @@ def _hermite_e_coupling(
     # IFFT to real space: C(n, x)
     C = jnp.fft.ifft(Ck, axis=-1, norm="forward")  # (Nn, Nx) complex → real part matters
 
-    # Shift down by 1: result[n] = C[n+1], zero at n=Nn-1
-    C_down = jnp.concatenate([C[1:, :], jnp.zeros((1, Nx), dtype=C.dtype)], axis=0)
+    # Source at n-1: result[n] = C[n-1], zero row at n=0
+    C_up = jnp.concatenate([jnp.zeros((1, Nx), dtype=C.dtype), C[:-1, :]], axis=0)
 
-    # Coupling: sqrt(n)*sqrt(2)/alpha * F(x) * C[n+1](x)
+    # Coupling: sqrt(2n)/alpha * F(x) * C[n-1](x)
     integrand = (
         sqrt_n_minus[:, None] * jnp.sqrt(2.0) / alpha
         * F_total[None, :]
-        * C_down
+        * C_up
     )  # (Nn, Nx)
 
     # FFT back and apply q/m * Omega_ce_tau

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -32,30 +32,32 @@ class TransverseWaveDriver:
             ey_driver_cfg: dict mapping pulse_name → pulse_dict from cfg["drivers"]["ey"].
         """
         self.x_a = x_a
-        self.pulses = list(ey_driver_cfg.items()) if isinstance(ey_driver_cfg, dict) else []
-
-    def __call__(self, t: float, args) -> Array:
-        total = jnp.zeros_like(self.x_a)
-        for _, pulse in self.pulses:
+        # Pre-parse all scalars at init so __call__ contains no float() on JAX arrays.
+        x_a_last = float(x_a[-1])
+        parsed = []
+        for _, pulse in (ey_driver_cfg.items() if isinstance(ey_driver_cfg, dict) else []):
             if not isinstance(pulse, dict):
                 continue
-            k0 = float(pulse["k0"])
-            w0 = float(pulse["w0"])
-            a0 = float(pulse["a0"])
-            dw = float(pulse.get("dw0", 0.0))
-            w_total = w0 + dw
-
+            w_total = float(pulse["w0"]) + float(pulse.get("dw0", 0.0))
             t_center = float(pulse.get("t_center", 0.0))
             t_half = 0.5 * float(pulse.get("t_width", 1e10))
             t_rise = float(pulse.get("t_rise", 0.0))
-            env_t = get_envelope(t_rise, t_rise, t_center - t_half, t_center + t_half, t)
-
-            x_center = float(pulse.get("x_center", 0.5 * float(self.x_a[-1])))
+            x_center = float(pulse.get("x_center", 0.5 * x_a_last))
             x_half = 0.5 * float(pulse.get("x_width", 1e10))
             x_rise = float(pulse.get("x_rise", 0.0))
-            env_x = get_envelope(x_rise, x_rise, x_center - x_half, x_center + x_half, self.x_a)
+            parsed.append((
+                float(pulse["k0"]), w_total, float(pulse["a0"]),
+                t_center, t_half, t_rise,
+                x_center, x_half, x_rise,
+            ))
+        self.parsed_pulses = parsed
 
-            total = total + env_t * env_x * (-(w_total**2)) * a0 * jnp.sin(k0 * self.x_a - w_total * t)
+    def __call__(self, t: float, args) -> Array:
+        total = jnp.zeros_like(self.x_a)
+        for k0, w_total, a0, t_center, t_half, t_rise, x_center, x_half, x_rise in self.parsed_pulses:
+            env_t = get_envelope(t_rise, t_rise, t_center - t_half, t_center + t_half, t)
+            env_x = get_envelope(x_rise, x_rise, x_center - x_half, x_center + x_half, self.x_a)
+            total = total + env_t * env_x * (-(w_total ** 2)) * a0 * jnp.sin(k0 * self.x_a - w_total * t)
         return total
 
 

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -1,0 +1,510 @@
+"""
+Core vector field for the 1D Hermite-Poisson solver.
+
+State: Ck_electrons(Nn_e, Nx), Ck_ions(Nn_i, Nx) [complex, stored as float64 views],
+       a(Nx+2), prev_a(Nx+2) [real, vector potential with boundary cells],
+       e(Nx) [real, electrostatic field for diagnostics].
+
+Integration: Lawson-RK4 for Ck (free-streaming exact, E-field/ponderomotive explicit)
+             + explicit leapfrog WaveSolver for a.
+             Uses the Stepper (discrete-map) convention from adept._base_.
+"""
+
+import jax.numpy as jnp
+from jax import Array
+
+from adept._base_ import get_envelope
+from adept._vlasov1d.solvers.pushers.field import WaveSolver
+
+
+class TransverseWaveDriver:
+    """Wave-equation source term S(x, t) = Σ_pulses -w² a0 envelope(x,t) sin(kx − wt).
+
+    Reads directly from the raw normalized driver_config dict (same format as
+    adept._spectrax1d.driver.Driver) so no Pydantic/EMDriver chain is needed.
+    Output shape: (Nx+2,), matching WaveSolver's djy_array expectation.
+    """
+
+    def __init__(self, x_a: Array, ey_driver_cfg: dict):
+        """
+        Args:
+            x_a: Extended x grid with ghost cells, shape (Nx+2,).
+            ey_driver_cfg: dict mapping pulse_name → pulse_dict from cfg["drivers"]["ey"].
+        """
+        self.x_a = x_a
+        self.pulses = list(ey_driver_cfg.items()) if isinstance(ey_driver_cfg, dict) else []
+
+    def __call__(self, t: float, args) -> Array:
+        total = jnp.zeros_like(self.x_a)
+        for _, pulse in self.pulses:
+            if not isinstance(pulse, dict):
+                continue
+            k0 = float(pulse["k0"])
+            w0 = float(pulse["w0"])
+            a0 = float(pulse["a0"])
+            dw = float(pulse.get("dw0", 0.0))
+            w_total = w0 + dw
+
+            t_center = float(pulse.get("t_center", 0.0))
+            t_half = 0.5 * float(pulse.get("t_width", 1e10))
+            t_rise = float(pulse.get("t_rise", 0.0))
+            env_t = get_envelope(t_rise, t_rise, t_center - t_half, t_center + t_half, t)
+
+            x_center = float(pulse.get("x_center", 0.5 * float(self.x_a[-1])))
+            x_half = 0.5 * float(pulse.get("x_width", 1e10))
+            x_rise = float(pulse.get("x_rise", 0.0))
+            env_x = get_envelope(x_rise, x_rise, x_center - x_half, x_center + x_half, self.x_a)
+
+            total = total + env_t * env_x * (-(w_total**2)) * a0 * jnp.sin(k0 * self.x_a - w_total * t)
+        return total
+
+
+# ---------------------------------------------------------------------------
+# Linear exponential operators for (Nn, Nx) arrays
+# ---------------------------------------------------------------------------
+
+
+class FreeStreamingExp1D:
+    """Exact exponential for free-streaming in x (acts on the n-axis, varies with kx).
+
+    Prediagonalizes the symmetric tridiagonal streaming matrix T where
+        T[n, n+1] = T[n+1, n] = sqrt((n+1)/2)   (+ diagonal drift/alpha term)
+    and stores V (eigenvectors) and eigenvalues so that
+        exp(-i*kx*alpha/Lx * T * s) = V * diag(exp(prefactor * kx * eigenvalues * s)) * V^T.
+    """
+
+    def __init__(self, Nn: int, alpha: float, u: float, Lx: float, kx_1d: Array):
+        """
+        Args:
+            Nn: Number of Hermite modes.
+            alpha: Thermal velocity (vth/c in skin-depth units).
+            u: Drift velocity (usually 0).
+            Lx: Domain length in normalized units.
+            kx_1d: 1D wavenumber array, shape (Nx,), values 2*pi*fftfreq(Nx)*Nx.
+        """
+        self.prefactor = -1j * float(alpha) / float(Lx)
+        self.kx_1d = kx_1d
+
+        if Nn == 1:
+            self.V = jnp.ones((1, 1))
+            self.eigenvalues = jnp.array([float(u / alpha)])
+        else:
+            n = jnp.arange(Nn, dtype=jnp.float64)
+            off_diag = jnp.sqrt((n + 1.0) / 2.0)[:-1]  # sqrt((n+1)/2) for n=0..Nn-2
+            T = jnp.diag(off_diag, k=1) + jnp.diag(off_diag, k=-1)
+            T = T + (float(u) / float(alpha)) * jnp.eye(Nn)
+            eigenvalues, V = jnp.linalg.eigh(T)
+            self.V = V
+            self.eigenvalues = eigenvalues
+
+    def apply(self, Ck: Array, s: float) -> Array:
+        """Apply exp(L_stream * s) to Ck, shape (Nn, Nx)."""
+        # Project: C_eig[i, kx] = V^T[i, n] * Ck[n, kx]
+        C_eig = self.V.T @ Ck  # (Nn, Nx)
+        # Scale: exp(prefactor * kx * eigenvalue * s)
+        exp_fac = jnp.exp(self.prefactor * s * self.eigenvalues[:, None] * self.kx_1d[None, :])
+        # Project back
+        return self.V @ (C_eig * exp_fac)  # (Nn, Nx)
+
+
+class DiagonalExp1D:
+    """Exact exponential for hypercollision + hyper-diffusion (diagonal in mode/k space)."""
+
+    def __init__(self, nu: float, col_1d: Array, D: float, kx_sq_1d: Array):
+        """
+        Args:
+            nu: Collision frequency.
+            col_1d: Hypercollisional damping coefficients, shape (Nn,).
+            D: Hyper-diffusion coefficient.
+            kx_sq_1d: kx^2 array, shape (Nx,).
+        """
+        self.nu = nu
+        self.col_1d = col_1d
+        self.D = D
+        self.kx_sq_1d = kx_sq_1d
+
+    def apply(self, Ck: Array, s: float) -> Array:
+        """Apply exp((-nu*col - D*kx^2) * s) to Ck, shape (Nn, Nx)."""
+        col_fac = -self.nu * self.col_1d[:, None] * s       # (Nn, Nx)
+        diff_fac = -self.D * self.kx_sq_1d[None, :] * s    # (1, Nx)
+        return Ck * jnp.exp(col_fac + diff_fac)
+
+
+class LinearExp1D:
+    """Combined free-streaming + diagonal exponential for one species."""
+
+    def __init__(self, free_streaming: FreeStreamingExp1D, diagonal: DiagonalExp1D):
+        self.free_streaming = free_streaming
+        self.diagonal = diagonal
+
+    def apply(self, Ck: Array, s: float) -> Array:
+        Ck = self.free_streaming.apply(Ck, s)
+        Ck = self.diagonal.apply(Ck, s)
+        return Ck
+
+
+class CombinedLinearExp1D:
+    """Applies exp(L*s) to the full state dict (electrons + ions).
+
+    Passes Ck_electrons and Ck_ions through their respective LinearExp1D operators.
+    Real-valued fields (a, prev_a, e, da) are passed through unchanged.
+    """
+
+    def __init__(
+        self,
+        linear_e: LinearExp1D,
+        linear_i: LinearExp1D,
+        static_ions: bool = False,
+    ):
+        self.linear_e = linear_e
+        self.linear_i = linear_i
+        self.static_ions = static_ions
+
+    def apply(self, state: dict, s: float) -> dict:
+        """Apply exp(L*s) to the Ck components; pass real arrays unchanged."""
+        Ck_e = state["Ck_electrons"].view(jnp.complex128)
+        Ck_e_new = self.linear_e.apply(Ck_e, s)
+
+        if self.static_ions:
+            Ck_i_new_view = state["Ck_ions"]
+        else:
+            Ck_i = state["Ck_ions"].view(jnp.complex128)
+            Ck_i_new_view = self.linear_i.apply(Ck_i, s).view(jnp.float64)
+
+        out = dict(state)
+        out["Ck_electrons"] = Ck_e_new.view(jnp.float64)
+        out["Ck_ions"] = Ck_i_new_view
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Poisson solver (electrostatic field from density)
+# ---------------------------------------------------------------------------
+
+
+class PoissonSolver1D:
+    """Spectral Poisson solver: Ex = -i/kx * FFT(n_i - n_e).
+
+    n_e(x) = alpha_e^3 * IFFT(Ck_e[0, :]).real  (3D normalization from spectrax)
+    n_i(x) = alpha_i^3 * IFFT(Ck_i[0, :]).real  (or static background)
+    """
+
+    def __init__(
+        self,
+        one_over_kx: Array,
+        alpha_e: float,
+        alpha_i: float,
+        static_ion_density: Array | None = None,
+    ):
+        """
+        Args:
+            one_over_kx: 1/kx array (0 at k=0), shape (Nx,).
+            alpha_e, alpha_i: Thermal velocities.
+            static_ion_density: Fixed ion density profile shape (Nx,) for static_ions=True.
+                                If None, ion density is computed from Ck_ions each step.
+        """
+        self.one_over_kx = one_over_kx
+        self.alpha_e = float(alpha_e)
+        self.alpha_i = float(alpha_i)
+        self.static_ion_density = static_ion_density
+
+    def electron_density(self, Ck_e: Array) -> Array:
+        """n_e(x) from Hermite coefficient C_0 in k-space."""
+        C0_e = jnp.fft.ifft(Ck_e[0, :], norm="forward").real
+        return (self.alpha_e ** 3) * C0_e
+
+    def ion_density(self, Ck_i: Array) -> Array:
+        """n_i(x) from Hermite coefficient C_0 in k-space (or static background)."""
+        if self.static_ion_density is not None:
+            return self.static_ion_density
+        C0_i = jnp.fft.ifft(Ck_i[0, :], norm="forward").real
+        return (self.alpha_i ** 3) * C0_i
+
+    def __call__(self, Ck_e: Array, Ck_i: Array) -> Array:
+        """Return Ex(x), shape (Nx,)."""
+        n_e = self.electron_density(Ck_e)
+        n_i = self.ion_density(Ck_i)
+        rho = n_i - n_e  # charge density (positive where ions > electrons)
+        rho_k = jnp.fft.fft(rho, norm="forward")
+        # Poisson: -kx^2 phi_k = -rho_k → phi_k = rho_k/kx^2
+        # Ex = -d phi/dx → Ex_k = -i*kx*phi_k = -i/kx * rho_k
+        Ex_k = -1j * self.one_over_kx * rho_k
+        return jnp.fft.ifft(Ex_k, norm="forward").real
+
+
+# ---------------------------------------------------------------------------
+# Nonlinear RHS: E-field + ponderomotive Hermite coupling
+# ---------------------------------------------------------------------------
+
+
+def _hermite_e_coupling(
+    Ck: Array,
+    F_total: Array,
+    sqrt_n_minus: Array,
+    q_over_m: float,
+    alpha: float,
+    Omega_ce_tau: float,
+) -> Array:
+    """Compute E-field (+ ponderomotive) coupling term for one species.
+
+    dCk_n/dt|E = (q/m) * Omega_ce_tau * FFT[sqrt(n)*sqrt(2)/alpha * F(x) * C[n+1](x)]
+
+    where C[n+1] means the real-space coefficient at mode n+1 (zero-padded at Nn).
+
+    Args:
+        Ck: (Nn, Nx) complex, in k-space.
+        F_total: (Nx,) real, total force field (Ex + ponderomotive).
+        sqrt_n_minus: (Nn,) = sqrt([0,1,...,Nn-1]).
+        q_over_m: Charge-to-mass ratio (e.g. -1 for electrons).
+        alpha: Thermal velocity.
+        Omega_ce_tau: Normalization constant (1.0 in current configs).
+    """
+    Nn, Nx = Ck.shape
+    # IFFT to real space: C(n, x)
+    C = jnp.fft.ifft(Ck, axis=-1, norm="forward")  # (Nn, Nx) complex → real part matters
+
+    # Shift down by 1: result[n] = C[n+1], zero at n=Nn-1
+    C_down = jnp.concatenate([C[1:, :], jnp.zeros((1, Nx), dtype=C.dtype)], axis=0)
+
+    # Coupling: sqrt(n)*sqrt(2)/alpha * F(x) * C[n+1](x)
+    integrand = (
+        sqrt_n_minus[:, None] * jnp.sqrt(2.0) / alpha
+        * F_total[None, :]
+        * C_down
+    )  # (Nn, Nx)
+
+    # FFT back and apply q/m * Omega_ce_tau
+    return q_over_m * Omega_ce_tau * jnp.fft.fft(integrand, axis=-1, norm="forward")
+
+
+# ---------------------------------------------------------------------------
+# Top-level vector field (Stepper/discrete-map convention)
+# ---------------------------------------------------------------------------
+
+
+def _tree_add(a: dict, b: dict) -> dict:
+    import jax
+    return jax.tree.map(lambda x, y: x + y, a, b)
+
+
+def _tree_scale(a: dict, c: float) -> dict:
+    import jax
+    return jax.tree.map(lambda x: c * x, a)
+
+
+class HermitePoisson1DVectorField:
+    """Advances the 1D Hermite-Poisson state by one timestep dt.
+
+    Uses Lawson-RK4 for Ck (free-streaming exact, E-field/ponderomotive explicit)
+    and explicit leapfrog WaveSolver for the transverse vector potential a.
+
+    Called by adept._base_.Stepper which treats the return value as the new state
+    (not dy/dt). dt is stored internally from grid.dt at construction time.
+    """
+
+    def __init__(
+        self,
+        combined_exp: CombinedLinearExp1D,
+        poisson: PoissonSolver1D,
+        wave_solver: WaveSolver,
+        ey_driver: TransverseWaveDriver,
+        sqrt_n_minus_e: Array,
+        sqrt_n_minus_i: Array,
+        alpha_e: float,
+        alpha_i: float,
+        q_e: float,
+        q_i: float,
+        mi_me: float,
+        Omega_ce_tau: float,
+        dx: float,
+        dt: float,
+        static_ions: bool = False,
+        sponge_plasma: Array | None = None,
+        sponge_fields: Array | None = None,
+    ):
+        self.combined_exp = combined_exp
+        self.poisson = poisson
+        self.wave_solver = wave_solver
+        self.ey_driver = ey_driver
+
+        self.sqrt_n_minus_e = sqrt_n_minus_e
+        self.sqrt_n_minus_i = sqrt_n_minus_i
+        self.alpha_e = float(alpha_e)
+        self.alpha_i = float(alpha_i)
+        # q/m in normalized units: electrons q=-1/m=1, ions q=+1/m=mi_me
+        self.qm_e = float(q_e) / 1.0
+        self.qm_i = float(q_i) / float(mi_me)
+        self.Omega_ce_tau = float(Omega_ce_tau)
+        self.dx = float(dx)
+        self.dt = float(dt)
+        self.static_ions = static_ions
+        self.sponge_plasma = sponge_plasma
+        self.sponge_fields = sponge_fields
+
+    # ------------------------------------------------------------------
+    # Nonlinear RHS (E-field + ponderomotive coupling only)
+    # ------------------------------------------------------------------
+
+    def _nonlinear_rhs(self, t: float, state: dict, a_frozen: Array, args: dict) -> dict:
+        """Compute the nonlinear part of dCk/dt for both species.
+
+        a_frozen: interior vector potential (Nx,) frozen from start of step.
+        Returns a dict with same keys as state but only Ck entries nonzero.
+        """
+        Ck_e = state["Ck_electrons"].view(jnp.complex128)
+        Ck_i = state["Ck_ions"].view(jnp.complex128)
+
+        # Electrostatic field from Poisson
+        Ex = self.poisson(Ck_e, Ck_i)  # (Nx,)
+
+        # Ponderomotive force: -0.5 * d(a^2)/dx  (on electrons)
+        a_sq = a_frozen ** 2
+        Fp = -0.5 * jnp.gradient(a_sq, self.dx)  # (Nx,)
+
+        # Electron E-field + ponderomotive coupling
+        dCk_e = _hermite_e_coupling(
+            Ck_e, Ex + Fp,
+            self.sqrt_n_minus_e, self.qm_e, self.alpha_e, self.Omega_ce_tau,
+        )
+
+        if self.static_ions:
+            dCk_i = jnp.zeros_like(state["Ck_ions"])
+        else:
+            dCk_i = _hermite_e_coupling(
+                Ck_i, Ex,  # ponderomotive negligible for ions
+                self.sqrt_n_minus_i, self.qm_i, self.alpha_i, self.Omega_ce_tau,
+            ).view(jnp.float64)
+
+        # Real-valued fields have zero nonlinear derivative in the Lawson frame
+        # (wave solver is handled outside the Lawson loop)
+        out = dict(state)
+        out["Ck_electrons"] = dCk_e.view(jnp.float64)
+        out["Ck_ions"] = dCk_i if self.static_ions else dCk_i
+        # Zero out non-Ck entries so tree arithmetic works cleanly
+        for k in ["a", "prev_a", "e", "da"]:
+            if k in out:
+                out[k] = jnp.zeros_like(state[k])
+        return out
+
+    # ------------------------------------------------------------------
+    # Lawson-RK4 for Ck
+    # ------------------------------------------------------------------
+
+    def _lawson_rk4(self, t: float, state: dict, a_frozen: Array, args: dict) -> dict:
+        """One Lawson-RK4 step for Ck (wave-eq fields not touched)."""
+        dt = self.dt
+        exp_L = self.combined_exp.apply
+
+        Eh_y = exp_L(state, dt / 2)
+        Ef_y = exp_L(state, dt)
+
+        N1 = self._nonlinear_rhs(t, state, a_frozen, args)
+
+        Eh_N1 = exp_L(N1, dt / 2)
+        y_star = _tree_add(Eh_y, _tree_scale(Eh_N1, dt / 2))
+        N2 = self._nonlinear_rhs(t + dt / 2, y_star, a_frozen, args)
+
+        y_dstar = _tree_add(Eh_y, _tree_scale(N2, dt / 2))
+        N3 = self._nonlinear_rhs(t + dt / 2, y_dstar, a_frozen, args)
+
+        Eh_N3 = exp_L(N3, dt / 2)
+        y_tstar = _tree_add(Ef_y, _tree_scale(Eh_N3, dt))
+        N4 = self._nonlinear_rhs(t + dt, y_tstar, a_frozen, args)
+
+        Ef_N1 = exp_L(N1, dt)
+        Eh_N2 = exp_L(N2, dt / 2)
+
+        weighted = _tree_scale(
+            _tree_add(
+                _tree_add(Ef_N1, _tree_scale(Eh_N2, 2.0)),
+                _tree_add(_tree_scale(Eh_N3, 2.0), N4),
+            ),
+            dt / 6.0,
+        )
+        return _tree_add(Ef_y, weighted)
+
+    # ------------------------------------------------------------------
+    # Sponge damping
+    # ------------------------------------------------------------------
+
+    def _apply_sponge(self, state: dict) -> dict:
+        """Apply exponential sponge damping post-step."""
+        dt = self.dt
+        out = dict(state)
+
+        if self.sponge_plasma is not None:
+            # Damp all non-density Hermite modes in real space
+            for key, alpha in [("Ck_electrons", self.alpha_e), ("Ck_ions", self.alpha_i)]:
+                Ck = out[key].view(jnp.complex128)  # (Nn, Nx)
+                Nn = Ck.shape[0]
+                C = jnp.fft.ifft(Ck, axis=-1, norm="forward")
+                # Zero mode (density) undamped; all others damped
+                n_idx = jnp.arange(Nn)[:, None]  # (Nn, 1)
+                damping = jnp.where(n_idx == 0, 1.0, jnp.exp(-self.sponge_plasma[None, :] * dt))
+                C_damped = C * damping
+                out[key] = jnp.fft.fft(C_damped, axis=-1, norm="forward").view(jnp.float64)
+
+        if self.sponge_fields is not None:
+            # Damp vector potential interior (not boundary cells)
+            a = out["a"]
+            damping = jnp.exp(-self.sponge_fields * dt)
+            a_interior = a[1:-1] * damping
+            out["a"] = a.at[1:-1].set(a_interior)
+            prev_a = out["prev_a"]
+            prev_a_interior = prev_a[1:-1] * damping
+            out["prev_a"] = prev_a.at[1:-1].set(prev_a_interior)
+
+        return out
+
+    # ------------------------------------------------------------------
+    # Top-level __call__ (Stepper convention: returns new state)
+    # ------------------------------------------------------------------
+
+    def __call__(self, t: float, y: dict, args: dict) -> dict:
+        """Advance state by one timestep dt. Returns new state dict."""
+
+        # Frozen interior vector potential for the whole Lawson step
+        a_frozen = y["a"][1:-1]  # (Nx,)
+
+        # 1. Lawson-RK4 for Ck
+        y_after_lawson = self._lawson_rk4(t, y, a_frozen, args)
+
+        # 2. Wave solver for a
+        # Electron density at start and end of Ck step (for wave eq. plasma term)
+        Ck_e_n = y["Ck_electrons"].view(jnp.complex128)
+        Ck_e_np1 = y_after_lawson["Ck_electrons"].view(jnp.complex128)
+        Ck_i_n = y["Ck_ions"].view(jnp.complex128)
+        Ck_i_np1 = y_after_lawson["Ck_ions"].view(jnp.complex128)
+
+        n_e_n = self.poisson.electron_density(Ck_e_n)
+        n_e_np1 = self.poisson.electron_density(Ck_e_np1)
+        # Wave eq. plasma term: averaged electron density (ωpe² * a)
+        electron_density_avg = 0.5 * (n_e_n + n_e_np1)
+
+        # Transverse current driver (evaluated at half-step for centered scheme)
+        djy = self.ey_driver(t + 0.5 * self.dt, args)
+
+        a_result = self.wave_solver(
+            a=y["a"],
+            aold=y["prev_a"],
+            djy_array=djy,
+            electron_density=electron_density_avg,
+        )
+
+        # 3. Electrostatic field for diagnostics/output
+        Ex = self.poisson(Ck_e_np1, Ck_i_np1)
+
+        # 4. Assemble new state
+        new_state = {
+            "Ck_electrons": y_after_lawson["Ck_electrons"],
+            "Ck_ions": y_after_lawson["Ck_ions"],
+            "a": a_result["a"],
+            "prev_a": a_result["prev_a"],
+            "e": Ex,
+            "da": djy,
+        }
+
+        # 5. Apply sponge damping
+        new_state = self._apply_sponge(new_state)
+
+        return new_state

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -110,26 +110,42 @@ class FreeStreamingExp1D:
 
 
 class DiagonalExp1D:
-    """Exact exponential for hypercollision + hyper-diffusion (diagonal in mode/k space)."""
+    """Exact exponential for hypercollision + hyper-diffusion + Hou-Li filter (diagonal in mode/k space)."""
 
-    def __init__(self, nu: float, col_1d: Array, D: float, kx_sq_1d: Array):
+    def __init__(
+        self,
+        nu: float,
+        col_1d: Array,
+        D: float,
+        kx_sq_1d: Array,
+        hou_li_strength: float = 0.0,
+        hou_li_col_1d: Array | None = None,
+    ):
         """
         Args:
             nu: Collision frequency.
             col_1d: Hypercollisional damping coefficients, shape (Nn,).
             D: Hyper-diffusion coefficient.
             kx_sq_1d: kx^2 array, shape (Nx,).
+            hou_li_strength: Hou-Li filter strength (0 to disable).
+            hou_li_col_1d: Hou-Li profile (n/Nn)^order, shape (Nn,). Required if strength > 0.
         """
         self.nu = nu
         self.col_1d = col_1d
         self.D = D
         self.kx_sq_1d = kx_sq_1d
+        self.hou_li_strength = hou_li_strength
+        self.hou_li_col_1d = hou_li_col_1d
 
     def apply(self, Ck: Array, s: float) -> Array:
-        """Apply exp((-nu*col - D*kx^2) * s) to Ck, shape (Nn, Nx)."""
+        """Apply exp((-nu*col - D*kx^2 - hou_li_strength*hou_li_col) * s) to Ck, shape (Nn, Nx)."""
         col_fac = -self.nu * self.col_1d[:, None] * s       # (Nn, Nx)
         diff_fac = -self.D * self.kx_sq_1d[None, :] * s    # (1, Nx)
-        return Ck * jnp.exp(col_fac + diff_fac)
+        if self.hou_li_strength > 0.0 and self.hou_li_col_1d is not None:
+            hl_fac = -self.hou_li_strength * self.hou_li_col_1d[:, None] * s
+        else:
+            hl_fac = 0.0
+        return Ck * jnp.exp(col_fac + diff_fac + hl_fac)
 
 
 class LinearExp1D:

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -269,6 +269,7 @@ def _hermite_e_coupling(
     q_over_m: float,
     alpha: float,
     Omega_ce_tau: float,
+    mask23: Array | None = None,
 ) -> Array:
     """Compute E-field (+ ponderomotive) coupling term for one species.
 
@@ -289,8 +290,18 @@ def _hermite_e_coupling(
         q_over_m: Charge-to-mass ratio (e.g. -1 for electrons).
         alpha: Thermal velocity.
         Omega_ce_tau: Normalization constant (1.0 in current configs).
+        mask23: Optional (Nx,) bool 2/3-rule dealiasing mask in FFT ordering.
+            The F*C product is quadratic: without truncating both factors to
+            |k| <= Nx//3 and masking the result, beyond-Nyquist products alias
+            back into the resolved band (the spectrax1d base applies the same
+            mask23 to every Lorentz product; the vlasov1d reference runs a
+            Hou-Li grid-scale filter in x for the same reason).
     """
     Nn, Nx = Ck.shape
+    if mask23 is not None:
+        Ck = Ck * mask23[None, :]
+        F_total = jnp.fft.ifft(jnp.fft.fft(F_total, norm="forward") * mask23, norm="forward").real
+
     # IFFT to real space: C(n, x)
     C = jnp.fft.ifft(Ck, axis=-1, norm="forward")  # (Nn, Nx) complex → real part matters
 
@@ -305,7 +316,10 @@ def _hermite_e_coupling(
     )  # (Nn, Nx)
 
     # FFT back and apply q/m * Omega_ce_tau
-    return q_over_m * Omega_ce_tau * jnp.fft.fft(integrand, axis=-1, norm="forward")
+    out = q_over_m * Omega_ce_tau * jnp.fft.fft(integrand, axis=-1, norm="forward")
+    if mask23 is not None:
+        out = out * mask23[None, :]
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +366,7 @@ class HermitePoisson1DVectorField:
         static_ions: bool = False,
         sponge_plasma: Array | None = None,
         sponge_fields: Array | None = None,
+        mask23: Array | None = None,
     ):
         self.combined_exp = combined_exp
         self.poisson = poisson
@@ -371,6 +386,7 @@ class HermitePoisson1DVectorField:
         self.static_ions = static_ions
         self.sponge_plasma = sponge_plasma
         self.sponge_fields = sponge_fields
+        self.mask23 = mask23
 
     # ------------------------------------------------------------------
     # Nonlinear RHS (E-field + ponderomotive coupling only)
@@ -396,6 +412,7 @@ class HermitePoisson1DVectorField:
         dCk_e = _hermite_e_coupling(
             Ck_e, Ex + Fp,
             self.sqrt_n_minus_e, self.qm_e, self.alpha_e, self.Omega_ce_tau,
+            mask23=self.mask23,
         )
 
         if self.static_ions:
@@ -404,6 +421,7 @@ class HermitePoisson1DVectorField:
             dCk_i = _hermite_e_coupling(
                 Ck_i, Ex,  # ponderomotive negligible for ions
                 self.sqrt_n_minus_i, self.qm_i, self.alpha_i, self.Omega_ce_tau,
+                mask23=self.mask23,
             ).view(jnp.float64)
 
         # Real-valued fields have zero nonlinear derivative in the Lawson frame

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -36,7 +36,7 @@ class TransverseWaveDriver:
         # Pre-parse all scalars at init so __call__ contains no float() on JAX arrays.
         x_a_last = float(x_a[-1])
         parsed = []
-        for _, pulse in (ey_driver_cfg.items() if isinstance(ey_driver_cfg, dict) else []):
+        for _, pulse in ey_driver_cfg.items() if isinstance(ey_driver_cfg, dict) else []:
             if not isinstance(pulse, dict):
                 continue
             w_total = float(pulse["w0"]) + float(pulse.get("dw0", 0.0))
@@ -46,11 +46,19 @@ class TransverseWaveDriver:
             x_center = float(pulse.get("x_center", 0.5 * x_a_last))
             x_half = 0.5 * float(pulse.get("x_width", 1e10))
             x_rise = float(pulse.get("x_rise", 0.0))
-            parsed.append((
-                float(pulse["k0"]), w_total, float(pulse["a0"]),
-                t_center, t_half, t_rise,
-                x_center, x_half, x_rise,
-            ))
+            parsed.append(
+                (
+                    float(pulse["k0"]),
+                    w_total,
+                    float(pulse["a0"]),
+                    t_center,
+                    t_half,
+                    t_rise,
+                    x_center,
+                    x_half,
+                    x_rise,
+                )
+            )
         self.parsed_pulses = parsed
 
     def __call__(self, t: float, args) -> Array:
@@ -58,7 +66,65 @@ class TransverseWaveDriver:
         for k0, w_total, a0, t_center, t_half, t_rise, x_center, x_half, x_rise in self.parsed_pulses:
             env_t = get_envelope(t_rise, t_rise, t_center - t_half, t_center + t_half, t)
             env_x = get_envelope(x_rise, x_rise, x_center - x_half, x_center + x_half, self.x_a)
-            total = total + env_t * env_x * (-(w_total ** 2)) * a0 * jnp.sin(k0 * self.x_a - w_total * t)
+            total = total + env_t * env_x * (-(w_total**2)) * a0 * jnp.sin(k0 * self.x_a - w_total * t)
+        return total
+
+
+class LongitudinalElectricFieldDriver:
+    """External longitudinal field E_drive(x, t) = Σ_pulses env(x,t) (w0+dw0) a0 sin(k0 x − (w0+dw0) t).
+
+    The Hermite-Poisson counterpart of adept._vlasov1d...field.LongitudinalElectricFieldDriver:
+    a prescribed Ex that is added to the self-consistent Poisson field inside the
+    velocity-space force term (so it drives the plasma directly, e.g. a resonant EPW
+    kick), without ever entering the Poisson or wave-equation solves. Reads the same
+    flat normalized driver dict as TransverseWaveDriver (cfg["drivers"]["ex"]).
+
+    Amplitude convention matches vlasov1d: the prefactor is the total angular frequency
+    w0+dw0 (not |k0|, which is the spectrax1d Ex convention). Output shape (Nx,), matching
+    the interior force-coupling grid (no ghost cells).
+    """
+
+    def __init__(self, x: Array, ex_driver_cfg: dict):
+        """
+        Args:
+            x: Interior x grid (no ghost cells), shape (Nx,).
+            ex_driver_cfg: dict mapping pulse_name → pulse_dict from cfg["drivers"]["ex"].
+        """
+        self.x = x
+        # Pre-parse all scalars at init so __call__ contains no float() on JAX arrays.
+        x_last = float(x[-1])
+        parsed = []
+        for _, pulse in ex_driver_cfg.items() if isinstance(ex_driver_cfg, dict) else []:
+            if not isinstance(pulse, dict):
+                continue
+            w_total = float(pulse["w0"]) + float(pulse.get("dw0", 0.0))
+            t_center = float(pulse.get("t_center", 0.0))
+            t_half = 0.5 * float(pulse.get("t_width", 1e10))
+            t_rise = float(pulse.get("t_rise", 0.0))
+            x_center = float(pulse.get("x_center", 0.5 * x_last))
+            x_half = 0.5 * float(pulse.get("x_width", 1e10))
+            x_rise = float(pulse.get("x_rise", 0.0))
+            parsed.append(
+                (
+                    float(pulse["k0"]),
+                    w_total,
+                    float(pulse["a0"]),
+                    t_center,
+                    t_half,
+                    t_rise,
+                    x_center,
+                    x_half,
+                    x_rise,
+                )
+            )
+        self.parsed_pulses = parsed
+
+    def __call__(self, t: float, args) -> Array:
+        total = jnp.zeros_like(self.x)
+        for k0, w_total, a0, t_center, t_half, t_rise, x_center, x_half, x_rise in self.parsed_pulses:
+            env_t = get_envelope(t_rise, t_rise, t_center - t_half, t_center + t_half, t)
+            env_x = get_envelope(x_rise, x_rise, x_center - x_half, x_center + x_half, self.x)
+            total = total + env_t * env_x * w_total * a0 * jnp.sin(k0 * self.x - w_total * t)
         return total
 
 
@@ -147,8 +213,8 @@ class DiagonalExp1D:
 
     def apply(self, Ck: Array, s: float) -> Array:
         """Apply exp((-nu*col - D*kx^2 - hou_li_strength*hou_li_col) * s) to Ck, shape (Nn, Nx)."""
-        col_fac = -self.nu * self.col_1d[:, None] * s       # (Nn, Nx)
-        diff_fac = -self.D * self.kx_sq_1d[None, :] * s    # (1, Nx)
+        col_fac = -self.nu * self.col_1d[:, None] * s  # (Nn, Nx)
+        diff_fac = -self.D * self.kx_sq_1d[None, :] * s  # (1, Nx)
         if self.hou_li_strength > 0.0 and self.hou_li_col_1d is not None:
             hl_fac = -self.hou_li_strength * self.hou_li_col_1d[:, None] * s
         else:
@@ -237,14 +303,14 @@ class PoissonSolver1D:
     def electron_density(self, Ck_e: Array) -> Array:
         """n_e(x) from Hermite coefficient C_0 in k-space."""
         C0_e = jnp.fft.ifft(Ck_e[0, :], norm="forward").real
-        return (self.alpha_e ** 3) * C0_e
+        return (self.alpha_e**3) * C0_e
 
     def ion_density(self, Ck_i: Array) -> Array:
         """n_i(x) from Hermite coefficient C_0 in k-space (or static background)."""
         if self.static_ion_density is not None:
             return self.static_ion_density
         C0_i = jnp.fft.ifft(Ck_i[0, :], norm="forward").real
-        return (self.alpha_i ** 3) * C0_i
+        return (self.alpha_i**3) * C0_i
 
     def __call__(self, Ck_e: Array, Ck_i: Array) -> Array:
         """Return Ex(x), shape (Nx,)."""
@@ -310,11 +376,7 @@ def _hermite_e_coupling(
     C_up = jnp.concatenate([jnp.zeros((1, Nx), dtype=C.dtype), C[:-1, :]], axis=0)
 
     # Coupling: sqrt(2n)/alpha * F(x) * C[n-1](x)
-    integrand = (
-        sqrt_n_minus[:, None] * jnp.sqrt(2.0) / alpha
-        * F_total[None, :]
-        * C_up
-    )  # (Nn, Nx)
+    integrand = sqrt_n_minus[:, None] * jnp.sqrt(2.0) / alpha * F_total[None, :] * C_up  # (Nn, Nx)
 
     # FFT back and apply q/m * Omega_ce_tau
     out = q_over_m * Omega_ce_tau * jnp.fft.fft(integrand, axis=-1, norm="forward")
@@ -330,11 +392,13 @@ def _hermite_e_coupling(
 
 def _tree_add(a: dict, b: dict) -> dict:
     import jax
+
     return jax.tree.map(lambda x, y: x + y, a, b)
 
 
 def _tree_scale(a: dict, c: float) -> dict:
     import jax
+
     return jax.tree.map(lambda x: c * x, a)
 
 
@@ -354,6 +418,7 @@ class HermitePoisson1DVectorField:
         poisson: PoissonSolver1D,
         wave_solver: WaveSolver,
         ey_driver: TransverseWaveDriver,
+        ex_driver: LongitudinalElectricFieldDriver,
         sqrt_n_minus_e: Array,
         sqrt_n_minus_i: Array,
         alpha_e: float,
@@ -376,6 +441,7 @@ class HermitePoisson1DVectorField:
         self.poisson = poisson
         self.wave_solver = wave_solver
         self.ey_driver = ey_driver
+        self.ex_driver = ex_driver
 
         self.sqrt_n_minus_e = sqrt_n_minus_e
         self.sqrt_n_minus_i = sqrt_n_minus_i
@@ -412,7 +478,9 @@ class HermitePoisson1DVectorField:
         white = jax.random.normal(key, self.noise_spatial_profile.shape)
         return self.noise_amplitude * white * self.noise_spatial_profile
 
-    def _nonlinear_rhs(self, t: float, state: dict, a_frozen: Array, args: dict, noise_frozen: Array | float = 0.0) -> dict:
+    def _nonlinear_rhs(
+        self, t: float, state: dict, a_frozen: Array, args: dict, noise_frozen: Array | float = 0.0
+    ) -> dict:
         """Compute the nonlinear part of dCk/dt for both species.
 
         a_frozen: interior vector potential (Nx,) frozen from start of step.
@@ -424,14 +492,23 @@ class HermitePoisson1DVectorField:
         # Electrostatic field from Poisson
         Ex = self.poisson(Ck_e, Ck_i)  # (Nx,)
 
+        # External longitudinal E-field driver, evaluated at this substep time.
+        # Lawson-RK4 calls _nonlinear_rhs at t, t+dt/2, t+dt, so this captures the
+        # driver's time variation within the step (same as vlasov1d's dex_array).
+        Edrive = self.ex_driver(t, args)  # (Nx,)
+
         # Ponderomotive force: -0.5 * d(a^2)/dx  (on electrons)
-        a_sq = a_frozen ** 2
+        a_sq = a_frozen**2
         Fp = -0.5 * jnp.gradient(a_sq, self.dx)  # (Nx,)
 
-        # Electron E-field + ponderomotive coupling (+ stochastic force noise)
+        # Electron E-field + ponderomotive + external Ex driver (+ stochastic force noise)
         dCk_e = _hermite_e_coupling(
-            Ck_e, Ex + Fp + noise_frozen,
-            self.sqrt_n_minus_e, self.qm_e, self.alpha_e, self.Omega_ce_tau,
+            Ck_e,
+            Ex + Fp + Edrive + noise_frozen,
+            self.sqrt_n_minus_e,
+            self.qm_e,
+            self.alpha_e,
+            self.Omega_ce_tau,
             mask23=self.mask23,
         )
 
@@ -439,8 +516,12 @@ class HermitePoisson1DVectorField:
             dCk_i = jnp.zeros_like(state["Ck_ions"])
         else:
             dCk_i = _hermite_e_coupling(
-                Ck_i, Ex + noise_frozen,  # ponderomotive negligible for ions
-                self.sqrt_n_minus_i, self.qm_i, self.alpha_i, self.Omega_ce_tau,
+                Ck_i,
+                Ex + Edrive + noise_frozen,  # ponderomotive negligible for ions
+                self.sqrt_n_minus_i,
+                self.qm_i,
+                self.alpha_i,
+                self.Omega_ce_tau,
                 mask23=self.mask23,
             ).view(jnp.float64)
 
@@ -448,9 +529,9 @@ class HermitePoisson1DVectorField:
         # (wave solver is handled outside the Lawson loop)
         out = dict(state)
         out["Ck_electrons"] = dCk_e.view(jnp.float64)
-        out["Ck_ions"] = dCk_i if self.static_ions else dCk_i
+        out["Ck_ions"] = dCk_i
         # Zero out non-Ck entries so tree arithmetic works cleanly
-        for k in ["a", "prev_a", "e", "da"]:
+        for k in ["a", "prev_a", "e", "da", "de"]:
             if k in out:
                 out[k] = jnp.zeros_like(state[k])
         return out
@@ -568,6 +649,10 @@ class HermitePoisson1DVectorField:
         # 3. Electrostatic field for diagnostics/output
         Ex = self.poisson(Ck_e_np1, Ck_i_np1)
 
+        # External longitudinal driver field at the start of the step (diagnostic only;
+        # it is applied to the force inside the Lawson loop, not here).
+        de = self.ex_driver(t, args)
+
         # 4. Assemble new state
         new_state = {
             "Ck_electrons": y_after_lawson["Ck_electrons"],
@@ -576,6 +661,7 @@ class HermitePoisson1DVectorField:
             "prev_a": a_result["prev_a"],
             "e": Ex,
             "da": djy,
+            "de": de,
         }
 
         # 5. Apply sponge damping

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -10,6 +10,7 @@ Integration: Lawson-RK4 for Ck (free-streaming exact, E-field/ponderomotive expl
              Uses the Stepper (discrete-map) convention from adept._base_.
 """
 
+import jax
 import jax.numpy as jnp
 from jax import Array
 
@@ -367,6 +368,9 @@ class HermitePoisson1DVectorField:
         sponge_plasma: Array | None = None,
         sponge_fields: Array | None = None,
         mask23: Array | None = None,
+        noise_amplitude: float = 0.0,
+        noise_seed: int = 0,
+        noise_spatial_profile: Array | None = None,
     ):
         self.combined_exp = combined_exp
         self.poisson = poisson
@@ -387,12 +391,28 @@ class HermitePoisson1DVectorField:
         self.sponge_plasma = sponge_plasma
         self.sponge_fields = sponge_fields
         self.mask23 = mask23
+        # Per-step stochastic Ex force noise (vlasov1d stochastic_noise parity):
+        # white in time, Gaussian in space, density-weighted; drawn ONCE per step
+        # (frozen across the Lawson-RK4 stages, like a_frozen) and added to the
+        # v-advection force only — never to Poisson or the wave solver.
+        self.noise_amplitude = float(noise_amplitude)
+        self.noise_base_key = jax.random.PRNGKey(int(noise_seed))
+        self.noise_spatial_profile = noise_spatial_profile
 
     # ------------------------------------------------------------------
     # Nonlinear RHS (E-field + ponderomotive coupling only)
     # ------------------------------------------------------------------
 
-    def _nonlinear_rhs(self, t: float, state: dict, a_frozen: Array, args: dict) -> dict:
+    def _draw_noise(self, t: float) -> Array:
+        """Deterministic per-step noise: key = fold_in(seed, round(t/dt)).
+        Same t -> same realization, so RK4 stages within a step see frozen noise
+        when the draw happens once at the step head."""
+        step = jnp.uint32(jnp.round(t / self.dt))
+        key = jax.random.fold_in(self.noise_base_key, step)
+        white = jax.random.normal(key, self.noise_spatial_profile.shape)
+        return self.noise_amplitude * white * self.noise_spatial_profile
+
+    def _nonlinear_rhs(self, t: float, state: dict, a_frozen: Array, args: dict, noise_frozen: Array | float = 0.0) -> dict:
         """Compute the nonlinear part of dCk/dt for both species.
 
         a_frozen: interior vector potential (Nx,) frozen from start of step.
@@ -408,9 +428,9 @@ class HermitePoisson1DVectorField:
         a_sq = a_frozen ** 2
         Fp = -0.5 * jnp.gradient(a_sq, self.dx)  # (Nx,)
 
-        # Electron E-field + ponderomotive coupling
+        # Electron E-field + ponderomotive coupling (+ stochastic force noise)
         dCk_e = _hermite_e_coupling(
-            Ck_e, Ex + Fp,
+            Ck_e, Ex + Fp + noise_frozen,
             self.sqrt_n_minus_e, self.qm_e, self.alpha_e, self.Omega_ce_tau,
             mask23=self.mask23,
         )
@@ -419,7 +439,7 @@ class HermitePoisson1DVectorField:
             dCk_i = jnp.zeros_like(state["Ck_ions"])
         else:
             dCk_i = _hermite_e_coupling(
-                Ck_i, Ex,  # ponderomotive negligible for ions
+                Ck_i, Ex + noise_frozen,  # ponderomotive negligible for ions
                 self.sqrt_n_minus_i, self.qm_i, self.alpha_i, self.Omega_ce_tau,
                 mask23=self.mask23,
             ).view(jnp.float64)
@@ -444,21 +464,26 @@ class HermitePoisson1DVectorField:
         dt = self.dt
         exp_L = self.combined_exp.apply
 
+        if self.noise_amplitude > 0.0 and self.noise_spatial_profile is not None:
+            noise_frozen = self._draw_noise(t)
+        else:
+            noise_frozen = 0.0
+
         Eh_y = exp_L(state, dt / 2)
         Ef_y = exp_L(state, dt)
 
-        N1 = self._nonlinear_rhs(t, state, a_frozen, args)
+        N1 = self._nonlinear_rhs(t, state, a_frozen, args, noise_frozen)
 
         Eh_N1 = exp_L(N1, dt / 2)
         y_star = _tree_add(Eh_y, _tree_scale(Eh_N1, dt / 2))
-        N2 = self._nonlinear_rhs(t + dt / 2, y_star, a_frozen, args)
+        N2 = self._nonlinear_rhs(t + dt / 2, y_star, a_frozen, args, noise_frozen)
 
         y_dstar = _tree_add(Eh_y, _tree_scale(N2, dt / 2))
-        N3 = self._nonlinear_rhs(t + dt / 2, y_dstar, a_frozen, args)
+        N3 = self._nonlinear_rhs(t + dt / 2, y_dstar, a_frozen, args, noise_frozen)
 
         Eh_N3 = exp_L(N3, dt / 2)
         y_tstar = _tree_add(Ef_y, _tree_scale(Eh_N3, dt))
-        N4 = self._nonlinear_rhs(t + dt, y_tstar, a_frozen, args)
+        N4 = self._nonlinear_rhs(t + dt, y_tstar, a_frozen, args, noise_frozen)
 
         Ef_N1 = exp_L(N1, dt)
         Eh_N2 = exp_L(N2, dt / 2)

--- a/adept/_spectrax1d/hermite_fourier_ode.py
+++ b/adept/_spectrax1d/hermite_fourier_ode.py
@@ -151,10 +151,17 @@ class HermiteFourierODE(eqx.Module):
         If a closure function is provided for a direction, it will be called to predict
         the value of out-of-range modes instead of using zero padding.
 
-        dn=+1 means 'use source at n-1' (upshift in n)
-        dn=-1 means 'use source at n+1' (downshift in n)
-        dn=0 means identity (no shift)
+        Semantics (verified empirically; locked by tests/test_spectrax1d/test_shift_and_lorentz.py):
+            dn=+1  →  result[n] = C[n+1]  (source at n+1; zero-padded at n=Nn-1)
+            dn=-1  →  result[n] = C[n-1]  (source at n-1; zero-padded at n=0)
+            dn=0   →  identity (no shift)
         Same for dm, dp.
+
+        WARNING: an earlier version of this docstring stated the opposite mapping.
+        Code written against that wording (instead of this function's behavior)
+        produced an inverted E·∂_v f coupling in a downstream solver. If you
+        transcribe this pattern, copy the slice arithmetic or call this method —
+        do not re-implement from the description.
 
         Args:
             Ck: Array with shape (Np, Nm, Nn, Ny, Nx, Nz) - Single species
@@ -194,7 +201,7 @@ class HermiteFourierODE(eqx.Module):
             P = P.at[-1, 1:-1, 1:-1, :, :, :].set(C_Np.squeeze(axis=0))
 
         # Extract shifted region (same as before)
-        n0 = 1 + dn  # dn=+1 -> 0 ; dn=0 -> 1 ; dn=-1 -> 2
+        n0 = 1 + dn  # dn=+1 -> 2 (source n+1) ; dn=0 -> 1 (identity) ; dn=-1 -> 0 (source n-1)
         m0 = 1 + dm
         p0 = 1 + dp
 

--- a/adept/hermite_poisson_1d.py
+++ b/adept/hermite_poisson_1d.py
@@ -1,0 +1,5 @@
+"""Re-export module for adept._hermite_poisson_1d."""
+
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
+
+__all__ = ["BaseHermitePoisson1D"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -48,6 +48,7 @@ allowed-confusables = [
     "−", # MINUS SIGN (vs HYPHEN-MINUS)
     "×", # MULTIPLICATION SIGN (vs LATIN SMALL LETTER X)
     "γ", # GREEK SMALL LETTER GAMMA (vs LATIN SMALL LETTER Y) — physics notation
+    "α", # GREEK SMALL LETTER ALPHA (vs LATIN SMALL LETTER A) — physics notation (thermal velocity)
 ]
 
 [lint.extend-per-file-ignores]

--- a/tests/test_hermite_poisson_1d/test_collisions.py
+++ b/tests/test_hermite_poisson_1d/test_collisions.py
@@ -1,0 +1,81 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Lenard-Bernstein collision model: exact per-mode decay rates.
+
+Hermite functions are eigenfunctions of the LB operator with eigenvalue
+-nu*n. With physics.collision_model = "lenard-bernstein", modes n >= 3 of a
+force-free, spatially-uniform state must decay as exp(-nu*n*t) exactly (the
+DiagonalExp applies it analytically), while n = 0, 1, 2 are untouched — the
+standard conserving truncation so collisions conserve density, momentum,
+and energy (USER: "typically, folks avoid having any of the collision
+operators hit the first 3 modes/moments").
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import numpy as np
+
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D, _collision_profile
+
+
+def test_collision_profiles():
+    prof_lb = np.asarray(_collision_profile(8, "lenard-bernstein"))
+    np.testing.assert_allclose(prof_lb, [0.0, 0.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+
+    prof_hc = np.asarray(_collision_profile(8, "hypercollision"))
+    assert prof_hc[0] == prof_hc[1] == prof_hc[2] == 0.0
+    np.testing.assert_allclose(prof_hc[-1], 1.0)
+
+
+def test_lenard_bernstein_decay_rates():
+    nu = 1.0e-3
+    tmax = 50.0
+    Nn = 8
+
+    cfg = {
+        "physics": {
+            "Lx": 10.0,
+            "alpha_e": 1.0,
+            "alpha_i": 1.0,
+            "nu": nu,
+            "collision_model": "lenard-bernstein",
+            "static_ions": True,
+            "c_light": 1.0,
+        },
+        "grid": {"Nn": Nn, "Ni": 2, "Nx": 32, "tmax": tmax, "dt": 0.1},
+        "drivers": {},
+        "save": {"hermite": {"t": {"tmin": 0.0, "tmax": tmax, "nt": 11}}},
+    }
+
+    module = BaseHermitePoisson1D(cfg)
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+
+    # Spatially-uniform, force-free state: seed every mode at k=0.
+    # (Uniform C_n produces no density perturbation -> E stays 0; free
+    # streaming at k=0 is inert -> evolution is purely collisional.)
+    import jax.numpy as jnp
+
+    Ck = module.state["Ck_electrons"].view(jnp.complex128)
+    for n in range(Nn):
+        Ck = Ck.at[n, 0].set(1.0)
+    module.state["Ck_electrons"] = Ck.view(jnp.float64)
+
+    module.init_diffeqsolve()
+    sol = module(None)["solver result"]
+
+    Ck_t = np.asarray(sol.ys["hermite"]["electrons"]).view(np.complex128)  # (nt, Nn, Nx)
+    t = np.asarray(sol.ts["hermite"])
+
+    amp = np.abs(Ck_t[:, :, 0])  # k=0 component of each mode vs time
+    for n in range(3, Nn):
+        expected = np.exp(-nu * n * t)
+        np.testing.assert_allclose(amp[:, n], expected, rtol=1e-8,
+                                   err_msg=f"mode n={n} LB decay mismatch")
+    # n=0,1,2 (density, momentum, energy) must be exactly conserved
+    for n in range(3):
+        np.testing.assert_allclose(amp[:, n], 1.0, rtol=1e-10,
+                                   err_msg=f"conserved moment n={n} was damped")

--- a/tests/test_hermite_poisson_1d/test_collisions.py
+++ b/tests/test_hermite_poisson_1d/test_collisions.py
@@ -73,9 +73,7 @@ def test_lenard_bernstein_decay_rates():
     amp = np.abs(Ck_t[:, :, 0])  # k=0 component of each mode vs time
     for n in range(3, Nn):
         expected = np.exp(-nu * n * t)
-        np.testing.assert_allclose(amp[:, n], expected, rtol=1e-8,
-                                   err_msg=f"mode n={n} LB decay mismatch")
+        np.testing.assert_allclose(amp[:, n], expected, rtol=1e-8, err_msg=f"mode n={n} LB decay mismatch")
     # n=0,1,2 (density, momentum, energy) must be exactly conserved
     for n in range(3):
-        np.testing.assert_allclose(amp[:, n], 1.0, rtol=1e-10,
-                                   err_msg=f"conserved moment n={n} was damped")
+        np.testing.assert_allclose(amp[:, n], 1.0, rtol=1e-10, err_msg=f"conserved moment n={n} was damped")

--- a/tests/test_hermite_poisson_1d/test_e_coupling.py
+++ b/tests/test_hermite_poisson_1d/test_e_coupling.py
@@ -1,0 +1,121 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Unit tests for the Hermite-Poisson 1D E-field/ponderomotive coupling.
+
+Regression context: _hermite_e_coupling originally read C[n+1] instead of
+C[n−1] — transcribed from a (then-wrong) docstring in spectrax1d's
+shift_multi rather than from its behavior. With that inversion, a uniform
+electric field applied to a Maxwellian drove zero current (the momentum
+equation was structurally absent), and every gradient-SRS production run
+blew up from a spurious, field-free low-n instability.
+
+The correct AW-Hermite force term (Parker & Dellar 2015 eq. 3.11):
+
+    dC_n/dt|E = +(q/m)·√(2n)/α · F · C_{n−1}
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+
+from adept._hermite_poisson_1d.vector_field import _hermite_e_coupling
+
+
+def _coupling(Ck, F, Nn, q_over_m=-1.0, alpha=1.0, Omega=1.0):
+    sqrt_n_minus = jnp.sqrt(jnp.arange(Nn, dtype=jnp.float64))
+    return np.asarray(_hermite_e_coupling(Ck, F, sqrt_n_minus, q_over_m, alpha, Omega))
+
+
+def test_uniform_E_on_maxwellian_drives_current():
+    """Uniform F on a Maxwellian (only C_0 ≠ 0) excites ONLY n=1, with
+    dC_1/dt = (q/m)·√2/α·F·C_0. This is the convention-independent momentum
+    equation; the inverted coupling returned identically zero here."""
+    Nn, Nx = 8, 16
+    c0, E0, alpha, q_over_m = 0.6, 0.3, 1.4, -1.0
+
+    Ck = jnp.zeros((Nn, Nx), dtype=jnp.complex128).at[0, 0].set(c0)
+    F = E0 * jnp.ones(Nx)
+
+    out = _coupling(Ck, F, Nn, q_over_m=q_over_m, alpha=alpha)
+
+    expected_c1 = q_over_m * np.sqrt(2.0) / alpha * E0 * c0
+    np.testing.assert_allclose(out[1, 0].real, expected_c1, rtol=1e-12)
+
+    mask = np.ones_like(out, dtype=bool)
+    mask[1, 0] = False
+    assert np.max(np.abs(out[mask])) < 1e-14
+
+
+def test_force_ladder_is_one_sided_upward():
+    """Seeding only C_2 excites only C_3 with coefficient √(2·3)/α."""
+    Nn, Nx = 8, 16
+    c2, E0, alpha, q_over_m = 0.5, 0.2, 0.9, -1.0
+
+    Ck = jnp.zeros((Nn, Nx), dtype=jnp.complex128).at[2, 0].set(c2)
+    F = E0 * jnp.ones(Nx)
+
+    out = _coupling(Ck, F, Nn, q_over_m=q_over_m, alpha=alpha)
+
+    expected_c3 = q_over_m * np.sqrt(6.0) / alpha * E0 * c2
+    np.testing.assert_allclose(out[3, 0].real, expected_c3, rtol=1e-12)
+
+    mask = np.ones_like(out, dtype=bool)
+    mask[3, 0] = False
+    assert np.max(np.abs(out[mask])) < 1e-14
+
+
+def test_density_is_never_forced():
+    """The force term must not alter C_0 (density) regardless of state."""
+    Nn, Nx = 8, 16
+    rng = np.random.default_rng(0)
+    Ck = jnp.asarray(rng.normal(size=(Nn, Nx)) + 1j * rng.normal(size=(Nn, Nx)))
+    F = jnp.asarray(rng.normal(size=Nx))
+
+    out = _coupling(Ck, F, Nn)
+    assert np.max(np.abs(out[0])) < 1e-14
+
+
+def test_matches_spectrax1d_lorentz_term():
+    """The HP coupling must equal the validated spectrax1d Lorentz E-term
+    (the path exercised by the passing spectrax EPW dispersion tests),
+    specialized to 1D (Nm=Np=1, E_x only)."""
+    from adept._spectrax1d.hermite_fourier_ode import HermiteFourierODE
+
+    Nn, Nx = 6, 8
+    alpha, q_over_m = 1.2, -1.0
+    rng = np.random.default_rng(1)
+    Ck = jnp.asarray(rng.normal(size=(Nn, Nx)) + 1j * rng.normal(size=(Nn, Nx)))
+    F = jnp.asarray(rng.normal(size=Nx))
+
+    out_hp = _coupling(Ck, F, Nn, q_over_m=q_over_m, alpha=alpha)
+
+    # spectrax reference
+    Lx = 2.0 * np.pi
+    kx_1d = jnp.fft.fftfreq(Nx) * Nx * 2 * jnp.pi / Lx
+    n = jnp.arange(Nn, dtype=jnp.float64)
+    ode = HermiteFourierODE(
+        Nn=Nn, Nm=1, Np=1, Nx=Nx,
+        kx_grid=kx_1d[None, :, None],
+        ky_grid=jnp.zeros((1, Nx, 1)),
+        kz_grid=jnp.zeros((1, Nx, 1)),
+        k2_grid=(kx_1d**2)[None, :, None],
+        Lx=Lx, Ly=1.0, Lz=1.0,
+        col=jnp.zeros((1, 1, Nn)),
+        sqrt_n_plus=jnp.sqrt(n + 1.0), sqrt_n_minus=jnp.sqrt(n),
+        sqrt_m_plus=jnp.array([1.0]), sqrt_m_minus=jnp.array([0.0]),
+        sqrt_p_plus=jnp.array([1.0]), sqrt_p_minus=jnp.array([0.0]),
+        mask23=jnp.ones((1, Nx, 1)),
+    )
+    C_real = jnp.fft.ifft(Ck, axis=-1, norm="forward")
+    C6 = C_real[None, None, :, None, :, None]
+    F6 = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, :, 0].set(F)
+    out_ref = ode._compute_lorentz_rhs(
+        C=C6, F=F6, alpha=jnp.array([alpha, 1.0, 1.0]), u=jnp.zeros(3),
+        q=q_over_m, Omega_ce_tau=1.0, m=1.0,
+    )
+    out_ref = np.asarray(out_ref[0, 0, :, 0, :, 0])
+
+    np.testing.assert_allclose(out_hp, out_ref, atol=1e-12)

--- a/tests/test_hermite_poisson_1d/test_e_coupling.py
+++ b/tests/test_hermite_poisson_1d/test_e_coupling.py
@@ -97,24 +97,37 @@ def test_matches_spectrax1d_lorentz_term():
     kx_1d = jnp.fft.fftfreq(Nx) * Nx * 2 * jnp.pi / Lx
     n = jnp.arange(Nn, dtype=jnp.float64)
     ode = HermiteFourierODE(
-        Nn=Nn, Nm=1, Np=1, Nx=Nx,
+        Nn=Nn,
+        Nm=1,
+        Np=1,
+        Nx=Nx,
         kx_grid=kx_1d[None, :, None],
         ky_grid=jnp.zeros((1, Nx, 1)),
         kz_grid=jnp.zeros((1, Nx, 1)),
         k2_grid=(kx_1d**2)[None, :, None],
-        Lx=Lx, Ly=1.0, Lz=1.0,
+        Lx=Lx,
+        Ly=1.0,
+        Lz=1.0,
         col=jnp.zeros((1, 1, Nn)),
-        sqrt_n_plus=jnp.sqrt(n + 1.0), sqrt_n_minus=jnp.sqrt(n),
-        sqrt_m_plus=jnp.array([1.0]), sqrt_m_minus=jnp.array([0.0]),
-        sqrt_p_plus=jnp.array([1.0]), sqrt_p_minus=jnp.array([0.0]),
+        sqrt_n_plus=jnp.sqrt(n + 1.0),
+        sqrt_n_minus=jnp.sqrt(n),
+        sqrt_m_plus=jnp.array([1.0]),
+        sqrt_m_minus=jnp.array([0.0]),
+        sqrt_p_plus=jnp.array([1.0]),
+        sqrt_p_minus=jnp.array([0.0]),
         mask23=jnp.ones((1, Nx, 1)),
     )
     C_real = jnp.fft.ifft(Ck, axis=-1, norm="forward")
     C6 = C_real[None, None, :, None, :, None]
     F6 = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, :, 0].set(F)
     out_ref = ode._compute_lorentz_rhs(
-        C=C6, F=F6, alpha=jnp.array([alpha, 1.0, 1.0]), u=jnp.zeros(3),
-        q=q_over_m, Omega_ce_tau=1.0, m=1.0,
+        C=C6,
+        F=F6,
+        alpha=jnp.array([alpha, 1.0, 1.0]),
+        u=jnp.zeros(3),
+        q=q_over_m,
+        Omega_ce_tau=1.0,
+        m=1.0,
     )
     out_ref = np.asarray(out_ref[0, 0, :, 0, :, 0])
 

--- a/tests/test_hermite_poisson_1d/test_ex_driver.py
+++ b/tests/test_hermite_poisson_1d/test_ex_driver.py
@@ -1,0 +1,127 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""External longitudinal (Ex) field driver for Hermite-Poisson 1D.
+
+Parity with adept._vlasov1d's LongitudinalElectricFieldDriver: a prescribed Ex
+is added to the velocity-space force (Poisson field + ponderomotive), driving the
+plasma directly. The field follows the vlasov1d amplitude convention
+
+    E_drive(x, t) = Σ_pulses env(x,t) · (w0+dw0) · a0 · sin(k0 x − (w0+dw0) t),
+
+reads the flat cfg["drivers"]["ex"] pulse dict (same format as the ey driver), and
+is exposed as the "de" diagnostic field.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
+from adept._hermite_poisson_1d.vector_field import LongitudinalElectricFieldDriver
+
+
+def test_driver_field_formula():
+    """Single pulse with effectively-unity envelopes reproduces the analytic
+    (w0+dw0)·a0·sin(k0 x − (w0+dw0) t) field exactly."""
+    Lx, Nx = 10.0, 64
+    x = jnp.linspace(0.0, Lx, Nx, endpoint=False)
+    # Huge widths (default 1e10) -> envelopes are 1.0 to float64 precision in the
+    # interior; finite rise avoids a 0/0 in get_envelope.
+    pulse = {"k0": 0.7, "w0": 1.3, "dw0": 0.1, "a0": 0.05, "t_rise": 1.0, "x_rise": 1.0}
+    driver = LongitudinalElectricFieldDriver(x, {"0": pulse})
+
+    t = 2.0
+    got = np.asarray(driver(t, {}))
+    w_total = 1.3 + 0.1
+    expected = w_total * 0.05 * np.sin(0.7 * np.asarray(x) - w_total * t)
+    np.testing.assert_allclose(got, expected, atol=1e-12)
+
+
+def test_driver_sums_multiple_pulses():
+    """The driver is the linear superposition of its pulses."""
+    Lx, Nx = 8.0, 48
+    x = jnp.linspace(0.0, Lx, Nx, endpoint=False)
+    p0 = {"k0": 0.6, "w0": 1.0, "a0": 0.03, "t_rise": 1.0, "x_rise": 1.0}
+    p1 = {"k0": -0.6, "w0": 1.2, "a0": 0.02, "t_rise": 1.0, "x_rise": 1.0}
+
+    both = LongitudinalElectricFieldDriver(x, {"0": p0, "1": p1})
+    only0 = LongitudinalElectricFieldDriver(x, {"0": p0})
+    only1 = LongitudinalElectricFieldDriver(x, {"1": p1})
+
+    t = 1.5
+    np.testing.assert_allclose(np.asarray(both(t, {})), np.asarray(only0(t, {})) + np.asarray(only1(t, {})), atol=1e-12)
+
+
+def test_no_ex_pulses_returns_zeros():
+    """An empty (or missing) ex config yields an identically-zero field."""
+    Lx, Nx = 10.0, 32
+    x = jnp.linspace(0.0, Lx, Nx, endpoint=False)
+    for cfg in ({}, None):
+        driver = LongitudinalElectricFieldDriver(x, cfg)
+        out = np.asarray(driver(3.0, {}))
+        assert out.shape == (Nx,)
+        assert np.max(np.abs(out)) == 0.0
+
+
+def _build_module(ex_enabled: bool, a0: float = 1.0e-3):
+    cfg = {
+        "physics": {
+            "Lx": 10.0,
+            "alpha_e": 1.0,
+            "alpha_i": 1.0,
+            "nu": 0.0,
+            "static_ions": True,
+            "c_light": 1.0,
+        },
+        "grid": {"Nn": 16, "Ni": 2, "Nx": 32, "tmax": 5.0, "dt": 0.1},
+        "drivers": {},
+        "save": {},
+    }
+    if ex_enabled:
+        cfg["drivers"]["ex"] = {
+            "0": {
+                "k0": 2.0 * np.pi / 10.0,  # mode 1 on the Lx=10 grid
+                "w0": 1.0,
+                "a0": a0,
+                "t_rise": 1.0,
+                "t_width": 1.0e10,
+            }
+        }
+    module = BaseHermitePoisson1D(cfg)
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    module.init_diffeqsolve()
+    return module
+
+
+def test_ex_driver_drives_kinetic_response():
+    """With the Ex driver on, a quiet Maxwellian develops density/field structure
+    (nonzero Poisson energy); with it off the run stays exactly quiet."""
+    out = {}
+    for enabled in (False, True):
+        module = _build_module(enabled)
+        sol = module(None)["solver result"]
+        scal = sol.ys["default"]
+        out[enabled] = float(np.nanmax(np.asarray(scal["e_energy"])))
+
+    assert out[False] == 0.0
+    assert out[True] > 0.0
+
+
+def test_de_diagnostic_matches_driver():
+    """The 'de' state field records the driver evaluated at the step start."""
+    module = _build_module(True)
+    vf = module.diffeqsolve_quants["terms"].vector_field
+    y0 = module.state
+
+    t0 = 7 * vf.dt
+    new_state = vf(t0, y0, {})
+    expected = np.asarray(vf.ex_driver(t0, {}))
+
+    assert "de" in new_state
+    np.testing.assert_allclose(np.asarray(new_state["de"]), expected, atol=1e-12)
+    assert np.max(np.abs(expected)) > 0.0  # driver actually firing at t0

--- a/tests/test_hermite_poisson_1d/test_knee_filter.py
+++ b/tests/test_hermite_poisson_1d/test_knee_filter.py
@@ -1,0 +1,90 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Scale-selective knee absorber (drivers.hermite_filter profile="knee").
+
+A tanh step in absolute n: ~0 below n_knee, ~1 above. Built so a low
+Lenard-Bernstein nu can preserve the resonant EPW mode (n ~ vphi^2/2) while
+the filamentation cascade just above it is strongly damped — a separation
+the default (n/Nn)^order Hou-Li profile cannot make at large Nn.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
+
+
+def _diag_e(filter_cfg):
+    cfg = {
+        "physics": {"Lx": 10.0, "alpha_e": 1.0, "alpha_i": 1.0, "nu": 0.0,
+                    "static_ions": True, "c_light": 1.0},
+        "grid": {"Nn": 1024, "Ni": 2, "Nx": 32, "tmax": 1.0, "dt": 0.1},
+        "drivers": {"hermite_filter": filter_cfg},
+        "save": {},
+    }
+    m = BaseHermitePoisson1D(cfg)
+    m.get_derived_quantities()
+    m.get_solver_quantities()
+    m.init_state_and_args()
+    m.init_diffeqsolve()
+    # the electron DiagonalExp holds the realized absorber column
+    return m.diffeqsolve_quants["terms"].vector_field.combined_exp.linear_e.diagonal
+
+
+def test_knee_profile_separates_resonance_from_cascade():
+    diag = _diag_e({"enabled": True, "profile": "knee",
+                    "strength": 0.1, "n_knee": 45.0, "width": 8.0})
+    col = np.asarray(diag.hou_li_col_1d)
+    assert diag.hou_li_strength == 0.1
+    # ~0 at the resonance (n=24), ~1 in the cascade (n>=70)
+    assert col[24] < 0.02
+    assert col[70] > 0.95
+    assert abs(col[45] - 0.5) < 1e-9   # tanh midpoint at the knee
+    # monotonic
+    assert np.all(np.diff(col) >= -1e-12)
+
+
+def test_houli_profile_still_default():
+    diag = _diag_e({"enabled": True, "strength": 36.0, "order": 8})
+    col = np.asarray(diag.hou_li_col_1d)
+    # (n/Nn)^8: negligible at moderate n, ~1 only at the truncation edge
+    assert col[24] < 1e-10
+    assert col[512] < 0.01
+    np.testing.assert_allclose(col[-1], 1.0)
+
+
+def test_knee_preserves_low_modes_dynamically():
+    """A pure resonance-band excitation (n=24) is barely damped; a cascade-band
+    excitation (n=80) decays fast — over a short force-free, k=0 run."""
+    import copy
+
+    base = {
+        "physics": {"Lx": 10.0, "alpha_e": 1.0, "alpha_i": 1.0, "nu": 0.0,
+                    "static_ions": True, "c_light": 1.0},
+        "grid": {"Nn": 1024, "Ni": 2, "Nx": 16, "tmax": 20.0, "dt": 0.1},
+        "drivers": {"hermite_filter": {"enabled": True, "profile": "knee",
+                                       "strength": 0.1, "n_knee": 45.0, "width": 8.0}},
+        "save": {"hermite": {"t": {"tmin": 0.0, "tmax": 20.0, "nt": 3}}},
+    }
+
+    decays = {}
+    for nmode in (24, 80):
+        cfg = copy.deepcopy(base)
+        m = BaseHermitePoisson1D(cfg)
+        m.get_derived_quantities()
+        m.get_solver_quantities()
+        m.init_state_and_args()
+        Ck = m.state["Ck_electrons"].view(jnp.complex128)
+        Ck = Ck.at[nmode, 0].set(1.0)  # k=0 -> streaming inert, isolate the absorber
+        m.state["Ck_electrons"] = Ck.view(jnp.float64)
+        m.init_diffeqsolve()
+        sol = m(None)["solver result"]
+        Ck_t = np.asarray(sol.ys["hermite"]["electrons"]).view(np.complex128)
+        decays[nmode] = abs(Ck_t[-1, nmode, 0]) / abs(Ck_t[0, nmode, 0])
+
+    assert decays[24] > 0.95      # resonance preserved
+    assert decays[80] < 0.2       # cascade strongly damped

--- a/tests/test_hermite_poisson_1d/test_knee_filter.py
+++ b/tests/test_hermite_poisson_1d/test_knee_filter.py
@@ -20,8 +20,7 @@ from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
 
 def _diag_e(filter_cfg):
     cfg = {
-        "physics": {"Lx": 10.0, "alpha_e": 1.0, "alpha_i": 1.0, "nu": 0.0,
-                    "static_ions": True, "c_light": 1.0},
+        "physics": {"Lx": 10.0, "alpha_e": 1.0, "alpha_i": 1.0, "nu": 0.0, "static_ions": True, "c_light": 1.0},
         "grid": {"Nn": 1024, "Ni": 2, "Nx": 32, "tmax": 1.0, "dt": 0.1},
         "drivers": {"hermite_filter": filter_cfg},
         "save": {},
@@ -36,14 +35,13 @@ def _diag_e(filter_cfg):
 
 
 def test_knee_profile_separates_resonance_from_cascade():
-    diag = _diag_e({"enabled": True, "profile": "knee",
-                    "strength": 0.1, "n_knee": 45.0, "width": 8.0})
+    diag = _diag_e({"enabled": True, "profile": "knee", "strength": 0.1, "n_knee": 45.0, "width": 8.0})
     col = np.asarray(diag.hou_li_col_1d)
     assert diag.hou_li_strength == 0.1
     # ~0 at the resonance (n=24), ~1 in the cascade (n>=70)
     assert col[24] < 0.02
     assert col[70] > 0.95
-    assert abs(col[45] - 0.5) < 1e-9   # tanh midpoint at the knee
+    assert abs(col[45] - 0.5) < 1e-9  # tanh midpoint at the knee
     # monotonic
     assert np.all(np.diff(col) >= -1e-12)
 
@@ -63,11 +61,11 @@ def test_knee_preserves_low_modes_dynamically():
     import copy
 
     base = {
-        "physics": {"Lx": 10.0, "alpha_e": 1.0, "alpha_i": 1.0, "nu": 0.0,
-                    "static_ions": True, "c_light": 1.0},
+        "physics": {"Lx": 10.0, "alpha_e": 1.0, "alpha_i": 1.0, "nu": 0.0, "static_ions": True, "c_light": 1.0},
         "grid": {"Nn": 1024, "Ni": 2, "Nx": 16, "tmax": 20.0, "dt": 0.1},
-        "drivers": {"hermite_filter": {"enabled": True, "profile": "knee",
-                                       "strength": 0.1, "n_knee": 45.0, "width": 8.0}},
+        "drivers": {
+            "hermite_filter": {"enabled": True, "profile": "knee", "strength": 0.1, "n_knee": 45.0, "width": 8.0}
+        },
         "save": {"hermite": {"t": {"tmin": 0.0, "tmax": 20.0, "nt": 3}}},
     }
 
@@ -86,5 +84,5 @@ def test_knee_preserves_low_modes_dynamically():
         Ck_t = np.asarray(sol.ys["hermite"]["electrons"]).view(np.complex128)
         decays[nmode] = abs(Ck_t[-1, nmode, 0]) / abs(Ck_t[0, nmode, 0])
 
-    assert decays[24] > 0.95      # resonance preserved
-    assert decays[80] < 0.2       # cascade strongly damped
+    assert decays[24] > 0.95  # resonance preserved
+    assert decays[80] < 0.2  # cascade strongly damped

--- a/tests/test_hermite_poisson_1d/test_landau_damping.py
+++ b/tests/test_hermite_poisson_1d/test_landau_damping.py
@@ -1,0 +1,114 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""EPW dispersion test for the Hermite-Poisson 1D solver (full solve path).
+
+Runs the actual production path — BaseHermitePoisson1D lifecycle with the
+Lawson-RK4 stepper and the explicit E·∂_v f coupling — on a uniform plasma
+with a small single-mode density perturbation, then checks the ringing
+frequency and Landau damping rate of E_x(k1, t) against the kinetic
+electrostatic dispersion relation.
+
+This is the physics gate the solver lacked when the inverted force coupling
+shipped: with that bug the perturbation produced no Langmuir oscillation at
+all (E never did work on the plasma), so any version of this test would have
+failed immediately.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+
+from adept import electrostatic
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
+
+
+def _measure_ringing(e_xt: np.ndarray, t: np.ndarray, mode: int) -> tuple[float, float]:
+    """Fit oscillation frequency and damping rate of the k=mode component.
+
+    The initial standing perturbation excites both ±ω branches, so
+    |A(t)| oscillates through near-zeros twice per period. We fit:
+      - omega from the mean spacing of |A| maxima (= pi / omega apart),
+      - gamma from a linear fit to log|A| at those maxima.
+    """
+    A = np.fft.fft(e_xt, axis=1)[:, mode] / e_xt.shape[1]
+    absA = np.abs(A)
+
+    # local maxima, skipping the initial transient (first 10% of the run)
+    i0 = len(t) // 10
+    peaks = [
+        i
+        for i in range(i0 + 1, len(t) - 1)
+        if absA[i] >= absA[i - 1] and absA[i] > absA[i + 1]
+    ]
+    assert len(peaks) >= 4, f"too few |A| maxima to fit ({len(peaks)})"
+
+    t_pk = t[peaks]
+    omega = np.pi / np.mean(np.diff(t_pk))
+    gamma = np.polyfit(t_pk, np.log(absA[peaks]), 1)[0]
+    return float(omega), float(gamma)
+
+
+@pytest.mark.parametrize("klambda_D", [0.30, 0.35])
+def test_epw_dispersion(klambda_D: float):
+    mode = 1
+    Lx = 4.0 * np.pi
+    k = 2.0 * np.pi * mode / Lx
+    alpha_e = klambda_D * np.sqrt(2.0) / k  # same convention as test_spectrax1d
+
+    root = electrostatic.get_roots_to_electrostatic_dispersion(
+        wp_e=1.0, vth_e=1.0, k0=klambda_D, maxwellian_convention_factor=2.0
+    )
+    expected_freq = float(np.real(root))
+    expected_damp = float(np.imag(root))
+
+    tmax = 80.0
+    nt_save = 1601
+
+    cfg = {
+        "physics": {
+            "Lx": Lx,
+            "alpha_e": alpha_e,
+            "alpha_i": alpha_e,
+            "n0_e": 1.0,
+            "n0_i": 1.0,
+            "nu": 0.0,
+            "static_ions": True,
+            "c_light": 1.0,
+        },
+        "grid": {
+            "Nn": 256,
+            "Ni": 2,
+            "Nx": 64,
+            "tmax": tmax,
+            "dt": 0.05,
+        },
+        "density": {"perturbation": {"mode": mode, "amplitude": 1.0e-4}},
+        "drivers": {},
+        "save": {"fields": {"t": {"tmin": 0.0, "tmax": tmax, "nt": nt_save}}},
+    }
+
+    module = BaseHermitePoisson1D(cfg)
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    module.init_diffeqsolve()
+    sol = module(None)["solver result"]
+
+    e_xt = np.asarray(sol.ys["fields"]["e"])
+    t = np.asarray(sol.ts["fields"])
+
+    measured_freq, measured_damp = _measure_ringing(e_xt, t, mode)
+
+    print(
+        f"\nklambda_D={klambda_D:.2f}  freq: {measured_freq:.4f} (expected {expected_freq:.4f})"
+        f"  damp: {measured_damp:.5f} (expected {expected_damp:.5f})"
+    )
+
+    # Observed agreement at these parameters is ~0.2% or better; the bounds
+    # below leave headroom for platform jitter while still catching any
+    # physics-level regression.
+    np.testing.assert_allclose(measured_freq, expected_freq, rtol=0.02)
+    np.testing.assert_allclose(measured_damp, expected_damp, rtol=0.05)

--- a/tests/test_hermite_poisson_1d/test_landau_damping.py
+++ b/tests/test_hermite_poisson_1d/test_landau_damping.py
@@ -38,11 +38,7 @@ def _measure_ringing(e_xt: np.ndarray, t: np.ndarray, mode: int) -> tuple[float,
 
     # local maxima, skipping the initial transient (first 10% of the run)
     i0 = len(t) // 10
-    peaks = [
-        i
-        for i in range(i0 + 1, len(t) - 1)
-        if absA[i] >= absA[i - 1] and absA[i] > absA[i + 1]
-    ]
+    peaks = [i for i in range(i0 + 1, len(t) - 1) if absA[i] >= absA[i - 1] and absA[i] > absA[i + 1]]
     assert len(peaks) >= 4, f"too few |A| maxima to fit ({len(peaks)})"
 
     t_pk = t[peaks]

--- a/tests/test_hermite_poisson_1d/test_stochastic_noise.py
+++ b/tests/test_hermite_poisson_1d/test_stochastic_noise.py
@@ -1,0 +1,86 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Per-step stochastic Ex force noise (vlasov1d stochastic_noise parity).
+
+The noise is a white-in-time, density-weighted Gaussian force added to the
+E/ponderomotive coupling each Lawson step (drawn once per step, frozen
+across RK4 stages). Determinism: key = fold_in(seed, round(t/dt)) — the
+same t always yields the same realization.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import numpy as np
+
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
+
+
+def _build_module(noise_enabled: bool, amplitude: float = 1.0e-5, seed: int = 7):
+    cfg = {
+        "physics": {
+            "Lx": 10.0,
+            "alpha_e": 1.0,
+            "alpha_i": 1.0,
+            "nu": 0.0,
+            "static_ions": True,
+            "c_light": 1.0,
+        },
+        "grid": {"Nn": 16, "Ni": 2, "Nx": 32, "tmax": 5.0, "dt": 0.1},
+        "drivers": {},
+        "save": {},
+    }
+    if noise_enabled:
+        cfg["stochastic_noise"] = {"enabled": True, "amplitude": amplitude, "seed": seed}
+    module = BaseHermitePoisson1D(cfg)
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    module.init_diffeqsolve()
+    return module
+
+
+def test_noise_draw_is_deterministic_and_scaled():
+    module = _build_module(True, amplitude=2.0e-5, seed=3)
+    vf = module.diffeqsolve_quants["terms"].vector_field
+
+    n1 = np.asarray(vf._draw_noise(1.0))
+    n1_again = np.asarray(vf._draw_noise(1.0))
+    n2 = np.asarray(vf._draw_noise(1.1))
+
+    np.testing.assert_allclose(n1, n1_again)          # same t -> same draw
+    assert np.max(np.abs(n1 - n2)) > 0.0              # different step -> different draw
+    # uniform density -> profile == 1 -> std ~ amplitude (loose bound, Nx=32)
+    assert 0.3 * 2.0e-5 < np.std(n1) < 3.0 * 2.0e-5
+
+
+def test_stage_freezing_within_a_step():
+    """round(t/dt) is constant across the RK4 stage times of one step."""
+    module = _build_module(True)
+    vf = module.diffeqsolve_quants["terms"].vector_field
+    dt = vf.dt
+    t0 = 17 * dt
+    n_head = np.asarray(vf._draw_noise(t0))
+    # _lawson_rk4 draws once at the step head and passes it to all stages;
+    # verify the head draw is what stages would freeze
+    n_head_again = np.asarray(vf._draw_noise(t0))
+    np.testing.assert_allclose(n_head, n_head_again)
+
+
+def test_noise_drives_kinetic_response():
+    """With noise on, a quiet Maxwellian develops C_1 content; with noise off
+    it stays exactly quiet (no spurious source)."""
+    import jax.numpy as jnp
+
+    out = {}
+    for enabled in (False, True):
+        module = _build_module(enabled)
+        sol = module(None)["solver result"]
+        # default scalar save always exists; the noise drives C_1 -> density
+        # structure -> nonzero Poisson field energy
+        scal = sol.ys["default"]
+        out[enabled] = float(np.nanmax(np.asarray(scal["e_energy"])))
+
+    assert out[False] == 0.0
+    assert out[True] > 0.0

--- a/tests/test_hermite_poisson_1d/test_stochastic_noise.py
+++ b/tests/test_hermite_poisson_1d/test_stochastic_noise.py
@@ -49,8 +49,8 @@ def test_noise_draw_is_deterministic_and_scaled():
     n1_again = np.asarray(vf._draw_noise(1.0))
     n2 = np.asarray(vf._draw_noise(1.1))
 
-    np.testing.assert_allclose(n1, n1_again)          # same t -> same draw
-    assert np.max(np.abs(n1 - n2)) > 0.0              # different step -> different draw
+    np.testing.assert_allclose(n1, n1_again)  # same t -> same draw
+    assert np.max(np.abs(n1 - n2)) > 0.0  # different step -> different draw
     # uniform density -> profile == 1 -> std ~ amplitude (loose bound, Nx=32)
     assert 0.3 * 2.0e-5 < np.std(n1) < 3.0 * 2.0e-5
 

--- a/tests/test_spectrax1d/test_landau_damping.py
+++ b/tests/test_spectrax1d/test_landau_damping.py
@@ -3,18 +3,21 @@
 """
 Tests for spectrax-1d EPW dispersion: real (frequency) and imaginary (damping) parts.
 
-Four cases covering both time integrators and ion mobility:
-  - explicit (Dopri8),          mobile ions
-  - explicit (Dopri8),          static ions
+Three cases covering both time-integrator paths and ion mobility:
   - exponential (Lawson-RK4),   mobile ions
   - exponential (Lawson-RK4),   static ions
+  - explicit (Dopri8),          static ions
+
+(An earlier version of this docstring advertised Dopri8 legs that were never
+actually parametrized — the explicit integrator path went untested for its
+entire history. The Dopri8 leg below closes that gap.)
 
 Each test drives the EPW at its theoretical frequency (randomly chosen klambda_D in
 [0.26, 0.34]) and asserts that the measured frequency and damping rate match the
 electrostatic dispersion relation within 10%.
 
 Static ions do not affect the EPW dispersion: ions are far too heavy to respond at
-electron plasma wave frequencies, so this pair of tests also verifies that the
+electron plasma wave frequencies, so the static/mobile pair also verifies that the
 static_ions flag doesn't break electron dynamics.
 """
 
@@ -87,24 +90,29 @@ def base_cfg():
 
 
 @pytest.mark.parametrize(
-    "static_ions",
-    [False, True],
-    ids=["mobile-ions", "static-ions"],
+    "integrator,static_ions",
+    [
+        ("exponential", False),
+        ("exponential", True),
+        ("Dopri8", True),
+    ],
+    ids=["exponential-mobile-ions", "exponential-static-ions", "dopri8-static-ions"],
 )
-def test_driven_epw_dispersion(base_cfg, static_ions):
+def test_driven_epw_dispersion(base_cfg, integrator, static_ions):
     """Driven EPW frequency and damping rate match the electrostatic dispersion within 10%."""
     klambda_D = np.random.uniform(0.26, 0.34)
 
     base_cfg["physics"]["static_ions"] = static_ions
-    base_cfg["grid"]["integrator"] = "exponential"
-    base_cfg["grid"]["adaptive_time_step"] = False
+    base_cfg["grid"]["integrator"] = integrator
+    if integrator == "exponential":
+        base_cfg["grid"]["adaptive_time_step"] = False
 
     base_cfg["mlflow"]["experiment"] = "test-adept-spectrax1d-epw"
-    base_cfg["mlflow"]["run"] = f"epw1d-exponential-{'static' if static_ions else 'mobile'}-{klambda_D:.3f}"
+    base_cfg["mlflow"]["run"] = f"epw1d-{integrator}-{'static' if static_ions else 'mobile'}-{klambda_D:.3f}"
 
     measured_freq, measured_damp, expected_freq, expected_damp = _run_driven_epw(base_cfg, klambda_D)
 
-    print(f"\nklambda_D={klambda_D:.4f}  integrator=exponential  static_ions={static_ions}")
+    print(f"\nklambda_D={klambda_D:.4f}  integrator={integrator}  static_ions={static_ions}")
     print(
         f"  freq:  measured={measured_freq:.6f}  expected={expected_freq:.6f}"
         f"  err={100 * abs(measured_freq - expected_freq) / expected_freq:.1f}%"

--- a/tests/test_spectrax1d/test_shift_and_lorentz.py
+++ b/tests/test_spectrax1d/test_shift_and_lorentz.py
@@ -1,0 +1,133 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Lock shift_multi's direction semantics and the E-field Lorentz coupling.
+
+These tests exist because shift_multi's docstring once stated the OPPOSITE
+direction mapping. Code transcribed from that wording (rather than from the
+function's behavior) shipped an inverted E·∂_v f term in a downstream solver
+(_hermite_poisson_1d), which produced a spurious low-n instability while a
+uniform E field drove zero current. The probes below pin the actual behavior
+so documentation and code can never silently diverge again.
+
+Physics reference: Parker & Dellar (2015). For the asymmetrically-weighted
+Hermite basis, ∂φ_m/∂v = −√(2(m+1)) φ_{m+1} (differentiation raises the
+index), so the projection of (q/m)E·∂_v f onto mode n draws from mode n−1:
+
+    dC_n/dt|E = +(q/m)·√(2n)/α · E · C_{n−1}
+
+The convention-independent acid test: a uniform E applied to a pure
+Maxwellian (only C_0 ≠ 0) must drive current, dC_1/dt = (q/m)·√2/α·E·C_0,
+and must excite no other mode.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+
+from adept._spectrax1d.hermite_fourier_ode import HermiteFourierODE
+
+
+def _make_ode(Nn: int = 6, Nm: int = 1, Np: int = 1, Nx: int = 8) -> HermiteFourierODE:
+    """Minimal 1D-in-x HermiteFourierODE for unit probes."""
+    Lx = 2.0 * np.pi
+    kx_1d = jnp.fft.fftfreq(Nx) * Nx * 2 * jnp.pi / Lx
+    kx_grid = kx_1d[None, :, None]  # (Ny, Nx, Nz) = (1, Nx, 1)
+    zeros_grid = jnp.zeros_like(kx_grid)
+    n = jnp.arange(Nn, dtype=jnp.float64)
+    m = jnp.arange(Nm, dtype=jnp.float64)
+    p = jnp.arange(Np, dtype=jnp.float64)
+    return HermiteFourierODE(
+        Nn=Nn,
+        Nm=Nm,
+        Np=Np,
+        Nx=Nx,
+        kx_grid=kx_grid,
+        ky_grid=zeros_grid,
+        kz_grid=zeros_grid,
+        k2_grid=kx_grid**2,
+        Lx=Lx,
+        Ly=1.0,
+        Lz=1.0,
+        col=jnp.zeros((Np, Nm, Nn)),
+        sqrt_n_plus=jnp.sqrt(n + 1.0),
+        sqrt_n_minus=jnp.sqrt(n),
+        sqrt_m_plus=jnp.sqrt(m + 1.0),
+        sqrt_m_minus=jnp.sqrt(m),
+        sqrt_p_plus=jnp.sqrt(p + 1.0),
+        sqrt_p_minus=jnp.sqrt(p),
+        mask23=jnp.ones((1, Nx, 1)),
+    )
+
+
+def test_shift_multi_direction_semantics():
+    """dn=+1 → result[n] = C[n+1]; dn=−1 → result[n] = C[n−1]; dn=0 → identity."""
+    ode = _make_ode(Nn=4, Nx=2)
+    vals = jnp.array([10.0, 20.0, 30.0, 40.0])
+    C = jnp.zeros((1, 1, 4, 1, 2, 1)).at[0, 0, :, 0, 0, 0].set(vals)
+
+    up = np.asarray(ode.shift_multi(C, dn=+1)[0, 0, :, 0, 0, 0])
+    down = np.asarray(ode.shift_multi(C, dn=-1)[0, 0, :, 0, 0, 0])
+    same = np.asarray(ode.shift_multi(C, dn=0)[0, 0, :, 0, 0, 0])
+
+    np.testing.assert_allclose(up, [20.0, 30.0, 40.0, 0.0])  # source at n+1
+    np.testing.assert_allclose(down, [0.0, 10.0, 20.0, 30.0])  # source at n-1
+    np.testing.assert_allclose(same, [10.0, 20.0, 30.0, 40.0])
+
+
+def test_uniform_E_on_maxwellian_drives_current():
+    """Uniform E_x on a Maxwellian responds ONLY at n=1 with (q/m)·√2/α·E·C_0."""
+    Nn, Nx = 6, 8
+    ode = _make_ode(Nn=Nn, Nx=Nx)
+
+    c0 = 0.7
+    E0 = 0.3
+    alpha = jnp.array([1.3, 1.0, 1.0])
+    u = jnp.zeros(3)
+    q, m_s, Omega = -1.0, 1.0, 1.0
+
+    # Real-space state: Maxwellian (C_0 = c0 everywhere), all higher modes zero
+    C = jnp.zeros((1, 1, Nn, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, 0].set(c0)
+    # Uniform E_x; all other field components zero
+    F = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0].set(E0)
+
+    dCk = ode._compute_lorentz_rhs(C=C, F=F, alpha=alpha, u=u, q=q, Omega_ce_tau=Omega, m=m_s)
+    dCk = np.asarray(dCk)
+
+    # fftn(norm="forward") of a uniform field puts the value in the k=0 bin
+    expected_c1 = (q / m_s) * Omega * np.sqrt(2.0) / float(alpha[0]) * E0 * c0
+    np.testing.assert_allclose(dCk[0, 0, 1, 0, 0, 0].real, expected_c1, rtol=1e-12)
+
+    # No response anywhere else (in particular: n=0 must be untouched —
+    # the force term must not alter density)
+    mask = np.ones_like(dCk, dtype=bool)
+    mask[0, 0, 1, 0, 0, 0] = False
+    assert np.max(np.abs(dCk[mask])) < 1e-14
+
+
+def test_force_ladder_is_one_sided_upward():
+    """Seeding only C_2 must excite only C_3 (coefficient √(2·3)/α): the AW
+    force term couples n−1 → n and nothing else."""
+    Nn, Nx = 6, 8
+    ode = _make_ode(Nn=Nn, Nx=Nx)
+
+    c2 = 0.4
+    E0 = 0.25
+    alpha = jnp.array([0.9, 1.0, 1.0])
+    q, m_s, Omega = -1.0, 1.0, 1.0
+
+    C = jnp.zeros((1, 1, Nn, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, 2].set(c2)
+    F = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0].set(E0)
+
+    dCk = np.asarray(
+        ode._compute_lorentz_rhs(C=C, F=F, alpha=alpha, u=jnp.zeros(3), q=q, Omega_ce_tau=Omega, m=m_s)
+    )
+
+    expected_c3 = (q / m_s) * Omega * np.sqrt(2.0 * 3.0) / float(alpha[0]) * E0 * c2
+    np.testing.assert_allclose(dCk[0, 0, 3, 0, 0, 0].real, expected_c3, rtol=1e-12)
+
+    mask = np.ones_like(dCk, dtype=bool)
+    mask[0, 0, 3, 0, 0, 0] = False
+    assert np.max(np.abs(dCk[mask])) < 1e-14

--- a/tests/test_spectrax1d/test_shift_and_lorentz.py
+++ b/tests/test_spectrax1d/test_shift_and_lorentz.py
@@ -121,9 +121,7 @@ def test_force_ladder_is_one_sided_upward():
     C = jnp.zeros((1, 1, Nn, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, 2].set(c2)
     F = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0].set(E0)
 
-    dCk = np.asarray(
-        ode._compute_lorentz_rhs(C=C, F=F, alpha=alpha, u=jnp.zeros(3), q=q, Omega_ce_tau=Omega, m=m_s)
-    )
+    dCk = np.asarray(ode._compute_lorentz_rhs(C=C, F=F, alpha=alpha, u=jnp.zeros(3), q=q, Omega_ce_tau=Omega, m=m_s))
 
     expected_c3 = (q / m_s) * Omega * np.sqrt(2.0 * 3.0) / float(alpha[0]) * E0 * c2
     np.testing.assert_allclose(dCk[0, 0, 3, 0, 0, 0].real, expected_c3, rtol=1e-12)


### PR DESCRIPTION
## Summary

- Adds `adept/_hermite_poisson_1d/` — a native 2D `(Nn, Nx)` Hermite-Poisson solver that avoids the 6D Spectrax tensor overhead for strictly 1D problems
- New `BaseHermitePoisson1D(ADEPTModule)` base class with Lawson-RK4 integration, WaveSolver for the vector potential, PoissonSolver1D for electrostatics, and sponge boundary support
- Eigendecomposition-based free-streaming exponential (`FreeStreamingExp1D`) directly on 2D `(Nn, Nx)` arrays instead of the full 6D spectrax machinery
- Exposes `adept.hermite_poisson_1d.BaseHermitePoisson1D` as a clean public API

## Motivation

The existing Spectrax-1D path runs with 6D tensors `(Np=1, Nm=1, Nn, Ny=1, Nx, Nz=1)` even for degenerate 1D problems. This new module eliminates the degenerate-axis overhead, which is significant at large `Nx` (e.g. 20k spatial cells × 64+ Hermite modes).

## Test plan

- [ ] `uv run python -c "from adept.hermite_poisson_1d import BaseHermitePoisson1D"` passes
- [ ] Downstream SRS solver (`kinetic_srs/hermite_poisson.py`) subclasses `BaseHermitePoisson1D` and imports cleanly
- [ ] Minimal forward-pass test pending (to be added in follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)