### PR TITLE
fix(hermite-poisson-1d): ponderomotive force is charge-sign independent (q²/m²)

### DIFF
--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -352,9 +352,13 @@ def _hermite_e_coupling(
 
     Args:
         Ck: (Nn, Nx) complex, in k-space.
-        F_total: (Nx,) real, total force field (Ex + ponderomotive).
+        F_total: (Nx,) real, force field. CONTRACT: q_over_m * F_total must be
+            the species ACCELERATION. E-field terms may be passed bare with
+            q_over_m=q/m, but the ponderomotive term is ∝ q²/m² (charge-sign
+            independent) and must be pre-composed by the caller — pass
+            accel = (q/m)·E + (q/m)²·pond with q_over_m=1 (see _nonlinear_rhs).
         sqrt_n_minus: (Nn,) = sqrt([0,1,...,Nn-1]).
-        q_over_m: Charge-to-mass ratio (e.g. -1 for electrons).
+        q_over_m: Charge-to-mass ratio applied as an overall factor.
         alpha: Thermal velocity.
         Omega_ce_tau: Normalization constant (1.0 in current configs).
         mask23: Optional (Nx,) bool 2/3-rule dealiasing mask in FFT ordering.
@@ -497,16 +501,25 @@ class HermitePoisson1DVectorField:
         # driver's time variation within the step (same as vlasov1d's dex_array).
         Edrive = self.ex_driver(t, args)  # (Nx,)
 
-        # Ponderomotive force: -0.5 * d(a^2)/dx  (on electrons)
+        # Ponderomotive force per unit charge²/mass: -0.5 * d(a^2)/dx.
+        # This term is ∝ q²/m² — charge-sign INDEPENDENT. It must NOT be folded
+        # under the q/m factor that multiplies the E-field terms: doing so flips
+        # its sign for electrons, which flips the sign of one leg of the SRS
+        # three-wave coupling (γ² ∝ product of legs) — Stokes backscatter becomes
+        # structurally stable (no SRS, ever) while the normally-stable anti-Stokes
+        # pair goes unstable and detonates. Reference: vlasov1d does this
+        # correctly (solvers/pushers/vlasov.py: force = q*e + (q²/m)*pond).
         a_sq = a_frozen**2
         Fp = -0.5 * jnp.gradient(a_sq, self.dx)  # (Nx,)
 
-        # Electron E-field + ponderomotive + external Ex driver (+ stochastic force noise)
+        # Per-species acceleration: (q/m)·(Ex + Edrive + noise) + (q/m)²·Fp,
+        # passed with q_over_m=1 so the coupling applies no further charge factor.
+        accel_e = self.qm_e * (Ex + Edrive + noise_frozen) + self.qm_e**2 * Fp
         dCk_e = _hermite_e_coupling(
             Ck_e,
-            Ex + Fp + Edrive + noise_frozen,
+            accel_e,
             self.sqrt_n_minus_e,
-            self.qm_e,
+            1.0,
             self.alpha_e,
             self.Omega_ce_tau,
             mask23=self.mask23,
@@ -515,11 +528,13 @@ class HermitePoisson1DVectorField:
         if self.static_ions:
             dCk_i = jnp.zeros_like(state["Ck_ions"])
         else:
+            # Ion ponderomotive is (q/m)² = 1/mi_me² — kept for correctness, negligible.
+            accel_i = self.qm_i * (Ex + Edrive + noise_frozen) + self.qm_i**2 * Fp
             dCk_i = _hermite_e_coupling(
                 Ck_i,
-                Ex + Edrive + noise_frozen,  # ponderomotive negligible for ions
+                accel_i,
                 self.sqrt_n_minus_i,
-                self.qm_i,
+                1.0,
                 self.alpha_i,
                 self.Omega_ce_tau,
                 mask23=self.mask23,

--- a/tests/test_hermite_poisson_1d/test_ponderomotive.py
+++ b/tests/test_hermite_poisson_1d/test_ponderomotive.py
@@ -1,0 +1,193 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Regression tests for the ponderomotive force sign in the HP force assembly.
+
+Regression context: _nonlinear_rhs originally computed Fp = -0.5*d(a²)/dx and
+passed Ex + Fp into _hermite_e_coupling, which multiplies the WHOLE sum by
+q/m (= -1 for electrons). But the ponderomotive acceleration is ∝ q²/m² —
+charge-sign independent — so folding it under q/m flipped its sign for
+electrons: acceleration = -Ex + ½∂x(a²) instead of -Ex - ½∂x(a²).
+
+The E-field leg passed every dispersion/Landau test (those never exercise a),
+while the sign flip inverted one leg of the SRS three-wave coupling
+(γ² ∝ product of both legs): Stokes backscatter had γ² < 0 (SRS structurally
+forbidden in every run) and the normally-stable anti-Stokes pair had γ² > 0.
+In the homogeneous 0.2 n_c / 3 keV bisection campaign the observed detonating
+electrostatic mode sat at k = 0.49 c/ωp0 — anti-Stokes matching
+ω_em = ω0 + ω_BG(k), k_em = k0 + k closes at k = 0.4919, within one spectral
+bin, while Stokes matching was 14% off.
+
+Ground truth for the force assembly is the vlasov1d reference
+(solvers/pushers/vlasov.py): force = q*e + (q²/m)*pond, accel = force/m.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+
+from adept._hermite_poisson_1d.vector_field import (
+    HermitePoisson1DVectorField,
+    LongitudinalElectricFieldDriver,
+    PoissonSolver1D,
+)
+
+
+def _make_vf(Nn, Nx, Lx, alpha_e, alpha_i, mi_me, static_ions, static_ion_density):
+    """Minimal vector field: only the pieces _nonlinear_rhs touches are real."""
+    x = jnp.linspace(0.0, Lx, Nx, endpoint=False)
+    kx = 2.0 * jnp.pi * jnp.fft.fftfreq(Nx) * Nx / Lx
+    one_over_kx = jnp.where(kx != 0.0, 1.0 / jnp.where(kx != 0.0, kx, 1.0), 0.0)
+
+    poisson = PoissonSolver1D(
+        one_over_kx=one_over_kx,
+        alpha_e=alpha_e,
+        alpha_i=alpha_i,
+        static_ion_density=static_ion_density,
+    )
+    n = jnp.arange(Nn, dtype=jnp.float64)
+    return HermitePoisson1DVectorField(
+        combined_exp=None,
+        poisson=poisson,
+        wave_solver=None,
+        ey_driver=None,
+        ex_driver=LongitudinalElectricFieldDriver(x, {}),
+        sqrt_n_minus_e=jnp.sqrt(n),
+        sqrt_n_minus_i=jnp.sqrt(n),
+        alpha_e=alpha_e,
+        alpha_i=alpha_i,
+        q_e=-1.0,
+        q_i=1.0,
+        mi_me=mi_me,
+        Omega_ce_tau=1.0,
+        dx=Lx / Nx,
+        dt=0.1,
+        static_ions=static_ions,
+    )
+
+
+def _maxwellian_state(Nn, Nx, n0, alpha_e, alpha_i):
+    """Uniform Maxwellians for both species (only C_0 ≠ 0), density n0."""
+    Ck_e = jnp.zeros((Nn, Nx), dtype=jnp.complex128).at[0, 0].set(n0 / alpha_e**3)
+    Ck_i = jnp.zeros((Nn, Nx), dtype=jnp.complex128).at[0, 0].set(n0 / alpha_i**3)
+    return {"Ck_electrons": Ck_e.view(jnp.float64), "Ck_ions": Ck_i.view(jnp.float64)}
+
+
+def test_electron_ponderomotive_sign_and_value():
+    """Static a(x) bump on a uniform Maxwellian (Ex = 0): the ONLY force is
+    ponderomotive, and the electron momentum response must be
+
+        dC_1/dt = √2/α_e · (-½ ∂x a²) · C_0
+
+    i.e. electrons are pushed DOWN the intensity gradient, independent of
+    their charge sign. The pre-fix code returned exactly the opposite sign
+    (ponderomotive folded under q/m = -1)."""
+    Nn, Nx, Lx = 8, 64, 2.0 * jnp.pi
+    alpha_e, alpha_i, n0 = 1.3, 0.05, 0.7
+    dx = Lx / Nx
+
+    vf = _make_vf(
+        Nn,
+        Nx,
+        Lx,
+        alpha_e,
+        alpha_i,
+        mi_me=1836.0,
+        static_ions=True,
+        static_ion_density=n0 * jnp.ones(Nx),
+    )
+    state = _maxwellian_state(Nn, Nx, n0, alpha_e, alpha_i)
+
+    x = np.linspace(0.0, Lx, Nx, endpoint=False)
+    a_frozen = jnp.asarray(0.3 * np.sin(x))
+
+    out = vf._nonlinear_rhs(0.0, state, a_frozen, {})
+    dC_e = np.fft.ifft(np.asarray(out["Ck_electrons"]).view(np.complex128), axis=-1) * Nx
+
+    Fp = np.asarray(-0.5 * jnp.gradient(a_frozen**2, dx))
+    expected_c1 = np.sqrt(2.0) / alpha_e * Fp * (n0 / alpha_e**3)
+
+    np.testing.assert_allclose(dC_e[1].real, expected_c1, rtol=1e-12, atol=1e-15)
+
+    # Only the momentum mode responds (force ladder feeds n=1 from n=0)
+    mask = np.ones(Nn, dtype=bool)
+    mask[1] = False
+    assert np.max(np.abs(dC_e[mask])) < 1e-14
+
+
+def test_ponderomotive_is_charge_sign_independent():
+    """Mobile ions with q = +1: the ponderomotive response must have the SAME
+    sign as the electrons' (both species pushed down the a² gradient), with
+    magnitude scaled by (q/m)² = 1/mi_me². The pre-fix code dropped the ion
+    ponderomotive entirely AND sign-flipped the electron one, so both species
+    fail this test there."""
+    Nn, Nx, Lx = 8, 64, 2.0 * jnp.pi
+    alpha_e, alpha_i, n0, mi_me = 1.1, 0.04, 0.5, 100.0
+    dx = Lx / Nx
+
+    vf = _make_vf(
+        Nn,
+        Nx,
+        Lx,
+        alpha_e,
+        alpha_i,
+        mi_me=mi_me,
+        static_ions=False,
+        static_ion_density=None,
+    )
+    state = _maxwellian_state(Nn, Nx, n0, alpha_e, alpha_i)
+
+    x = np.linspace(0.0, Lx, Nx, endpoint=False)
+    a_frozen = jnp.asarray(0.2 * np.cos(2.0 * x))
+
+    out = vf._nonlinear_rhs(0.0, state, a_frozen, {})
+    dC_e = np.fft.ifft(np.asarray(out["Ck_electrons"]).view(np.complex128), axis=-1) * Nx
+    dC_i = np.fft.ifft(np.asarray(out["Ck_ions"]).view(np.complex128), axis=-1) * Nx
+
+    Fp = np.asarray(-0.5 * jnp.gradient(a_frozen**2, dx))
+    expected_e = np.sqrt(2.0) / alpha_e * Fp * (n0 / alpha_e**3)
+    expected_i = (1.0 / mi_me**2) * np.sqrt(2.0) / alpha_i * Fp * (n0 / alpha_i**3)
+
+    np.testing.assert_allclose(dC_e[1].real, expected_e, rtol=1e-12, atol=1e-14)
+    np.testing.assert_allclose(dC_i[1].real, expected_i, rtol=1e-12, atol=1e-14)
+
+
+def test_e_field_leg_unchanged_by_fix():
+    """The E-field leg (uniform charge separation → Poisson Ex) must still
+    carry q/m: electron and ion accelerations from the same Ex have OPPOSITE
+    signs, ratio -mi_me (per unit C_0 response). Guards against 'fixing' the
+    ponderomotive by dropping the charge factor everywhere."""
+    Nn, Nx, Lx = 8, 64, 2.0 * jnp.pi
+    alpha_e, alpha_i, n0, mi_me = 1.0, 0.05, 0.6, 25.0
+
+    vf = _make_vf(
+        Nn,
+        Nx,
+        Lx,
+        alpha_e,
+        alpha_i,
+        mi_me=mi_me,
+        static_ions=False,
+        static_ion_density=None,
+    )
+    # Perturb electron density at one k so Poisson gives Ex ≠ 0
+    state = _maxwellian_state(Nn, Nx, n0, alpha_e, alpha_i)
+    Ck_e = state["Ck_electrons"].view(jnp.complex128).at[0, 1].set(0.01 / alpha_e**3)
+    state["Ck_electrons"] = Ck_e.view(jnp.float64)
+
+    out = vf._nonlinear_rhs(0.0, state, jnp.zeros(Nx), {})
+    dC_e = np.fft.ifft(np.asarray(out["Ck_electrons"]).view(np.complex128), axis=-1) * Nx
+    dC_i = np.fft.ifft(np.asarray(out["Ck_ions"]).view(np.complex128), axis=-1) * Nx
+
+    # Expected: dC_1 = √2/α_s · (q_s/m_s)·Ex · C_0_s(x), with q/m = -1 (e), +1/mi_me (i)
+    Ex = np.asarray(vf.poisson(state["Ck_electrons"].view(jnp.complex128), state["Ck_ions"].view(jnp.complex128)))
+    assert np.max(np.abs(Ex)) > 1e-12  # non-trivial field
+    C0_e = np.fft.ifft(np.asarray(state["Ck_electrons"].view(jnp.complex128))[0]) * Nx
+    C0_i = np.fft.ifft(np.asarray(state["Ck_ions"].view(jnp.complex128))[0]) * Nx
+    expected_e = np.sqrt(2.0) / alpha_e * (-1.0) * Ex * C0_e
+    expected_i = np.sqrt(2.0) / alpha_i * (1.0 / mi_me) * Ex * C0_i
+
+    np.testing.assert_allclose(dC_e[1], expected_e, rtol=1e-12, atol=1e-13)
+    np.testing.assert_allclose(dC_i[1], expected_i, rtol=1e-12, atol=1e-13)


### PR DESCRIPTION
## The bug

`_nonlinear_rhs` computed `Fp = -0.5*∂x(a²)` and passed `Ex + Fp` into `_hermite_e_coupling`, which multiplies the whole sum by `q/m` (−1 for electrons). The ponderomotive acceleration is ∝ q²/m² — charge-sign **independent** — so folding it under q/m flipped its sign for electrons:

- as coded: `accel_e = −Ex + ½∂x(a²)`
- correct: `accel_e = −Ex − ½∂x(a²)`

The vlasov1d reference composes it correctly and documents it (`_vlasov1d/solvers/pushers/vlasov.py`): `force = q*e + (q²/m)*pond`.

## Why it mattered

The three-wave SRS gain is γ² ∝ (coupling leg 1)·(coupling leg 2). Leg 1 (`−n_e·a` beat current in the wave equation) is correct; leg 2 (ponderomotive beat driving the EPW) was sign-flipped, so γ² flipped sign for every parametric pair:

- **Stokes backscatter (real SRS): γ² < 0 — structurally forbidden.** No filter, Nn, collisionality, or dt choice could ever produce SRS with this solver.
- **Anti-Stokes (normally stable): γ² > 0 — spuriously unstable**, growth ∝ pump amplitude.

Quantitative confirmation from the homogeneous SRS campaign (0.2 n_c, 3 keV, ω0=1, k0=0.894): the unexplained detonating electrostatic mode sat at k ≈ 0.49 c/ωp0. Anti-Stokes matching (ω_em = ω0 + ω_BG(k), k_em = k0 + k) closes at **k = 0.4919** — within one spectral bin — while Stokes matching is 14% off. The EPW dispersion/Landau test gate never exercises the ponderomotive path, which is why this survived it.

## The fix

Compose the per-species acceleration at the caller — `(q/m)·(Ex + Edrive + noise) + (q/m)²·Fp` — and pass `q_over_m=1` to `_hermite_e_coupling` (docstring contract updated). The ion leg now carries its (negligible, 1/mi_me²) ponderomotive term too instead of dropping it.

## Tests

New `tests/test_hermite_poisson_1d/test_ponderomotive.py`:
- `test_electron_ponderomotive_sign_and_value` — static a(x) on a uniform Maxwellian (Ex=0): `dC_1/dt = √2/α·(−½∂x a²)·C_0`. Fails pre-fix with the opposite sign.
- `test_ponderomotive_is_charge_sign_independent` — mobile ions respond with the same sign, scaled by (q/m)². Fails pre-fix.
- `test_e_field_leg_unchanged_by_fix` — the electrostatic q/m handling is bit-compatible with the validated dispersion/Landau path.

Full HP suite: **22 passed** (pre-fix: the two new sign tests fail, everything else unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)