### PR TITLE
feat(hermite-poisson-1d): strang-exp integrator — exact force exponential, time-centered couplings

### DIFF
--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -367,6 +367,15 @@ class BaseHermitePoisson1D(ADEPTModule):
         ex_cfg = self.cfg.get("drivers", {}).get("ex", {})
         ex_driver = LongitudinalElectricFieldDriver(grid["x"], ex_cfg)
 
+        # Integrator selection: terms.integrator ∈ {"strang-exp" (default), "lawson-rk4"}.
+        # strang-exp = Strang-split exp(L dt/2) → exact force-exponential substep
+        # (finite nilpotent series, terms.force_exp_terms) → exp(L dt/2) with
+        # time-centered wave↔plasma couplings (no explicit force stability bound).
+        # lawson-rk4 = the legacy explicit path, kept for A/B.
+        terms_cfg = self.cfg.get("terms", {})
+        integrator = str(terms_cfg.get("integrator", "strang-exp"))
+        force_exp_terms = int(terms_cfg.get("force_exp_terms", 24))
+
         # Assemble top-level vector field (discrete-map via Stepper)
         vector_field = HermitePoisson1DVectorField(
             combined_exp=combined_exp,
@@ -391,6 +400,8 @@ class BaseHermitePoisson1D(ADEPTModule):
             noise_amplitude=noise_amplitude,
             noise_seed=noise_seed,
             noise_spatial_profile=noise_spatial_profile,
+            integrator=integrator,
+            force_exp_terms=force_exp_terms,
         )
 
         # Configure save quantities

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -389,6 +389,66 @@ def _hermite_e_coupling(
     return out
 
 
+def _exp_force_substep(
+    Ck: Array,
+    accel: Array,
+    sqrt_n_minus: Array,
+    alpha: float,
+    Omega_ce_tau: float,
+    dt: float,
+    mask23: Array | None = None,
+    n_terms: int = 24,
+) -> Array:
+    """Exact exponential step for the force coupling dC_n/dt = kappa_n·accel(x)·C_{n-1}.
+
+    kappa_n = Omega_ce_tau·√(2n)/alpha. `accel` is the species ACCELERATION —
+    (q/m)·E-terms + (q/m)²·ponderomotive, composed by the caller (same contract
+    as _hermite_e_coupling called with q_over_m=1).
+
+    With accel frozen over the substep, the force flow is exactly a velocity
+    shift f(v) → f(v − accel·dt) — the same sub-flow the Fourier-in-v vlasov1d
+    solver applies as a unitary phase, which is why that solver has NO E-field
+    stability bound. In the AW-Hermite basis the generator A is strictly lower
+    bidiagonal (nilpotent), so exp(dt·A) is the FINITE series Σ (dt·A)^k/k!,
+    applied here as n_terms cheap bidiagonal products (O(n_terms·Nn·Nx), far
+    below the streaming matmul). Truncating at n_terms is accurate when
+    x_max = dt·|accel|·√(2·Nn)·√2/α satisfies x_max^n_terms/n_terms! ≪ 1 —
+    n_terms=24 covers x_max ≲ 6, i.e. fields ~2× past the explicit-RK4
+    divergence bound (~2.8) that killed the Lawson path in production.
+
+    NOT Crank-Nicolson: the trapezoidal rational approximation is spectrally
+    stable but its non-normal transient response down the nilpotent ladder
+    behaves like (2x)^k where the true flow has x^k/k! — it detonates in
+    exactly the strong-force regime this substep exists to survive.
+    """
+    Nn, Nx = Ck.shape
+    if mask23 is not None:
+        Ck = Ck * mask23[None, :]
+        accel = jnp.fft.ifft(jnp.fft.fft(accel, norm="forward") * mask23, norm="forward").real
+
+    C = jnp.fft.ifft(Ck, axis=-1, norm="forward")  # (Nn, Nx) complex
+    kappa = Omega_ce_tau * jnp.sqrt(2.0) / alpha * sqrt_n_minus  # (Nn,)
+    kdt = (kappa * dt)[:, None] * accel[None, :]  # (Nn, Nx) real
+
+    zero_row = jnp.zeros((1, Nx), dtype=C.dtype)
+
+    def apply_A_dt(V: Array) -> Array:
+        # (dt·A·V)_n = dt·kappa_n·accel·V_{n-1}; row 0 = 0
+        return kdt * jnp.concatenate([zero_row, V[:-1, :]], axis=0)
+
+    out_C = C
+    term = C
+    k_max = min(int(n_terms), Nn - 1) if Nn > 1 else 0
+    for k in range(1, k_max + 1):
+        term = apply_A_dt(term) / k
+        out_C = out_C + term
+
+    out = jnp.fft.fft(out_C, axis=-1, norm="forward")
+    if mask23 is not None:
+        out = out * mask23[None, :]
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Top-level vector field (Stepper/discrete-map convention)
 # ---------------------------------------------------------------------------
@@ -409,8 +469,28 @@ def _tree_scale(a: dict, c: float) -> dict:
 class HermitePoisson1DVectorField:
     """Advances the 1D Hermite-Poisson state by one timestep dt.
 
-    Uses Lawson-RK4 for Ck (free-streaming exact, E-field/ponderomotive explicit)
-    and explicit leapfrog WaveSolver for the transverse vector potential a.
+    Two integrators (select via `integrator`):
+
+    "strang-exp" (default): Strang split exp(L·dt/2) → exact force-exponential
+      substep (finite nilpotent series; the frozen-force flow is exactly a
+      velocity shift, so this is the Hermite analog of vlasov1d's unitary
+      e^{i·k_v·E·dt} push and carries no explicit-RK force stability bound)
+      → exp(L·dt/2), with every wave↔plasma coupling time-centered: the force
+      substep sees Poisson-Ex from the mid-step C_0, the vector potential
+      linearly extrapolated to t+dt/2, and the Ex driver at t+dt/2; the
+      leapfrog wave update sees n_e and the source at t_n (its own centering
+      point). Second order, ~3× cheaper per step than Lawson-RK4.
+
+    "lawson-rk4" (legacy): Lawson-RK4 for Ck with the force treated explicitly
+      (stability bound |F|·√(2Nn)·√2/α·dt ≲ 2.8) and two half-step-off-center
+      couplings kept bug-compatible for A/B: the ponderomotive uses a frozen at
+      step START (half-step early) and the wave equation uses ½(n_eⁿ+n_eⁿ⁺¹)
+      and the source at t+dt/2 (half-step late). These opposite first-order
+      offsets in the two legs of the parametric loop are the suspected source
+      of the anomalous γ ≈ a0·ωp0 pump-proportional gain observed at
+      quarter-critical in SRS runs (4–5× the physical γ0), and the explicit
+      force bound is the observed super-exponential runaway once fields reach
+      E_crit ≈ 0.034 (Nn=1024, dt=0.1).
 
     Called by adept._base_.Stepper which treats the return value as the new state
     (not dy/dt). dt is stored internally from grid.dt at construction time.
@@ -440,7 +520,13 @@ class HermitePoisson1DVectorField:
         noise_amplitude: float = 0.0,
         noise_seed: int = 0,
         noise_spatial_profile: Array | None = None,
+        integrator: str = "strang-exp",
+        force_exp_terms: int = 24,
     ):
+        if integrator not in ("strang-exp", "lawson-rk4"):
+            raise ValueError(f"Unknown integrator {integrator!r}; use 'strang-exp' or 'lawson-rk4'")
+        self.integrator = integrator
+        self.force_exp_terms = int(force_exp_terms)
         self.combined_exp = combined_exp
         self.poisson = poisson
         self.wave_solver = wave_solver
@@ -632,6 +718,106 @@ class HermitePoisson1DVectorField:
 
     def __call__(self, t: float, y: dict, args: dict) -> dict:
         """Advance state by one timestep dt. Returns new state dict."""
+        if self.integrator == "strang-exp":
+            return self._strang_exp_step(t, y, args)
+        return self._lawson_step(t, y, args)
+
+    def _strang_exp_step(self, t: float, y: dict, args: dict) -> dict:
+        """Strang split: exp(L·dt/2) → exact force exponential → exp(L·dt/2) + leapfrog wave.
+
+        All couplings time-centered; see class docstring.
+        """
+        dt = self.dt
+        exp_L = self.combined_exp.apply
+
+        if self.noise_amplitude > 0.0 and self.noise_spatial_profile is not None:
+            noise_frozen = self._draw_noise(t)
+        else:
+            noise_frozen = 0.0
+
+        # Wave-equation inputs at t_n — the leapfrog update
+        # a_{n+1} = 2a_n − a_{n−1} + dt²(∂xx a − n_e·a + S) is centered at t_n,
+        # so n_e and S belong at t_n (pre-step C_0), not averaged/half-shifted.
+        Ck_e_n = y["Ck_electrons"].view(jnp.complex128)
+        n_e_n = self.poisson.electron_density(Ck_e_n)
+        djy = self.ey_driver(t, args)
+
+        # 1. First linear half-step (streaming + collisions + filter, exact)
+        y_h = exp_L(y, dt / 2)
+        Ck_e_h = y_h["Ck_electrons"].view(jnp.complex128)
+        Ck_i_h = y_h["Ck_ions"].view(jnp.complex128)
+
+        # 2. Time-centered force substep over the full dt.
+        # Ex from the mid-step C_0 (streaming has advanced it to t+dt/2; the
+        # force operator itself never changes C_0, so Ex is constant across
+        # the substep and the substep is linear with frozen coefficients).
+        Ex = self.poisson(Ck_e_h, Ck_i_h)
+        Edrive = self.ex_driver(t + 0.5 * dt, args)
+        # Vector potential linearly extrapolated to t+dt/2 from (a_n, a_{n-1});
+        # error O((ω0·dt)²) vs the half-step-early freeze's O(ω0·dt).
+        a_mid = 1.5 * y["a"][1:-1] - 0.5 * y["prev_a"][1:-1]
+        Fp = -0.5 * jnp.gradient(a_mid**2, self.dx)
+
+        accel_e = self.qm_e * (Ex + Edrive + noise_frozen) + self.qm_e**2 * Fp
+        Ck_e_f = _exp_force_substep(
+            Ck_e_h,
+            accel_e,
+            self.sqrt_n_minus_e,
+            self.alpha_e,
+            self.Omega_ce_tau,
+            dt,
+            mask23=self.mask23,
+            n_terms=self.force_exp_terms,
+        )
+        if self.static_ions:
+            Ck_i_f_view = y_h["Ck_ions"]
+        else:
+            accel_i = self.qm_i * (Ex + Edrive + noise_frozen) + self.qm_i**2 * Fp
+            Ck_i_f_view = _exp_force_substep(
+                Ck_i_h,
+                accel_i,
+                self.sqrt_n_minus_i,
+                self.alpha_i,
+                self.Omega_ce_tau,
+                dt,
+                mask23=self.mask23,
+                n_terms=self.force_exp_terms,
+            ).view(jnp.float64)
+
+        y_f = dict(y_h)
+        y_f["Ck_electrons"] = Ck_e_f.view(jnp.float64)
+        y_f["Ck_ions"] = Ck_i_f_view
+
+        # 3. Second linear half-step
+        y1 = exp_L(y_f, dt / 2)
+
+        # 4. Wave solver (inputs at t_n, computed above)
+        a_result = self.wave_solver(
+            a=y["a"],
+            aold=y["prev_a"],
+            djy_array=djy,
+            electron_density=n_e_n,
+        )
+
+        # 5. Diagnostics + assemble
+        Ck_e_np1 = y1["Ck_electrons"].view(jnp.complex128)
+        Ck_i_np1 = y1["Ck_ions"].view(jnp.complex128)
+        Ex_out = self.poisson(Ck_e_np1, Ck_i_np1)
+        de = self.ex_driver(t, args)
+
+        new_state = {
+            "Ck_electrons": y1["Ck_electrons"],
+            "Ck_ions": y1["Ck_ions"],
+            "a": a_result["a"],
+            "prev_a": a_result["prev_a"],
+            "e": Ex_out,
+            "da": djy,
+            "de": de,
+        }
+        return self._apply_sponge(new_state)
+
+    def _lawson_step(self, t: float, y: dict, args: dict) -> dict:
+        """Legacy Lawson-RK4 step (explicit force; see class docstring for caveats)."""
 
         # Frozen interior vector potential for the whole Lawson step
         a_frozen = y["a"][1:-1]  # (Nx,)

--- a/tests/test_hermite_poisson_1d/test_integrators.py
+++ b/tests/test_hermite_poisson_1d/test_integrators.py
@@ -145,7 +145,7 @@ def test_both_integrators_agree_in_smooth_regime():
     for integrator in ("lawson-rk4", "strang-exp"):
         module = _make_module(integrator, e_amplitude=3e-4)
         vf = module.diffeqsolve_quants["terms"].vector_field
-        step = jax.jit(lambda t, y: vf(t, y, {}))
+        step = jax.jit(lambda t, y, vf=vf: vf(t, y, {}))
         y = module.state
         for i in range(100):
             y = step(0.1 * i, y)

--- a/tests/test_hermite_poisson_1d/test_integrators.py
+++ b/tests/test_hermite_poisson_1d/test_integrators.py
@@ -1,0 +1,158 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Tests for the Strang / exact-force-exponential integrator ("strang-exp").
+
+Regression context: the legacy Lawson-RK4 path treats the E/ponderomotive
+force coupling explicitly, with stability bound |F|·√(2Nn)·√2/α·dt ≲ 2.8 —
+E_crit ≈ 0.034 at Nn=1024, dt=0.1, α=0.108. In the first threshold campaign
+on the sign-fixed solver, quarter-critical SRS fields reached that bound and
+every run detonated super-exponentially to ~1e35 before NaN.
+
+The strang-exp force substep applies the EXACT exponential of the nilpotent
+lower-bidiagonal coupling (the frozen-force flow is a velocity shift — the
+Hermite analog of vlasov1d's unitary e^{i·k_v·E·dt} push), as a finite series
+of cheap bidiagonal products. Deliberately NOT Crank-Nicolson: CN is
+spectrally stable but its non-normal transient response down the nilpotent
+ladder behaves like (2x)^k where the true flow has x^k/k! — measured during
+development, CN detonated where the exact series is machine-exact.
+
+There is deliberately NO lawson-diverges/strang-survives contrast test here:
+at any unit-test-accessible parameters strong enough to break the explicit
+RK4 stage (per-level x = dt·|E|·√(2Nn)·√2/α ≳ 2.8), the truncated AW-Hermite
+SYSTEM itself is unstable (dt-convergence study during development: growth
+γ ≈ 1 ωp at E/α = 0.5, Nn=512, persisting as dt→0 with the o8-s36 filter on —
+the Schumer-Holloway non-normal unboundedness under strong forcing, not an
+integrator artifact). The integrator contract is therefore: exactness of the
+sub-flow, conservation, and agreement with Lawson-RK4 in the smooth regime;
+production-scale behavior is validated by SRS campaign A/Bs.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
+from adept._hermite_poisson_1d.vector_field import _exp_force_substep
+
+
+def _dense_nilpotent_exp(Nn: int, kappa_F_dt: np.ndarray) -> np.ndarray:
+    """Dense exp(dt·A) for the nilpotent lower-bidiagonal coupling A (one x point).
+
+    A[n, n-1] = kappa_n·F; nilpotent (A^Nn = 0) so the series is finite/exact.
+    """
+    A = np.zeros((Nn, Nn))
+    for n in range(1, Nn):
+        A[n, n - 1] = kappa_F_dt[n]
+    E = np.eye(Nn)
+    term = np.eye(Nn)
+    for k in range(1, Nn):
+        term = term @ A / k
+        E = E + term
+    return E
+
+
+def test_exp_substep_matches_dense_nilpotent_exponential():
+    """With n_terms >= Nn-1 the series is the EXACT matrix exponential —
+    machine-precision agreement with a dense reference, even at large dt·F
+    (here per-level x up to ~1.2, well past where any rational approximation
+    would distort the transient)."""
+    Nn, Nx = 8, 4
+    alpha, F0, dt = 1.2, 0.5, 0.8
+    rng = np.random.default_rng(3)
+    C0 = rng.normal(size=(Nn, Nx)) + 1j * rng.normal(size=(Nn, Nx))
+    Ck = jnp.asarray(np.fft.fft(C0, axis=-1) / Nx)  # k-space, norm="forward" convention
+    sqrt_n = jnp.sqrt(jnp.arange(Nn, dtype=jnp.float64))
+
+    out = _exp_force_substep(Ck, F0 * jnp.ones(Nx), sqrt_n, alpha, 1.0, dt, n_terms=24)
+    C_num = np.fft.ifft(np.asarray(out), axis=-1) * Nx
+
+    E = _dense_nilpotent_exp(Nn, dt * np.sqrt(2.0) / alpha * np.asarray(sqrt_n) * F0)
+    C_exact = E @ C0
+
+    np.testing.assert_allclose(C_num, C_exact, rtol=1e-13, atol=1e-13)
+
+
+def test_exp_substep_conserves_density_and_momentum_response_sign():
+    """Uniform accel on a Maxwellian: C_0 untouched exactly; the exact one-step
+    momentum response is dC_1 = dt·(√2/α)·accel·C_0 (the same convention the
+    ponderomotive-sign fix locked in for _hermite_e_coupling)."""
+    Nn, Nx = 8, 16
+    alpha, n0, F0, dt = 1.3, 0.7, 0.2, 0.05
+    Ck = jnp.zeros((Nn, Nx), dtype=jnp.complex128).at[0, 0].set(n0 / alpha**3)
+    sqrt_n = jnp.sqrt(jnp.arange(Nn, dtype=jnp.float64))
+
+    out = _exp_force_substep(Ck, F0 * jnp.ones(Nx), sqrt_n, alpha, 1.0, dt)
+    C = np.fft.ifft(np.asarray(out), axis=-1) * Nx
+
+    np.testing.assert_allclose(C[0].real, n0 / alpha**3, rtol=1e-14)
+    expected_c1 = dt * np.sqrt(2.0) / alpha * F0 * (n0 / alpha**3)
+    np.testing.assert_allclose(C[1].real, expected_c1, rtol=1e-12)
+
+
+def _make_module(integrator: str, e_amplitude: float, w0: float = 3.0):
+    """Uniform plasma + uniform-envelope Ex driver with |E| = e_amplitude.
+
+    w0=3 (above ωpe=1) so Debye shielding doesn't cancel the applied field and
+    the oscillation velocity stays modest (v_osc/vth = E/(w0·α))."""
+    Lx = 20.0
+    cfg = {
+        "physics": {
+            "Lx": Lx,
+            "alpha_e": 0.1,
+            "alpha_i": 0.1,
+            "n0_e": 1.0,
+            "n0_i": 1.0,
+            "nu": 0.02,
+            "collision_model": "lenard-bernstein",
+            "static_ions": True,
+            "c_light": 1.0,
+        },
+        "grid": {"Nn": 512, "Ni": 2, "Nx": 32, "tmax": 40.0, "dt": 0.1},
+        "density": {},
+        "terms": {"integrator": integrator},
+        "drivers": {
+            "ex": {
+                "0": {
+                    "k0": 2.0 * np.pi / Lx,
+                    "w0": w0,
+                    "a0": e_amplitude / w0,  # driver amplitude prefactor is w0*a0
+                    "t_rise": 1.0,
+                    "t_center": 0.0,
+                    "t_width": 1.0e10,
+                }
+            }
+        },
+        "save": {"fields": {"t": {"tmin": 0.0, "tmax": 40.0, "nt": 3}}},
+    }
+    module = BaseHermitePoisson1D(cfg)
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    module.init_diffeqsolve()
+    return module
+
+
+def test_both_integrators_agree_in_smooth_regime():
+    """At weak drive (explicit-stage parameter ≪ 1) the two integrators solve
+    the same physics: after 100 steps the electron states should agree to
+    second-order accuracy levels."""
+    import jax
+
+    states = {}
+    for integrator in ("lawson-rk4", "strang-exp"):
+        module = _make_module(integrator, e_amplitude=3e-4)
+        vf = module.diffeqsolve_quants["terms"].vector_field
+        step = jax.jit(lambda t, y: vf(t, y, {}))
+        y = module.state
+        for i in range(100):
+            y = step(0.1 * i, y)
+        states[integrator] = np.asarray(y["Ck_electrons"].view(jnp.complex128))
+
+    a, b = states["lawson-rk4"], states["strang-exp"]
+    scale = np.max(np.abs(a[1:]))  # driven response lives in n >= 1 (n=0 is the Maxwellian)
+    diff = np.max(np.abs(a - b))
+    assert scale > 0
+    assert diff < 0.05 * scale, f"integrators disagree: diff={diff:.3e} vs response scale={scale:.3e}"

--- a/tests/test_hermite_poisson_1d/test_landau_damping.py
+++ b/tests/test_hermite_poisson_1d/test_landau_damping.py
@@ -47,8 +47,9 @@ def _measure_ringing(e_xt: np.ndarray, t: np.ndarray, mode: int) -> tuple[float,
     return float(omega), float(gamma)
 
 
+@pytest.mark.parametrize("integrator", ["strang-exp", "lawson-rk4"])
 @pytest.mark.parametrize("klambda_D", [0.30, 0.35])
-def test_epw_dispersion(klambda_D: float):
+def test_epw_dispersion(klambda_D: float, integrator: str):
     mode = 1
     Lx = 4.0 * np.pi
     k = 2.0 * np.pi * mode / Lx
@@ -83,6 +84,7 @@ def test_epw_dispersion(klambda_D: float):
         },
         "density": {"perturbation": {"mode": mode, "amplitude": 1.0e-4}},
         "drivers": {},
+        "terms": {"integrator": integrator},
         "save": {"fields": {"t": {"tmin": 0.0, "tmax": tmax, "nt": nt_save}}},
     }
 


### PR DESCRIPTION
## What

New default integrator for `_hermite_poisson_1d` (`terms.integrator: "strang-exp"`; the legacy `"lawson-rk4"` stays selectable for A/B):

**Strang split: exp(L·dt/2) → exact force-exponential substep → exp(L·dt/2)**, plus the leapfrog wave update, with every wave↔plasma coupling time-centered.

## Why

From the first sign-fixed SRS threshold campaign (post-#298; all four intensities NaN'd at 0.21–0.42 ps):

1. **Off-center couplings.** The Lawson path evaluates the two legs of the parametric loop half a step off in *opposite* directions — ponderomotive from `a` frozen at step start (early), wave equation from ½(n_eⁿ+n_eⁿ⁺¹) and the source at t+dt/2 (late; the leapfrog's own centering point is t_n). This first-order asymmetric energy exchange is the prime suspect for the anomalous γ ≈ a0·ωp0 growth (4–5× the physical SRS γ0, present even at intensities where the Vlasov reference is quiescent). strang-exp centers everything: the force substep sees Poisson-Ex from the mid-step C₀, `a` extrapolated to t+dt/2, and the driver at t+dt/2; the leapfrog sees n_e and S at t_n.
2. **Explicit force stage.** Lawson-RK4 treats the force coupling explicitly, bound |E|·√(2Nn)·√2/α·dt ≲ 2.8 (E_crit ≈ 0.034 at Nn=1024, dt=0.1) — the observed super-exponential runaway to ~1e35. The frozen-force flow is exactly a velocity shift (the Hermite analog of vlasov1d's unitary e^{ik_v·E·dt} push); its generator is nilpotent lower-bidiagonal, so exp(dt·A) is applied **exactly** as `terms.force_exp_terms` (default 24) cheap bidiagonal products.

Also ~3× cheaper per step (2 streaming matmuls + an O(Nn·Nx) series vs 6 matmuls + 4 nonlinear RHS evaluations).

## Scope, honestly bounded

A dt-convergence study during development showed that under strong forcing (E/α ≳ 0.5 at Nn=512, o8-s36 filter on) the truncated AW-Hermite **system itself** grows at γ ~ ωp, independent of integrator and dt — Schumer–Holloway non-normal unboundedness, not an integrator artifact. No integrator removes that; the operating-point mitigation is small Nn + filter (the per-level parameter x = dt·|E|·√(2Nn)·√2/α stays ≪ 1 for threshold-grade fields at Nn ≲ 128). For the same reason there is deliberately no "lawson diverges / strang survives" unit test — at unit-test-accessible parameters past the RK4 bound, the system instability dominates both. Production validation is the SRS threshold-scan A/B (queued in kinetic-srs).

Not Crank–Nicolson by choice: CN is spectrally stable but its non-normal transient down the nilpotent ladder goes like (2x)^k vs the true x^k/k!, and it detonated in testing exactly where the exact series is machine-precise.

## Tests

- `test_exp_substep_matches_dense_nilpotent_exponential` — machine-precision vs dense expm
- `test_exp_substep_conserves_density_and_momentum_response_sign` — C₀ untouched; dC₁ = dt·(√2/α)·accel·C₀ (same convention #298 locked in)
- `test_both_integrators_agree_in_smooth_regime` — weak-drive A/B vs lawson-rk4
- EPW dispersion/Landau gate now parametrized over **both** integrators (strang-exp passes at the same tolerances)

Full HP suite: **27 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)