### PR TITLE
feat(hermite-poisson-1d): terms.stabilize — LPSE-style clamps so runs complete above threshold

### DIFF
--- a/adept/_hermite_poisson_1d/modules.py
+++ b/adept/_hermite_poisson_1d/modules.py
@@ -376,6 +376,27 @@ class BaseHermitePoisson1D(ADEPTModule):
         integrator = str(terms_cfg.get("integrator", "strang-exp"))
         force_exp_terms = int(terms_cfg.get("force_exp_terms", 24))
 
+        # LPSE-style stabilization (terms.stabilize: true): the sim stays
+        # numerically stable below AND above threshold; above-threshold
+        # amplitudes are artificially saturated (not accurate, by design).
+        #   force_cap: tanh cap on the species acceleration. Auto default
+        #     caps the hierarchy-forcing parameter x = dt*|a|*sqrt(4Nn)/alpha
+        #     at 0.3 — inside the truncated-AW safe zone, ~2-3x above
+        #     vlasov-reference saturated SRS fields (transparent during the
+        #     linear/threshold phase: relative distortion (a/cap)^2/3).
+        #   wave_density_max: clip on n_e in the wave equation (safety net).
+        # Explicit terms.force_cap / terms.wave_density_max override the
+        # auto values; either can be set without stabilize for fine control.
+        stabilize = bool(terms_cfg.get("stabilize", False))
+        force_cap = terms_cfg.get("force_cap", None)
+        wave_density_max = terms_cfg.get("wave_density_max", None)
+        if stabilize and force_cap is None:
+            force_cap = 0.3 * alpha_e / (2.0 * np.sqrt(Nn_e) * dt)
+        if stabilize and wave_density_max is None:
+            wave_density_max = 2.0
+        force_cap = None if force_cap is None else float(force_cap)
+        wave_density_max = None if wave_density_max is None else float(wave_density_max)
+
         # Assemble top-level vector field (discrete-map via Stepper)
         vector_field = HermitePoisson1DVectorField(
             combined_exp=combined_exp,
@@ -402,6 +423,8 @@ class BaseHermitePoisson1D(ADEPTModule):
             noise_spatial_profile=noise_spatial_profile,
             integrator=integrator,
             force_exp_terms=force_exp_terms,
+            force_cap=force_cap,
+            wave_density_max=wave_density_max,
         )
 
         # Configure save quantities

--- a/adept/_hermite_poisson_1d/vector_field.py
+++ b/adept/_hermite_poisson_1d/vector_field.py
@@ -554,11 +554,25 @@ class HermitePoisson1DVectorField:
         noise_spatial_profile: Array | None = None,
         integrator: str = "strang-exp",
         force_exp_terms: int = 24,
+        force_cap: float | None = None,
+        wave_density_max: float | None = None,
     ):
         if integrator not in ("strang-exp", "lawson-rk4"):
             raise ValueError(f"Unknown integrator {integrator!r}; use 'strang-exp' or 'lawson-rk4'")
         self.integrator = integrator
         self.force_exp_terms = int(force_exp_terms)
+        # LPSE-style stabilization clamps (None = off). See _strang_exp_step.
+        # force_cap: smooth tanh saturation of the species acceleration —
+        # accel -> cap*tanh(accel/cap). Transparent while |accel| << cap
+        # (relative distortion (accel/cap)^2/3), artificially saturates the
+        # parametric loop gain above it, and bounds the hierarchy-forcing
+        # parameter x = dt*|accel|*sqrt(4*Nn)/alpha below the truncated-AW
+        # detonation threshold. Above-threshold runs become stable but NOT
+        # quantitatively accurate at saturation amplitude (by design).
+        # wave_density_max: clip on the electron density the wave equation
+        # sees (safety net against runaway omega_pe^2*dt^2 at huge delta-n).
+        self.force_cap = None if force_cap is None else float(force_cap)
+        self.wave_density_max = None if wave_density_max is None else float(wave_density_max)
         self.combined_exp = combined_exp
         self.poisson = poisson
         self.wave_solver = wave_solver
@@ -772,6 +786,8 @@ class HermitePoisson1DVectorField:
         # so n_e and S belong at t_n (pre-step C_0), not averaged/half-shifted.
         Ck_e_n = y["Ck_electrons"].view(jnp.complex128)
         n_e_n = self.poisson.electron_density(Ck_e_n)
+        if self.wave_density_max is not None:
+            n_e_n = jnp.clip(n_e_n, 0.0, self.wave_density_max)
         djy = self.ey_driver(t, args)
 
         # 1. First linear half-step (streaming + collisions + filter, exact)
@@ -791,6 +807,8 @@ class HermitePoisson1DVectorField:
         Fp = -0.5 * jnp.gradient(a_mid**2, self.dx)
 
         accel_e = self.qm_e * (Ex + Edrive + noise_frozen) + self.qm_e**2 * Fp
+        if self.force_cap is not None:
+            accel_e = self.force_cap * jnp.tanh(accel_e / self.force_cap)
         Ck_e_f = _exp_force_substep(
             Ck_e_h,
             accel_e,
@@ -805,6 +823,8 @@ class HermitePoisson1DVectorField:
             Ck_i_f_view = y_h["Ck_ions"]
         else:
             accel_i = self.qm_i * (Ex + Edrive + noise_frozen) + self.qm_i**2 * Fp
+            if self.force_cap is not None:
+                accel_i = self.force_cap * jnp.tanh(accel_i / self.force_cap)
             Ck_i_f_view = _exp_force_substep(
                 Ck_i_h,
                 accel_i,

--- a/tests/test_hermite_poisson_1d/test_stabilization.py
+++ b/tests/test_hermite_poisson_1d/test_stabilization.py
@@ -1,0 +1,166 @@
+#  Copyright (c) Ergodic LLC 2026
+#  research@ergodic.io
+"""Tests for the LPSE-style stabilization clamps (terms.stabilize).
+
+Purpose: SRS-threshold campaigns need runs that complete both below AND above
+threshold. Above threshold the truncated AW-Hermite hierarchy detonates once
+local fields reach the strong-forcing zone (hierarchy-forcing parameter
+x = dt·|accel|·√(4Nn)/α ≳ O(1)) — an instability of the truncated system
+itself, insensitive to filter strength/shape, LB nu, and Nn (absorber-bracket
+campaign, kinetic-srs 2026-07-04). The clamp caps the acceleration with a
+smooth tanh at x ≈ 0.3 (auto default), which is transparent through the
+linear/threshold phase (fields 10–100× below the cap; relative distortion
+(a/cap)²/3) and artificially saturates the parametric loop above it —
+stable-but-inaccurate at saturation, like an enveloped LPSE run that just
+keeps growing. A clip on the wave-equation density is the second safety net.
+"""
+
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept._hermite_poisson_1d.modules import BaseHermitePoisson1D
+
+
+def _make_module(e_amplitude: float, stabilize: bool, w0: float = 3.0):
+    """Uniform plasma + uniform-envelope Ex driver with |E| = e_amplitude
+    (same rig as test_integrators; drive above ωpe so shielding is weak)."""
+    Lx = 20.0
+    cfg = {
+        "physics": {
+            "Lx": Lx,
+            "alpha_e": 0.1,
+            "alpha_i": 0.1,
+            "n0_e": 1.0,
+            "n0_i": 1.0,
+            "nu": 0.02,
+            "collision_model": "lenard-bernstein",
+            "static_ions": True,
+            "c_light": 1.0,
+        },
+        "grid": {"Nn": 512, "Ni": 2, "Nx": 32, "tmax": 40.0, "dt": 0.1},
+        "density": {},
+        "terms": {"integrator": "strang-exp", "stabilize": stabilize},
+        "drivers": {
+            "ex": {
+                "0": {
+                    "k0": 2.0 * np.pi / Lx,
+                    "w0": w0,
+                    "a0": e_amplitude / w0,
+                    "t_rise": 1.0,
+                    "t_center": 0.0,
+                    "t_width": 1.0e10,
+                }
+            }
+        },
+        "save": {"fields": {"t": {"tmin": 0.0, "tmax": 40.0, "nt": 3}}},
+    }
+    module = BaseHermitePoisson1D(cfg)
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    module.init_diffeqsolve()
+    return module
+
+
+def _run(module, n_steps: int):
+    vf = module.diffeqsolve_quants["terms"].vector_field
+    step = jax.jit(lambda t, y, vf=vf: vf(t, y, {}))
+    y = module.state
+    peak = 0.0
+    for i in range(n_steps):
+        y = step(0.1 * i, y)
+        m = float(jnp.max(jnp.abs(y["Ck_electrons"])))
+        if not np.isfinite(m):
+            return y, np.inf
+        peak = max(peak, m)
+    return y, peak
+
+
+def test_stabilize_transparent_at_small_amplitude():
+    """Weak drive (|accel|/cap ≈ 0.05): clamped and unclamped runs agree to
+    well under a percent of the driven response — the clamp must not touch
+    below-threshold / linear-growth physics."""
+    states = {}
+    for stab in (False, True):
+        module = _make_module(e_amplitude=3e-4, stabilize=stab)
+        y, peak = _run(module, 100)
+        assert np.isfinite(peak)
+        states[stab] = np.asarray(y["Ck_electrons"].view(jnp.complex128))
+    a, b = states[False], states[True]
+    scale = np.max(np.abs(a[1:]))  # response lives in n >= 1
+    assert scale > 0
+    diff = np.max(np.abs(a - b))
+    assert diff < 1e-2 * scale, f"clamp not transparent: diff={diff:.3e} vs response={scale:.3e}"
+
+
+def test_stabilize_survives_strong_forcing():
+    """The regression: |E|/α = 1.5 at Nn=512, dt=0.1 detonates the truncated
+    hierarchy for EVERY uncapped integrator at any dt (development
+    dt-convergence study: γ ≈ 1 ωp persisting as dt→0, filter on). With
+    terms.stabilize the same drive must run 400 steps finite and bounded."""
+    module = _make_module(e_amplitude=0.15, stabilize=True)
+    # auto cap at Nn=512, dt=0.1, alpha=0.1: 0.3*0.1/(2*sqrt(512)*0.1) ≈ 6.6e-3
+    vf = module.diffeqsolve_quants["terms"].vector_field
+    assert vf.force_cap is not None and 5e-3 < vf.force_cap < 8e-3
+    _, peak = _run(module, 400)
+    assert np.isfinite(peak), "stabilized run went non-finite"
+    assert peak < 1e6, f"stabilized run unbounded: peak/C0 ~ {peak / 1e3:.2e}"
+
+
+def test_epw_dispersion_unchanged_with_stabilize():
+    """Landau gate with the clamp on: perturbation fields (~1e-4) sit far
+    below the cap, so frequency and damping must match kinetic theory at the
+    same tolerances as the unclamped suite."""
+    from adept import electrostatic
+
+    klambda_D = 0.30
+    mode = 1
+    Lx = 4.0 * np.pi
+    k = 2.0 * np.pi * mode / Lx
+    alpha_e = klambda_D * np.sqrt(2.0) / k
+
+    root = electrostatic.get_roots_to_electrostatic_dispersion(
+        wp_e=1.0, vth_e=1.0, k0=klambda_D, maxwellian_convention_factor=2.0
+    )
+
+    tmax = 80.0
+    cfg = {
+        "physics": {
+            "Lx": Lx,
+            "alpha_e": alpha_e,
+            "alpha_i": alpha_e,
+            "n0_e": 1.0,
+            "n0_i": 1.0,
+            "nu": 0.0,
+            "static_ions": True,
+            "c_light": 1.0,
+        },
+        "grid": {"Nn": 256, "Ni": 2, "Nx": 64, "tmax": tmax, "dt": 0.05},
+        "density": {"perturbation": {"mode": mode, "amplitude": 1.0e-4}},
+        "drivers": {},
+        "terms": {"integrator": "strang-exp", "stabilize": True},
+        "save": {"fields": {"t": {"tmin": 0.0, "tmax": tmax, "nt": 1601}}},
+    }
+    module = BaseHermitePoisson1D(cfg)
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    module.init_diffeqsolve()
+    sol = module(None)["solver result"]
+
+    e_xt = np.asarray(sol.ys["fields"]["e"])
+    t = np.asarray(sol.ts["fields"])
+    A = np.abs(np.fft.fft(e_xt, axis=1)[:, mode]) / e_xt.shape[1]
+    i0 = len(t) // 10
+    peaks = [i for i in range(i0 + 1, len(t) - 1) if A[i] >= A[i - 1] and A[i] > A[i + 1]]
+    t_pk = t[peaks]
+    omega = np.pi / np.mean(np.diff(t_pk))
+    gamma = np.polyfit(t_pk, np.log(A[peaks]), 1)[0]
+
+    np.testing.assert_allclose(omega, float(np.real(root)), rtol=0.02)
+    np.testing.assert_allclose(gamma, float(np.imag(root)), rtol=0.05)


### PR DESCRIPTION
## Why

SRS threshold campaigns need runs that complete below **and** above threshold; accuracy at saturation amplitude is explicitly out of scope (there is no trapping saturation in a truncated ladder). Above threshold the truncated AW-Hermite hierarchy detonates once local fields reach the strong-forcing zone (x = dt·|accel|·√(4Nn)/α ≳ O(1)). The kinetic-srs absorber-bracket campaign (2026-07-04) showed this is an instability of the truncated *system*, not a dissipation-tuning problem: death times were insensitive to 30× filter strength, 5× LB ν, and 2× Nn (1.97–2.07 ps vs 1.99 ps control at 3e14), and absolute-n knee absorbers were catastrophically unstable (0.01–0.05 ps). The detonating structure lives at n ≈ 1–25 — inside the resonance band, below any absorber that preserves the instability being measured.

## What

`terms.stabilize: true` enables two clamps (each independently overridable):

- **`force_cap`** (auto = 0.3·α/(2·√Nn·dt), i.e. x capped at 0.3): smooth tanh saturation of the species acceleration. Transparent through the linear/threshold phase — fields sit 10–100× below the cap and the relative distortion is (a/cap)²/3 — and artificially saturates the parametric loop gain above it. Above-threshold runs are stable but **not** quantitatively accurate at saturation, analogous to an enveloped LPSE run growing past its validity.
- **`wave_density_max`** (auto = 2.0): clip on the electron density the wave equation sees (safety net against runaway ωpe²·dt² at large δn).

## Tests

- transparency: clamped == unclamped to <1% of the driven response at |accel|/cap ≈ 0.05
- survival: the strong-forcing case (E/α = 1.5, Nn=512) that detonates every uncapped configuration at any dt runs 400 steps finite and bounded
- physics gate: EPW dispersion + Landau damping with `stabilize: true` at the standard tolerances

Full HP suite: **32 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)