### PR TITLE
fix(driftdiffusion): grad-safe chang_cooper_delta at w=0

### DIFF
--- a/adept/driftdiffusion.py
+++ b/adept/driftdiffusion.py
@@ -93,8 +93,12 @@ def chang_cooper_delta(w: Array) -> Array:
         Delta weighting factors, same shape as w
     """
     small = jnp.abs(w) < 1.0e-8
+    # Grad-safety (double-where): feed the full branch a nonzero w wherever `small`, so its
+    # 1/w and 1/expm1(w) singularities at w=0 don't poison the gradient through jnp.where.
+    # Value is unchanged (full branch is masked out where small); only the NaN grad is fixed.
+    w_safe = jnp.where(small, 1.0, w)
     delta_small = 0.5 - w / 12.0 + w**3 / 720.0
-    delta_full = 1.0 / w - 1.0 / jnp.expm1(w)
+    delta_full = 1.0 / w_safe - 1.0 / jnp.expm1(w_safe)
     return jnp.where(small, delta_small, delta_full)
 
 


### PR DESCRIPTION
## What
Make `chang_cooper_delta` in `adept/driftdiffusion.py` gradient-safe at `w = 0`.

## Why
`delta(w) = 1/w - 1/(exp(w)-1)` is computed as
`jnp.where(|w| < eps, taylor(w), 1/w - 1/expm1(w))`. The full branch is singular at
`w = 0`; `jnp.where` returns the correct **value** (the Taylor branch is selected there),
but its **gradient** flows through *both* arms, so the `NaN`/`inf` from the unused singular
branch poisons it — the classic `jnp.where` double-gradient pitfall.

`w = C_edge·dv/D` is exactly zero wherever the drift `C_edge` vanishes: the entire
Maxwellian-equilibrium tail, and **everywhere** when the operator is pure diffusion (`C = 0`).
So the Chang–Cooper scheme was **non-differentiable at equilibrium**, which breaks
`value_and_grad` through any learned / optimized Fokker–Planck operator built on it.

## Fix
Standard "double where": feed the full branch a safe nonzero `w` wherever `small`, so `1/w`
and `1/expm1(w)` never enter the graph at `w = 0`. The returned **value is unchanged** (the
full branch is masked out where `small`); only the spurious `NaN` gradient is removed.

## Test
`jax.grad` through a Chang–Cooper drift–diffusion solve (a learned velocity-space closure)
returned `NaN` w.r.t. the operator's shape parameters before this change and **finite**
gradients after. Forward value and density conservation (~1e-16 in float64) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)