### PR TITLE
Remove velocity-space Hou-Li filtering (vlasov1d + vlasov2d)

### DIFF
--- a/adept/_vlasov1d/datamodel.py
+++ b/adept/_vlasov1d/datamodel.py
@@ -144,12 +144,23 @@ class EMDriverSetConfig(BaseModel):
 
 
 class HouLiFilterConfig(BaseModel):
-    """Configuration for optional Hou-Li spectral filtering."""
+    """Configuration for optional Hou-Li spectral filtering (configuration space only)."""
 
     is_on: bool
     alpha: float = 36.0
     order: int = 36
-    dimensions: list[str] = ["x", "v"]
+    dimensions: list[str] = ["x"]
+
+    @field_validator("dimensions")
+    @classmethod
+    def _no_velocity_space(cls, v: list[str]) -> list[str]:
+        bad = [d for d in v if d != "x"]
+        if bad:
+            raise ValueError(
+                "velocity-space Hou-Li filtering has been removed: the FFT filter is "
+                f"periodic in v and corrupts f(v). Only dimensions=['x'] is allowed; got {v}."
+            )
+        return v
 
 
 class FokkerPlanckConfig(BaseModel):

--- a/adept/_vlasov1d/solvers/pushers/vlasov.py
+++ b/adept/_vlasov1d/solvers/pushers/vlasov.py
@@ -175,9 +175,7 @@ class HouLiFilter:
         """Apply the x-space Hou-Li filter to each species distribution."""
         result = {}
         for species_name, f in f_dict.items():
-            result[species_name] = jnp.real(
-                jnp.fft.irfft(self.filter_x[:, None] * jnp.fft.rfft(f, axis=0), axis=0)
-            )
+            result[species_name] = jnp.real(jnp.fft.irfft(self.filter_x[:, None] * jnp.fft.rfft(f, axis=0), axis=0))
         return result
 
 

--- a/adept/_vlasov1d/solvers/pushers/vlasov.py
+++ b/adept/_vlasov1d/solvers/pushers/vlasov.py
@@ -147,8 +147,11 @@ class HouLiFilter:
     """Hou-Li spectral filter.
 
     Applies the exponential filter from Hou & Li (2007) to damp high-frequency
-    numerical oscillations without affecting well-resolved modes. Can filter
-    in x (position), v (velocity), or both dimensions.
+    numerical oscillations without affecting well-resolved modes.
+
+    Configuration-space (x) ONLY. Velocity-space filtering was removed: the FFT-based
+    filter is periodic in v, so it wraps the forward tail onto the -v edge and corrupts
+    f(v). It must never be applied in velocity space.
 
     The filter kernel in Fourier space is:
 
@@ -162,37 +165,19 @@ class HouLiFilter:
         pseudo-spectral methods. J. Comput. Phys., 226(1), 379-397.
     """
 
-    def __init__(self, species_grids: dict, nx: int, alpha: float, order: int, dimensions: list[str]):
-        """Precompute x and v Fourier-space filter kernels for requested dimensions."""
-        if "x" in dimensions:
-            j_x = jnp.arange(nx // 2 + 1)
-            eta_x = j_x / (nx // 2)
-            self.filter_x = jnp.exp(-alpha * eta_x ** (2 * order))
-        else:
-            self.filter_x = None
-
-        self.filters_v = {}
-        if "v" in dimensions:
-            for species_name, sg in species_grids.items():
-                nv = sg["nv"]
-                j = jnp.arange(nv // 2 + 1)
-                eta = j / (nv // 2)
-                self.filters_v[species_name] = jnp.exp(-alpha * eta ** (2 * order))
+    def __init__(self, nx: int, alpha: float, order: int):
+        """Precompute the x (configuration-space) Fourier filter kernel."""
+        j_x = jnp.arange(nx // 2 + 1)
+        eta_x = j_x / (nx // 2)
+        self.filter_x = jnp.exp(-alpha * eta_x ** (2 * order))
 
     def __call__(self, f_dict: dict) -> dict:
-        """Apply configured Hou-Li filters to each species distribution."""
+        """Apply the x-space Hou-Li filter to each species distribution."""
         result = {}
         for species_name, f in f_dict.items():
-            filtered = f
-
-            if self.filter_x is not None:
-                filtered = jnp.real(jnp.fft.irfft(self.filter_x[:, None] * jnp.fft.rfft(filtered, axis=0), axis=0))
-
-            if species_name in self.filters_v:
-                sigma_v = self.filters_v[species_name]
-                filtered = jnp.real(jnp.fft.irfft(sigma_v[None, :] * jnp.fft.rfft(filtered, axis=1), axis=1))
-
-            result[species_name] = filtered
+            result[species_name] = jnp.real(
+                jnp.fft.irfft(self.filter_x[:, None] * jnp.fft.rfft(f, axis=0), axis=0)
+            )
         return result
 
 

--- a/adept/_vlasov1d/solvers/vector_field.py
+++ b/adept/_vlasov1d/solvers/vector_field.py
@@ -222,11 +222,9 @@ class VlasovPoissonFokkerPlanck:
             self.hou_li_filter_on = hl_cfg["is_on"]
             if self.hou_li_filter_on:
                 self.hou_li_filter = vlasov.HouLiFilter(
-                    species_grids=cfg["grid"]["species_grids"],
                     nx=cfg["grid"]["nx"],
                     alpha=hl_cfg["alpha"],
                     order=hl_cfg["order"],
-                    dimensions=hl_cfg["dimensions"],
                 )
         else:
             self.hou_li_filter_on = False

--- a/adept/_vlasov2d/datamodel.py
+++ b/adept/_vlasov2d/datamodel.py
@@ -140,7 +140,19 @@ class HouLiFilterConfig(BaseModel):
     is_on: bool = False
     alpha: float = 36.0
     order: int = 36
-    dimensions: list[str] = ["x", "y", "vx", "vy"]
+    dimensions: list[str] = ["x", "y"]
+
+    @field_validator("dimensions")
+    @classmethod
+    def _no_velocity_space(cls, v: list[str]) -> list[str]:
+        bad = [d for d in v if d not in ("x", "y")]
+        if bad:
+            raise ValueError(
+                "velocity-space Hou-Li filtering has been removed: the FFT filter is "
+                f"periodic in velocity and corrupts f(v). Only spatial dims ['x','y'] "
+                f"are allowed; got {v}."
+            )
+        return v
 
 
 class FokkerPlanckConfig(BaseModel):

--- a/adept/_vlasov2d/solvers/pushers/vlasov.py
+++ b/adept/_vlasov2d/solvers/pushers/vlasov.py
@@ -174,9 +174,14 @@ class VelocityRotateB:
 
 
 class HouLiFilter:
-    """Separable Hou-Li spectral filter in any subset of {x, y, vx, vy}."""
+    """Separable Hou-Li spectral filter in configuration space {x, y}.
 
-    def __init__(self, species_grids: dict, nx: int, ny: int, alpha: float, order: int, dimensions: list[str]):
+    Velocity-space (vx, vy) filtering was removed: the FFT-based filter is periodic in
+    velocity, so it wraps the forward tail onto the -v edge and corrupts f(v). It must
+    never be applied in velocity space.
+    """
+
+    def __init__(self, nx: int, ny: int, alpha: float, order: int, dimensions: list[str]):
         self.dimensions = dimensions
 
         def _f1d(n):
@@ -186,14 +191,6 @@ class HouLiFilter:
 
         self.filter_x = _f1d(nx) if "x" in dimensions else None
         self.filter_y = _f1d(ny) if "y" in dimensions else None
-
-        self.filters_vx = {}
-        self.filters_vy = {}
-        for name, sg in species_grids.items():
-            if "vx" in dimensions:
-                self.filters_vx[name] = _f1d(sg["nvx"])
-            if "vy" in dimensions:
-                self.filters_vy[name] = _f1d(sg["nvy"])
 
     @staticmethod
     def _apply(f, sigma, axis):
@@ -207,10 +204,7 @@ class HouLiFilter:
     def __call__(self, f_dict):
         out = {}
         for name, f in f_dict.items():
-            ff = f
-            ff = self._apply(ff, self.filter_x, 0)
+            ff = self._apply(f, self.filter_x, 0)
             ff = self._apply(ff, self.filter_y, 1)
-            ff = self._apply(ff, self.filters_vx.get(name), 2)
-            ff = self._apply(ff, self.filters_vy.get(name), 3)
             out[name] = ff
         return out

--- a/adept/_vlasov2d/solvers/vector_field.py
+++ b/adept/_vlasov2d/solvers/vector_field.py
@@ -68,7 +68,6 @@ class TimeIntegrator:
         hl = cfg["terms"].get("hou_li_filter", {"is_on": False})
         if hl.get("is_on", False):
             self.filter = vlasov.HouLiFilter(
-                species_grids=species_grids,
                 nx=cfg["grid"]["nx"],
                 ny=cfg["grid"]["ny"],
                 alpha=hl["alpha"],

--- a/configs/vlasov-2d/base.yaml
+++ b/configs/vlasov-2d/base.yaml
@@ -48,7 +48,7 @@ terms:
     is_on: false
     alpha: 36.0
     order: 36
-    dimensions: ["x", "y", "vx", "vy"]
+    dimensions: ["x", "y"]
 
 drivers:
   ex: {}


### PR DESCRIPTION
## Why
The Hou-Li spectral filter is FFT-based → **periodic** in whatever axis it filters. Applied in **velocity** space it wraps the forward tail of `f` onto the `-v` edge, producing a spurious `-v` bump and corrupting `f(v)`. It should never be applied in velocity space.

## What
- **`HouLiFilter` (vlasov1d & vlasov2d): configuration-space only.** Removed the velocity-kernel precompute (`filters_v` / `filters_vx` / `filters_vy`), their application in `__call__`, and the now-unused `species_grids` constructor arg. x-space (and x/y in 2d) filtering is unchanged.
- **`HouLiFilterConfig.dimensions`** now defaults to `["x"]` (1d) / `["x","y"]` (2d), with a `field_validator` that **raises** if any velocity dimension (`v` / `vx` / `vy`) is requested — so it cannot be re-enabled from a config.
- `configs/vlasov-2d/base.yaml`: `dimensions: ["x","y","vx","vy"]` → `["x","y"]`.

## Verification
- All changed modules compile; `HouLiFilterConfig` accepts `["x"]`/`["x","y"]` and rejects `["x","v"]` / `["x","y","vx","vy"]`; `HouLiFilter` constructs and runs x-only (1d) and x/y-only (2d).
- No remaining references to the velocity kernels or `species_grids=` in the filter call sites; no test/example config enables velocity-space filtering.

Companion change in kinetic-srs: all vlasov configs set `dimensions: [x]` (velocity filter off), which remains valid under this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)