### PR TITLE
feat(vlasov1d): support asymmetric velocity grids (vmin != -vmax)

### DIFF
--- a/adept/_vlasov1d/datamodel.py
+++ b/adept/_vlasov1d/datamodel.py
@@ -69,6 +69,7 @@ class GridConfig(BaseModel):
     xmin: float | str
     nv: int | None = None
     vmax: float | None = None
+    vmin: float | None = None
     parallel: tuple[str, ...] | bool = False
     c_light: float | None = None
 
@@ -175,6 +176,7 @@ class SpeciesConfig(BaseModel):
     charge: float
     mass: float
     vmax: float
+    vmin: float | None = None
     nv: int
     density_components: list[str]
 

--- a/adept/_vlasov1d/helpers.py
+++ b/adept/_vlasov1d/helpers.py
@@ -42,6 +42,7 @@ def _initialize_supergaussian_distribution_(
     T0=1.0,
     mass=1.0,
     vmax=6.0,
+    vmin=None,
     n_prof=np.ones(1),
 ):
     """
@@ -56,14 +57,17 @@ def _initialize_supergaussian_distribution_(
         supergaussian_order: order of supergaussian (2 = Maxwell-Boltzmann)
         T0: temperature
         mass: species mass for thermal velocity calculation
-        vmax: maximum absolute value of v
+        vmax: upper bound of the velocity grid
+        vmin: lower bound of the velocity grid (defaults to ``-vmax``)
         n_prof: density profile (noise should already be applied)
 
     Returns:
         Tuple of (f[nx, nv], vax[nv])
     """
-    dv = 2.0 * vmax / nv
-    vax = np.linspace(-vmax + dv / 2.0, vmax - dv / 2.0, nv)
+    if vmin is None:
+        vmin = -vmax
+    dv = (vmax - vmin) / nv
+    vax = np.linspace(vmin + dv / 2.0, vmax - dv / 2.0, nv)
 
     # Thermal velocity: v_t = sqrt(T/m)
     v_thermal = np.sqrt(T0 / mass)
@@ -115,13 +119,14 @@ def _initialize_total_distribution_(cfg, simulation: Vlasov1DSimulation):
         species_name = species_cfg.name
         density_components = species_distribution_specs[species_name]
         vmax = species_cfg.vmax
+        vmin = species_cfg.vmin
         nv = species_cfg.nv
         mass = species_cfg.mass
 
         # Initialize arrays for this species
         n_prof_species = np.zeros([grid.nx])
-        dv = 2.0 * vmax / nv
-        vax = np.linspace(-vmax + dv / 2.0, vmax - dv / 2.0, nv)
+        dv = (vmax - vmin) / nv
+        vax = np.linspace(vmin + dv / 2.0, vmax - dv / 2.0, nv)
         f_species = np.zeros([grid.nx, nv])
 
         # Sum contributions from all density components
@@ -139,6 +144,7 @@ def _initialize_total_distribution_(cfg, simulation: Vlasov1DSimulation):
                 T0=distribution_spec.T0,
                 mass=mass,
                 vmax=vmax,
+                vmin=vmin,
                 n_prof=nprof,
             )
             f_species += temp_f

--- a/adept/_vlasov1d/modules.py
+++ b/adept/_vlasov1d/modules.py
@@ -40,6 +40,7 @@ def species_set_from_config(cfg: Vlasov1DConfig) -> list[Species]:
                     charge=-1.0,
                     mass=1.0,
                     vmax=cfg.grid.vmax,
+                    vmin=cfg.grid.vmin,
                     nv=cfg.grid.nv,
                     density_components=density_components,
                 )
@@ -211,8 +212,9 @@ class BaseVlasov1D(ADEPTModule):
 
             nv = species_cfg.nv
             vmax = species_cfg.vmax
+            vmin = species_cfg.vmin
 
-            dv = 2.0 * vmax / nv
+            dv = (vmax - vmin) / nv
 
             # Build velocity grid parameters for this species
             cfg_grid["species_grids"][species_name] = {
@@ -220,6 +222,7 @@ class BaseVlasov1D(ADEPTModule):
                 "dv": dv,
                 "nv": nv,
                 "vmax": vmax,
+                "vmin": vmin,
                 "kv": jnp.fft.fftfreq(nv, d=dv) * 2.0 * np.pi,
                 "kvr": jnp.fft.rfftfreq(nv, d=dv) * 2.0 * np.pi,
             }

--- a/adept/_vlasov1d/simulation.py
+++ b/adept/_vlasov1d/simulation.py
@@ -111,17 +111,25 @@ class Species(eqx.Module):
     mass: float
     charge: float
     vmax: float
+    vmin: float
     nv: int
     density_components: list[str]
 
     @staticmethod
     def from_config(cfg: SpeciesConfig) -> "Species":
-        """Convert a species config into the immutable simulation species model."""
+        """Convert a species config into the immutable simulation species model.
+
+        ``vmin`` defaults to ``-vmax`` (the historical symmetric velocity grid)
+        when it is not specified in the config.
+        """
+        vmax = float(cfg.vmax)
+        vmin = float(cfg.vmin) if cfg.vmin is not None else -vmax
         return Species(
             name=cfg.name,
             mass=float(cfg.mass),
             charge=float(cfg.charge),
-            vmax=float(cfg.vmax),
+            vmax=vmax,
+            vmin=vmin,
             nv=int(cfg.nv),
             density_components=cfg.density_components,
         )

--- a/docs/source/solvers/vlasov1d/config.md
+++ b/docs/source/solvers/vlasov1d/config.md
@@ -162,12 +162,15 @@ Simulation grid parameters.
 | `nx` | int | Number of spatial grid points |
 | `tmin` | float | Start time |
 | `tmax` | float | End time |
-| `vmax` | float | Maximum velocity extent (not needed for multispecies) |
+| `vmax` | float | Upper bound of the velocity grid (not needed for multispecies) |
+| `vmin` | float | Lower bound of the velocity grid. Optional; defaults to `-vmax` (symmetric grid). Use to specify an asymmetric velocity extent (not needed for multispecies). |
 | `xmin` | float | Domain minimum x |
 | `xmax` | float | Domain maximum x |
 | `parallel` | `false` or list of `"x"`, `"v"` | Axes to parallelize across devices using `jax.shard_map`. `"x"` shards the `edfdv` push and collision operator along the spatial axis; `"v"` shards the `vdfdx` push along the velocity axis. Requires the corresponding dimension (`nx` or `nv`) to be divisible by the number of JAX devices. Defaults to `false`. |
 
-**Note:** For multispecies simulations, `nv` and `vmax` are defined per-species in `terms.species` and the global values are not used.
+The velocity grid is uniform and cell-centered: `dv = (vmax - vmin) / nv` with cell centers spanning `vmin + dv/2` to `vmax - dv/2`. An asymmetric grid (`vmin != -vmax`) is useful, for example, for a bump-on-tail distribution where less resolution is needed on one side. As with `vmax`, choose bounds wide enough that `f ~ 0` at *both* edges so that the spectral velocity push and the zero-flux collision boundary conditions remain accurate.
+
+**Note:** For multispecies simulations, `nv`, `vmax`, and `vmin` are defined per-species in `terms.species` and the global values are not used.
 
 Example:
 ```yaml
@@ -402,13 +405,14 @@ For multispecies simulations, you can define multiple particle species (e.g., el
 | `name` | string | Species identifier (e.g., `"electron"`, `"ion"`) |
 | `charge` | float | Charge in units of fundamental charge (e.g., `-1.0` for electrons, `10.0` for Z=10 ions) |
 | `mass` | float | Mass in units of electron mass (e.g., `1.0` for electrons, `1836.0` for protons) |
-| `vmax` | float | Maximum velocity extent for this species |
+| `vmax` | float | Upper bound of the velocity grid for this species |
+| `vmin` | float | Lower bound of the velocity grid for this species. Optional; defaults to `-vmax` (symmetric grid) |
 | `nv` | int | Number of velocity grid points for this species |
 | `density_components` | list | List of density component names (from `density` section) that belong to this species |
 
 **Important notes:**
 
-- Each species can have its own velocity grid parameters (`vmax`, `nv`), allowing heavier species to use smaller velocity extents
+- Each species can have its own velocity grid parameters (`vmax`, `vmin`, `nv`), allowing heavier species to use smaller velocity extents or asymmetric velocity bounds
 - The `density_components` field maps species to their density profiles defined in the `density` section
 - For single-species simulations, `terms.species` can be omitted; a default electron species will be auto-generated from the `grid.vmax`, `grid.nv`, and all `species-*` density components
 - When using multispecies, `grid.vmax` and `grid.nv` are not used (each species defines its own)

--- a/tests/test_vlasov1d/test_asymmetric_velocity_grid.py
+++ b/tests/test_vlasov1d/test_asymmetric_velocity_grid.py
@@ -1,0 +1,162 @@
+"""Tests for asymmetric velocity grids (vmin != -vmax) in Vlasov-1D."""
+
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import yaml
+from jax import numpy as jnp
+
+from adept._vlasov1d.modules import BaseVlasov1D
+
+
+def _load(config_name: str) -> dict:
+    config_path = Path(__file__).parent / "configs" / config_name
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def _build(config_dict: dict) -> BaseVlasov1D:
+    module = BaseVlasov1D(config_dict)
+    module.write_units()
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    return module
+
+
+def _assert_grid(species_grid: dict, vmin: float, vmax: float, nv: int) -> None:
+    """Check a species velocity grid is the expected cell-centered, asymmetric grid."""
+    dv = (vmax - vmin) / nv
+    v = np.asarray(species_grid["v"])
+
+    assert species_grid["nv"] == nv
+    assert np.isclose(species_grid["vmin"], vmin)
+    assert np.isclose(species_grid["vmax"], vmax)
+    assert np.isclose(species_grid["dv"], dv)
+    assert len(v) == nv
+    # Cell-centered grid: first/last cell centers are half a cell inside the bounds
+    assert np.isclose(v[0], vmin + dv / 2.0)
+    assert np.isclose(v[-1], vmax - dv / 2.0)
+    # Uniform spacing
+    assert np.allclose(np.diff(v), dv)
+
+
+def test_single_species_asymmetric_grid():
+    """Grid-level vmin/vmax produces an asymmetric electron velocity grid."""
+    config_dict = _load("resonance.yaml")
+    config_dict["grid"]["vmin"] = -4.0
+    config_dict["grid"]["vmax"] = 8.0
+    nv = config_dict["grid"]["nv"]
+
+    module = _build(config_dict)
+
+    electron_grid = module.cfg["grid"]["species_grids"]["electron"]
+    _assert_grid(electron_grid, vmin=-4.0, vmax=8.0, nv=nv)
+
+    # The single-species top-level convenience grid matches the species grid
+    np.testing.assert_allclose(np.asarray(module.cfg["grid"]["v"]), np.asarray(electron_grid["v"]))
+
+
+def test_single_species_defaults_to_symmetric():
+    """Omitting vmin reproduces the historical symmetric grid (vmin == -vmax)."""
+    config_dict = _load("resonance.yaml")
+    config_dict["grid"].pop("vmin", None)
+    vmax = config_dict["grid"]["vmax"]
+    nv = config_dict["grid"]["nv"]
+
+    module = _build(config_dict)
+
+    electron_grid = module.cfg["grid"]["species_grids"]["electron"]
+    _assert_grid(electron_grid, vmin=-vmax, vmax=vmax, nv=nv)
+
+
+def test_multispecies_asymmetric_grid():
+    """Per-species vmin overrides the default symmetric grid for that species only."""
+    config_dict = _load("multispecies_ion_acoustic.yaml")
+    species = config_dict["terms"]["species"]
+    electron_cfg = next(s for s in species if s["name"] == "electron")
+    ion_cfg = next(s for s in species if s["name"] == "ion")
+
+    # Asymmetric electron grid; ion left symmetric (no vmin key)
+    electron_cfg["vmin"] = -3.0
+    electron_cfg["vmax"] = 9.0
+
+    module = _build(config_dict)
+
+    species_grids = module.cfg["grid"]["species_grids"]
+    _assert_grid(species_grids["electron"], vmin=-3.0, vmax=9.0, nv=electron_cfg["nv"])
+    # Ion falls back to the symmetric default
+    _assert_grid(species_grids["ion"], vmin=-ion_cfg["vmax"], vmax=ion_cfg["vmax"], nv=ion_cfg["nv"])
+
+
+def test_asymmetric_grid_distribution_is_normalized():
+    """An asymmetric grid wide enough to contain the bulk still integrates to ~density."""
+    config_dict = _load("resonance.yaml")
+    config_dict["grid"]["vmin"] = -5.0
+    config_dict["grid"]["vmax"] = 10.0
+
+    module = _build(config_dict)
+
+    electron_grid = module.cfg["grid"]["species_grids"]["electron"]
+    f = np.asarray(module.state["electron"])
+    dv = electron_grid["dv"]
+    density = f.sum(axis=1) * dv
+    # Background density is uniform and normalized to 1
+    np.testing.assert_allclose(density, 1.0, rtol=1e-3)
+
+
+def test_collisions_conserve_density_on_asymmetric_grid():
+    """Fokker-Planck + Krook collisions run and conserve density on an asymmetric grid.
+
+    The zero-flux boundary conditions of the drift-diffusion scheme conserve density
+    independent of where vmin/vmax sit, provided the grid brackets the bulk so that
+    f ~ 0 at both edges. resonance.yaml has both fokker_planck and krook enabled.
+    """
+    from adept._vlasov1d.solvers.pushers.fokker_planck import Collisions
+
+    config_dict = _load("resonance.yaml")
+    # Asymmetric but still wide enough to contain the v0=0, T0=1 bulk at both edges
+    config_dict["grid"]["vmin"] = -5.0
+    config_dict["grid"]["vmax"] = 8.0
+
+    module = _build(config_dict)
+    cfg = module.cfg
+    dv = cfg["grid"]["species_grids"]["electron"]["dv"]
+    f0 = np.asarray(module.state["electron"])
+
+    collisions = Collisions(cfg)
+    nx = f0.shape[0]
+    nu = jnp.ones(nx)
+    dt = cfg["grid"]["dt"]
+
+    f1 = np.asarray(collisions(nu, nu, jnp.asarray(f0), dt))
+
+    assert np.all(np.isfinite(f1))
+    # Density (zeroth moment) is conserved by the collision operators
+    np.testing.assert_allclose(f1.sum(axis=1) * dv, f0.sum(axis=1) * dv, rtol=1e-6)
+
+
+def test_cubic_spline_accepts_asymmetric_grid():
+    """The cubic-spline edfdv pusher runs on an asymmetric velocity grid."""
+    config_dict = deepcopy(_load("resonance.yaml"))
+    config_dict["grid"]["vmin"] = -4.0
+    config_dict["grid"]["vmax"] = 8.0
+    config_dict["terms"]["edfdv"] = "cubic-spline"
+
+    module = _build(config_dict)
+
+    # State builds and the velocity grid is the requested asymmetric one
+    electron_grid = module.cfg["grid"]["species_grids"]["electron"]
+    _assert_grid(electron_grid, vmin=-4.0, vmax=8.0, nv=config_dict["grid"]["nv"])
+    assert module.state["electron"].shape == (config_dict["grid"]["nx"], config_dict["grid"]["nv"])
+
+
+if __name__ == "__main__":
+    test_single_species_asymmetric_grid()
+    test_single_species_defaults_to_symmetric()
+    test_multispecies_asymmetric_grid()
+    test_asymmetric_grid_distribution_is_normalized()
+    test_collisions_conserve_density_on_asymmetric_grid()
+    test_cubic_spline_accepts_asymmetric_grid()
+    print("All asymmetric velocity grid tests passed!")


### PR DESCRIPTION
## Summary

Adds support for **asymmetric velocity grids** in the Vlasov-1D solver. Previously the velocity grid was always symmetric (`vmin = -vmax`, `dv = 2*vmax/nv`, spanning `[-vmax, vmax]`). You can now specify an independent `vmin`.

This is useful, for example, for bump-on-tail problems where the interesting physics lives on the positive tail and less resolution is needed on the negative side.

## What changed

- **`grid.vmin`** — optional, for single-species (auto-generated electron) runs.
- **`terms.species[].vmin`** — optional, per-species for multispecies runs.
- In both cases `vmin` defaults to `-vmax`, so **existing configs are unchanged**.

The grid stays **uniform and cell-centered**: `dv = (vmax - vmin) / nv`, with cell centers spanning `vmin + dv/2 … vmax - dv/2`.

### Why nothing downstream needed changing

- **Spectral velocity push** (`VelocityExponential`) uses `kvr = rfftfreq(nv, dv)` — depends only on `dv`/`nv`, and the push is a translation in `v`, so it is offset-invariant.
- **Cubic-spline push** (`VelocityCubicSpline`) interpolates `f` on the actual `v` array (out-of-bounds → ~0), so it is grid-agnostic.
- **Moments / field solve** use the actual `v` array and `dv`.
- **Collision operators** (Lenard-Bernstein, Dougherty, Chang-Cooper, Krook, and the self-consistent-β machinery) use the actual `v`/`dv`, edge velocities `0.5*(v[1:]+v[:-1])`, density-normalized moments, and **true zero-flux boundary conditions** — so density is conserved regardless of where `vmin`/`vmax` sit. Krook's Maxwellian target stays centered at `v=0` and is normalized over the actual grid.

The only constraint is physical and identical to today: choose bounds wide enough that `f ~ 0` at **both** edges.

## Files

- `adept/_vlasov1d/datamodel.py` — `vmin` on `GridConfig` and `SpeciesConfig`
- `adept/_vlasov1d/simulation.py` — `Species.vmin` (defaults to `-vmax`)
- `adept/_vlasov1d/modules.py` — thread `vmin` through; `dv = (vmax - vmin)/nv`; store `vmin` in `species_grids`
- `adept/_vlasov1d/helpers.py` — build asymmetric cell-centered `vax`
- `docs/source/solvers/vlasov1d/config.md` — document `vmin`
- `tests/test_vlasov1d/test_asymmetric_velocity_grid.py` — new

## Tests

New tests cover: single-species asymmetric grid, backward-compat default (`vmin = -vmax`), per-species asymmetric grid in multispecies, distribution normalization, **collision-operator density conservation on an asymmetric grid**, and the cubic-spline path.

`tests/test_vlasov1d/test_asymmetric_velocity_grid.py` — 6 passed. Existing config/init/collision regression tests — 29 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)