### PR TITLE
fix(hermite-poisson-1d): calibrate the transverse pump driver (was radiating 9× nominal a0)

### DIFF
--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -358,9 +358,9 @@ class BaseHermitePoisson1D(ADEPTModule):
         # Wave solver (c_light > 0 → EM waves; = 0 → frozen a)
         wave_solver = WaveSolver(c=c_light, dx=dx, dt=dt)
 
-        # Transverse wave source driver
+        # Transverse wave source driver (calibrated; pulse["source"]: point|extended)
         ey_cfg = self.cfg.get("drivers", {}).get("ey", {})
-        ey_driver = TransverseWaveDriver(x_a, ey_cfg)
+        ey_driver = TransverseWaveDriver(x_a, ey_cfg, c=c_light)
 
         # Longitudinal (Ex) field driver — prescribed Ex added to the velocity-space
         # force, on the interior x grid (no ghost cells).

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -19,20 +19,42 @@ from adept._vlasov1d.solvers.pushers.field import WaveSolver
 
 
 class TransverseWaveDriver:
-    """Wave-equation source term S(x, t) = Σ_pulses -w² a0 envelope(x,t) sin(kx − wt).
+    """Wave-equation source term, CALIBRATED so the radiated wave has amplitude a0.
 
-    Reads directly from the raw normalized driver_config dict (same format as
-    adept._spectrax1d.driver.Driver) so no Pydantic/EMDriver chain is needed.
-    Output shape: (Nx+2,), matching WaveSolver's djy_array expectation.
+    Two source modes per pulse (pulse["source"], default "extended"):
+
+    "point" (recommended; identical to vlasov1d's TransverseCurrentSourceDriver):
+        S = (F0/dx) · time_envelope(t) · δ_{i0} · sin(w·t),  F0 = 2·w·c·a0.
+        The 1D Green's function for S = F0·δ(x−x0)·sin(wt) gives outgoing waves
+        of amplitude F0/(2·k·c²); with vacuum k = w/c that is exactly a0.
+        Radiates both directions — place near an absorbing boundary.
+
+    "extended": S = −w²·a0·(2c/(w·G))·envelope(x,t)·sin(kx − wt), where
+        G = ∫env_x dx. A phase-matched traveling source of integrated strength
+        S0·G radiates amplitude S0·G/(2·w·c), so the 2c/(w·G) factor calibrates
+        the outgoing amplitude to a0 (accurate for antenna width ≳ wavelength).
+
+    REGRESSION NOTE: the extended mode originally had NO calibration — the
+    radiated amplitude was a0·(w·G/2c), a factor ~9 (81× intensity) for the
+    production SRS geometry (1 µm antenna, 351 nm pump at n_c normalization).
+    Every HP campaign before 2026-07-04 was driven at ~81× nominal intensity;
+    measured pump/nominal = 9.00 at all four campaign intensities, matching
+    (w/2c)·G = 8.95 analytically. The vlasov1d reference campaigns used its
+    calibrated point source and were unaffected.
+
+    Reads the raw normalized driver_config dict. Output shape: (Nx+2,),
+    matching WaveSolver's djy_array expectation.
     """
 
-    def __init__(self, x_a: Array, ey_driver_cfg: dict):
+    def __init__(self, x_a: Array, ey_driver_cfg: dict, c: float = 1.0):
         """
         Args:
             x_a: Extended x grid with ghost cells, shape (Nx+2,).
             ey_driver_cfg: dict mapping pulse_name → pulse_dict from cfg["drivers"]["ey"].
+            c: normalized light speed (1.0 in skin-depth units).
         """
         self.x_a = x_a
+        dx = float(x_a[1] - x_a[0])
         # Pre-parse all scalars at init so __call__ contains no float() on JAX arrays.
         x_a_last = float(x_a[-1])
         parsed = []
@@ -46,27 +68,37 @@ class TransverseWaveDriver:
             x_center = float(pulse.get("x_center", 0.5 * x_a_last))
             x_half = 0.5 * float(pulse.get("x_width", 1e10))
             x_rise = float(pulse.get("x_rise", 0.0))
-            parsed.append(
-                (
-                    float(pulse["k0"]),
-                    w_total,
-                    float(pulse["a0"]),
-                    t_center,
-                    t_half,
-                    t_rise,
-                    x_center,
-                    x_half,
-                    x_rise,
-                )
-            )
+            source = str(pulse.get("source", "extended"))
+            if source not in ("extended", "point"):
+                raise ValueError(f"drivers.ey pulse source must be 'extended' or 'point', got {source!r}")
+
+            if source == "point":
+                i0 = int(jnp.argmin(jnp.abs(x_a - x_center)))
+                mask = jnp.zeros_like(x_a).at[i0].set(1.0)
+                # F0 = 2*w*c*a0 (vacuum-dispersion Green's factor), applied as F0/dx
+                scale = 2.0 * w_total * float(c) * float(pulse["a0"]) / dx
+                parsed.append(("point", scale, w_total, t_center, t_half, t_rise, mask))
+            else:
+                env_x = get_envelope(x_rise, x_rise, x_center - x_half, x_center + x_half, x_a)
+                G = float(jnp.trapezoid(env_x, x_a))
+                if G <= 0.0:
+                    raise ValueError("drivers.ey: extended-source spatial envelope integrates to zero")
+                # Radiated amplitude of the uncalibrated antenna is a0*(w*G/2c);
+                # divide it out so the launched wave has amplitude a0.
+                cal = 2.0 * float(c) / (w_total * G)
+                amp = -(w_total**2) * float(pulse["a0"]) * cal
+                parsed.append(("extended", amp, w_total, t_center, t_half, t_rise, (float(pulse["k0"]), env_x)))
         self.parsed_pulses = parsed
 
     def __call__(self, t: float, args) -> Array:
         total = jnp.zeros_like(self.x_a)
-        for k0, w_total, a0, t_center, t_half, t_rise, x_center, x_half, x_rise in self.parsed_pulses:
+        for source, amp, w_total, t_center, t_half, t_rise, extra in self.parsed_pulses:
             env_t = get_envelope(t_rise, t_rise, t_center - t_half, t_center + t_half, t)
-            env_x = get_envelope(x_rise, x_rise, x_center - x_half, x_center + x_half, self.x_a)
-            total = total + env_t * env_x * (-(w_total**2)) * a0 * jnp.sin(k0 * self.x_a - w_total * t)
+            if source == "point":
+                total = total + amp * env_t * extra * jnp.sin(w_total * t)
+            else:
+                k0, env_x = extra
+                total = total + env_t * env_x * amp * jnp.sin(k0 * self.x_a - w_total * t)
         return total
 
 

--- a/tests/test_hermite_poisson_1d/test_transverse_driver.py
+++ b/tests/test_hermite_poisson_1d/test_transverse_driver.py
@@ -1,0 +1,97 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Radiation-amplitude calibration tests for TransverseWaveDriver.
+
+Regression context: the extended source originally injected
+S = −w²·a0·env·sin(kx−wt) with NO calibration, so the launched wave had
+amplitude a0·(w·G/2c) with G = ∫env dx — a factor 9.0 (81× intensity) for the
+production SRS geometry (1 µm antenna, w=1). Every HP campaign before
+2026-07-04 was pumped at ~81× nominal intensity; the pump measured at the
+probes was 9.00× nominal at all four campaign intensities (the ep = Ey + Bz
+probe convention contributes a further ×2, giving the observed 18.00).
+The vlasov1d reference used its point source, which divides the Green's
+factor out explicitly (F0 = 2·w·c·a0) and was unaffected.
+
+These tests launch each source into vacuum with the production WaveSolver and
+assert the radiated |Ey| equals w·a0 — the check that was always missing.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept._hermite_poisson_1d.vector_field import TransverseWaveDriver
+from adept._vlasov1d.solvers.pushers.field import WaveSolver
+
+
+def _radiated_amplitude(pulse: dict, Lx=200.0, Nx=800, dt=0.1, t_end=350.0, x_probe=140.0):
+    """Launch one pulse into vacuum; return radiated |Ey| at x_probe.
+
+    Ey = -(a - a_old)/dt; amplitude from the last third of the run (steady state:
+    source at x=30, probe transit 110/c plus margin).
+    """
+    dx = Lx / Nx
+    x = jnp.linspace(0.0, Lx, Nx, endpoint=False)
+    x_a = jnp.concatenate([jnp.array([x[0] - dx]), x, jnp.array([x[-1] + dx])])
+
+    driver = TransverseWaveDriver(x_a, {"0": pulse}, c=1.0)
+    wave = WaveSolver(c=1.0, dx=dx, dt=dt)
+    n_e = jnp.zeros(Nx)  # vacuum
+
+    @jax.jit
+    def step(carry, t):
+        a, prev_a = carry
+        res = wave(a=a, aold=prev_a, djy_array=driver(t, {}), electron_density=n_e)
+        return (res["a"], res["prev_a"]), (res["a"] - a)[1:-1]
+
+    n_steps = int(t_end / dt)
+    a0_arr = jnp.zeros(Nx + 2)
+    (_, _), da_hist = jax.lax.scan(step, (a0_arr, a0_arr), dt * jnp.arange(n_steps))
+    ey = -np.asarray(da_hist) / dt  # (nt, Nx)
+
+    ip = int(x_probe / dx)
+    sig = ey[int(0.67 * n_steps) :, ip]
+    return float(np.sqrt(2.0 * np.mean(sig**2)))
+
+
+def test_point_source_radiates_a0():
+    """Point source (vlasov1d convention): radiated |Ey| = w·a0 within 3%."""
+    w0, a0 = 1.0, 1.0e-3
+    pulse = {
+        "source": "point",
+        "k0": w0,
+        "w0": w0,
+        "a0": a0,
+        "t_center": 0.0,
+        "t_width": 1.0e10,
+        "t_rise": 5.0,
+        "x_center": 30.0,
+    }
+    amp = _radiated_amplitude(pulse)
+    np.testing.assert_allclose(amp, w0 * a0, rtol=0.03)
+
+
+def test_extended_source_radiates_a0():
+    """Calibrated extended source: radiated |Ey| = w·a0 within 10%.
+
+    Antenna width 18 c/wp0 (the production 1 µm geometry, ~3 wavelengths at
+    w=1). Pre-fix this radiated 9.0× nominal."""
+    w0, a0 = 1.0, 1.0e-3
+    pulse = {
+        "source": "extended",
+        "k0": w0,
+        "w0": w0,
+        "a0": a0,
+        "t_center": 0.0,
+        "t_width": 1.0e10,
+        "t_rise": 5.0,
+        "x_center": 30.0,
+        "x_width": 17.9,
+        "x_rise": 1.8,
+    }
+    amp = _radiated_amplitude(pulse)
+    np.testing.assert_allclose(amp, w0 * a0, rtol=0.10)


### PR DESCRIPTION
## The bug

`TransverseWaveDriver` (extended source) injected `S = −w²·a0·env·sin(kx−wt)` with **no radiation calibration**. A phase-matched traveling antenna of integrated envelope G radiates amplitude `a0·(w·G/2c)` — for the production SRS geometry (1 µm antenna, 351 nm pump, n_c normalization) that is **9.0× nominal amplitude = 81× nominal intensity**.

Measured directly from the campaign probe data: pump/nominal = **18.00 ± 0.04 at all four intensities** (the ep = Ey+Bz probe convention contributes ×2, so the wave is 9.00×; the analytic factor (w/2c)·G = 8.95).

Every HP campaign to date effectively ran at ~81× its nominal intensity. The vlasov1d reference campaigns used that solver's **point source, which explicitly divides out the Green's factor** (`F0 = 2·w·c·a0`, `_vlasov1d/solvers/pushers/field.py`) and was unaffected — resolving the standing mystery of why HP grew pump-scaled instabilities (γ ≈ a0_nominal·ωp0 ≈ 0.1·a0_actual·ωp0) at intensities where the Vlasov reference is quiescent, with no visible threshold. (vlasov1d's own *extended*-source branch has the same latent issue; not touched here.)

## The fix

- **`pulse["source"]: "point"`** — new mode, identical to vlasov1d's calibrated convention: `S = (2·w·c·a0/dx)·time_env·δ_i0·sin(wt)`. Recommended; matches the vlasov `-cs` reference antenna exactly.
- **`"extended"`** (default) now calibrated by `2c/(w·G)` so the launched amplitude is a0 (accurate for antenna width ≳ wavelength).
- `TransverseWaveDriver` takes `c`; `modules.py` passes `c_light`.

## Tests

New `test_transverse_driver.py`: launches each source into vacuum with the production WaveSolver and asserts the radiated |Ey| equals w·a0 (3% point / 10% extended) — the missing check. Full HP suite: **29 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)