### PR TITLE
fix(vlasov1d): correct v0/L0 normalization (drop spurious sqrt(2))

### DIFF
--- a/adept/normalization.py
+++ b/adept/normalization.py
@@ -79,7 +79,10 @@ def electron_debye_normalization(n0_str, T0_str):
     Returns the electron thermal normalization for the given density and temperature.
     Unit quantities are:
         - Debye length
-        - Electron thermal velocity
+        - Electron thermal velocity (RMS/std-dev convention: v0 = sqrt(T0/m_e), so a
+          Maxwellian at T_hat=1 is exp(-v_hat^2/2)) -- this is the convention the
+          _vlasov1d module's initializer, collision operators, and dispersion tests
+          actually run in.
         - Langmuir oscillation frequency
     """
     n0 = UREG.Quantity(n0_str)
@@ -88,7 +91,7 @@ def electron_debye_normalization(n0_str, T0_str):
     wp0 = ((n0 * UREG.e**2.0 / (UREG.m_e * UREG.epsilon_0)) ** 0.5).to("rad/s")
     tau = 1 / wp0
 
-    v0 = ((2.0 * T0 / UREG.m_e) ** 0.5).to("m/s")
+    v0 = ((T0 / UREG.m_e) ** 0.5).to("m/s")
     x0 = (v0 / wp0).to("nm")
 
     return PlasmaNormalization(m0=UREG.m_e, q0=UREG.e, n0=n0, T0=T0, L0=x0, v0=v0, tau=tau)

--- a/docs/source/solvers/vlasov1d/overview.md
+++ b/docs/source/solvers/vlasov1d/overview.md
@@ -16,6 +16,24 @@ where $f$ is the distribution function, $E$ is the electric field, $C(f)$ is the
 
 The distribution function is $f = f(t, x, v)$ and the electric field is $E = E(t, x)$.
 
+## Normalization
+
+`_vlasov1d` uses `adept.normalization.electron_debye_normalization`, which normalizes to:
+
+- Velocity unit $v_0 = \sqrt{T_0/m_e}$ (RMS / standard-deviation convention, **not**
+  the most-probable-speed $\sqrt{2T_0/m_e}$).
+- Length unit $L_0 = v_0/\omega_{p0} = \lambda_{De}$ (the electron Debye length).
+- Time unit $\tau = 1/\omega_{p0}$.
+- Code wavenumber $\hat k = k\,\lambda_{De}$.
+- A Maxwellian at $\hat T = 1$ is $f \propto e^{-v^2/2}$ (variance 1 in code units).
+
+This is the convention the initializer (`helpers.py`), the Lenard-Bernstein/Dougherty
+collision operators, and the Landau-damping/ion-acoustic dispersion tests all assume.
+Dimensionless (numeric) config inputs bypass normalization entirely and are unaffected
+by this convention; only dimensional-string inputs (temperatures, box sizes, gradient
+scale lengths, laser wavelengths) and logged physical units (`v0`, `x0`, `c_light`,
+`box_length`) go through it.
+
 ## Multispecies Support
 
 The solver supports multiple particle species (e.g., electrons and ions) evolving self-consistently under a shared electric field. Each species can have:

--- a/tests/test_vlasov1d/test_config_regression/fokker_planck_conservation_array_config.yml
+++ b/tests/test_vlasov1d/test_config_regression/fokker_planck_conservation_array_config.yml
@@ -38,7 +38,7 @@ drivers:
         w0: 1.0
   ey: {}
 grid:
-  beta: 0.088474881879774
+  beta: 0.062561188941867
   dt: 0.1
   dx: 0.785
   ion_charge:
@@ -16505,6 +16505,7 @@ grid:
       - 6.38125
       - 6.39375
       vmax: 6.4
+      vmin: -6.4
   species_params:
     electron:
       charge: -1.0
@@ -17723,17 +17724,17 @@ terms:
 units:
   derived:
     T0: 2000 electron_volt
-    beta: 0.088474881879774
-    box_length: 0.07623654008768617 micron
+    beta: 0.062561188941867
+    box_length: 0.05390737447020297 micron
     box_width: inf
-    c_light: 11.302642950785
+    c_light: 15.984350951661
     logLambda_ee: -11.781233290653
     n0: 1.5e+21 / cubic_centimeter
     nuee: -574949910190.1326 hertz
     sim_duration: 0.004622577634581562 picosecond
     tp0: 0.45768095391896646 femtosecond
-    v0: 26524102.30999721 meter / second
+    v0: 18755372.608284798 meter / second
     wp0: 2184928150138955.5 radian / second
-    x0: 12.139576447083783 nanometer
+    x0: 8.58397682646544 nanometer
   normalizing_density: 1.5e21/cc
   normalizing_temperature: 2000eV

--- a/tests/test_vlasov1d/test_config_regression/fokker_planck_conservation_derived_config.yml
+++ b/tests/test_vlasov1d/test_config_regression/fokker_planck_conservation_derived_config.yml
@@ -38,7 +38,7 @@ drivers:
         w0: 1.0
   ey: {}
 grid:
-  beta: 0.088474881879774
+  beta: 0.062561188941867
   dt: 0.1
   dx: 0.785
   max_steps: 105
@@ -111,17 +111,17 @@ terms:
 units:
   derived:
     T0: 2000 electron_volt
-    beta: 0.088474881879774
-    box_length: 0.07623654008768617 micron
+    beta: 0.062561188941867
+    box_length: 0.05390737447020297 micron
     box_width: inf
-    c_light: 11.302642950785
+    c_light: 15.984350951661
     logLambda_ee: -11.781233290653
     n0: 1.5e+21 / cubic_centimeter
     nuee: -574949910190.1326 hertz
     sim_duration: 0.004622577634581562 picosecond
     tp0: 0.45768095391896646 femtosecond
-    v0: 26524102.30999721 meter / second
+    v0: 18755372.608284798 meter / second
     wp0: 2184928150138955.5 radian / second
-    x0: 12.139576447083783 nanometer
+    x0: 8.58397682646544 nanometer
   normalizing_density: 1.5e21/cc
   normalizing_temperature: 2000eV

--- a/tests/test_vlasov1d/test_config_regression/fokker_planck_conservation_units.yml
+++ b/tests/test_vlasov1d/test_config_regression/fokker_planck_conservation_units.yml
@@ -1,13 +1,13 @@
 T0: 2000 electron_volt
-beta: 0.088474881879774
-box_length: 0.07623654008768617 micron
+beta: 0.062561188941867
+box_length: 0.05390737447020297 micron
 box_width: inf
-c_light: 11.302642950785
+c_light: 15.984350951661
 logLambda_ee: -11.781233290653
 n0: 1.5e+21 / cubic_centimeter
 nuee: -574949910190.1326 hertz
 sim_duration: 0.004622577634581562 picosecond
 tp0: 0.45768095391896646 femtosecond
-v0: 26524102.30999721 meter / second
+v0: 18755372.608284798 meter / second
 wp0: 2184928150138955.5 radian / second
-x0: 12.139576447083783 nanometer
+x0: 8.58397682646544 nanometer

--- a/tests/test_vlasov1d/test_config_regression/multispecies_ion_acoustic_array_config.yml
+++ b/tests/test_vlasov1d/test_config_regression/multispecies_ion_acoustic_array_config.yml
@@ -29,7 +29,7 @@ drivers:
   ex: {}
   ey: {}
 grid:
-  beta: 0.088474881879774
+  beta: 0.062561188941867
   dt: 0.5
   dx: 9.81746875
   ion_charge:
@@ -27674,6 +27674,7 @@ grid:
       - 6.3625
       - 6.3875
       vmax: 6.4
+      vmin: -6.4
     ion:
       dv: 3.90625e-05
       kv:
@@ -28709,6 +28710,7 @@ grid:
       - 0.00494140625
       - 0.00498046875
       vmax: 0.005
+      vmin: -0.005
   species_params:
     electron:
       charge: -1.0
@@ -38873,17 +38875,17 @@ terms:
 units:
   derived:
     T0: 2000 electron_volt
-    beta: 0.088474881879774
-    box_length: 3.8137571970393944 micron
+    beta: 0.062561188941867
+    box_length: 2.696733575825556 micron
     box_width: inf
-    c_light: 11.302642950785
+    c_light: 15.984350951661
     logLambda_ee: -11.781233290653
     n0: 1.5e+21 / cubic_centimeter
     nuee: -574949910190.1326 hertz
     sim_duration: 2.288633610071792 picosecond
     tp0: 0.45768095391896646 femtosecond
-    v0: 26524102.30999721 meter / second
+    v0: 18755372.608284798 meter / second
     wp0: 2184928150138955.5 radian / second
-    x0: 12.139576447083783 nanometer
+    x0: 8.58397682646544 nanometer
   normalizing_density: 1.5e21/cc
   normalizing_temperature: 2000eV

--- a/tests/test_vlasov1d/test_config_regression/multispecies_ion_acoustic_derived_config.yml
+++ b/tests/test_vlasov1d/test_config_regression/multispecies_ion_acoustic_derived_config.yml
@@ -29,7 +29,7 @@ drivers:
   ex: {}
   ey: {}
 grid:
-  beta: 0.088474881879774
+  beta: 0.062561188941867
   dt: 0.5
   dx: 9.81746875
   max_steps: 10005
@@ -120,17 +120,17 @@ terms:
 units:
   derived:
     T0: 2000 electron_volt
-    beta: 0.088474881879774
-    box_length: 3.8137571970393944 micron
+    beta: 0.062561188941867
+    box_length: 2.696733575825556 micron
     box_width: inf
-    c_light: 11.302642950785
+    c_light: 15.984350951661
     logLambda_ee: -11.781233290653
     n0: 1.5e+21 / cubic_centimeter
     nuee: -574949910190.1326 hertz
     sim_duration: 2.288633610071792 picosecond
     tp0: 0.45768095391896646 femtosecond
-    v0: 26524102.30999721 meter / second
+    v0: 18755372.608284798 meter / second
     wp0: 2184928150138955.5 radian / second
-    x0: 12.139576447083783 nanometer
+    x0: 8.58397682646544 nanometer
   normalizing_density: 1.5e21/cc
   normalizing_temperature: 2000eV

--- a/tests/test_vlasov1d/test_config_regression/multispecies_ion_acoustic_units.yml
+++ b/tests/test_vlasov1d/test_config_regression/multispecies_ion_acoustic_units.yml
@@ -1,13 +1,13 @@
 T0: 2000 electron_volt
-beta: 0.088474881879774
-box_length: 3.8137571970393944 micron
+beta: 0.062561188941867
+box_length: 2.696733575825556 micron
 box_width: inf
-c_light: 11.302642950785
+c_light: 15.984350951661
 logLambda_ee: -11.781233290653
 n0: 1.5e+21 / cubic_centimeter
 nuee: -574949910190.1326 hertz
 sim_duration: 2.288633610071792 picosecond
 tp0: 0.45768095391896646 femtosecond
-v0: 26524102.30999721 meter / second
+v0: 18755372.608284798 meter / second
 wp0: 2184928150138955.5 radian / second
-x0: 12.139576447083783 nanometer
+x0: 8.58397682646544 nanometer

--- a/tests/test_vlasov1d/test_config_regression/resonance_array_config.yml
+++ b/tests/test_vlasov1d/test_config_regression/resonance_array_config.yml
@@ -38,7 +38,7 @@ drivers:
         w0: 1.1598
   ey: {}
 grid:
-  beta: 0.088474881879774
+  beta: 0.062561188941867
   dt: 0.25
   dx: 0.654375
   ion_charge:
@@ -20745,6 +20745,7 @@ grid:
       - 6.3625
       - 6.3875
       vmax: 6.4
+      vmin: -6.4
   species_params:
     electron:
       charge: -1.0
@@ -23327,17 +23328,17 @@ terms:
 units:
   derived:
     T0: 2000 electron_volt
-    beta: 0.088474881879774
-    box_length: 0.25420273080193445 micron
+    beta: 0.062561188941867
+    box_length: 0.17974847474618633 micron
     box_width: inf
-    c_light: 11.302642950785
+    c_light: 15.984350951661
     logLambda_ee: -11.781233290653
     n0: 1.5e+21 / cubic_centimeter
     nuee: -574949910190.1326 hertz
     sim_duration: 0.21980127811958367 picosecond
     tp0: 0.45768095391896646 femtosecond
-    v0: 26524102.30999721 meter / second
+    v0: 18755372.608284798 meter / second
     wp0: 2184928150138955.5 radian / second
-    x0: 12.139576447083783 nanometer
+    x0: 8.58397682646544 nanometer
   normalizing_density: 1.5e21/cc
   normalizing_temperature: 2000eV

--- a/tests/test_vlasov1d/test_config_regression/resonance_derived_config.yml
+++ b/tests/test_vlasov1d/test_config_regression/resonance_derived_config.yml
@@ -38,7 +38,7 @@ drivers:
         w0: 1.1598
   ey: {}
 grid:
-  beta: 0.088474881879774
+  beta: 0.062561188941867
   dt: 0.25
   dx: 0.654375
   max_steps: 1925
@@ -119,17 +119,17 @@ terms:
 units:
   derived:
     T0: 2000 electron_volt
-    beta: 0.088474881879774
-    box_length: 0.25420273080193445 micron
+    beta: 0.062561188941867
+    box_length: 0.17974847474618633 micron
     box_width: inf
-    c_light: 11.302642950785
+    c_light: 15.984350951661
     logLambda_ee: -11.781233290653
     n0: 1.5e+21 / cubic_centimeter
     nuee: -574949910190.1326 hertz
     sim_duration: 0.21980127811958367 picosecond
     tp0: 0.45768095391896646 femtosecond
-    v0: 26524102.30999721 meter / second
+    v0: 18755372.608284798 meter / second
     wp0: 2184928150138955.5 radian / second
-    x0: 12.139576447083783 nanometer
+    x0: 8.58397682646544 nanometer
   normalizing_density: 1.5e21/cc
   normalizing_temperature: 2000eV

--- a/tests/test_vlasov1d/test_config_regression/resonance_units.yml
+++ b/tests/test_vlasov1d/test_config_regression/resonance_units.yml
@@ -1,13 +1,13 @@
 T0: 2000 electron_volt
-beta: 0.088474881879774
-box_length: 0.25420273080193445 micron
+beta: 0.062561188941867
+box_length: 0.17974847474618633 micron
 box_width: inf
-c_light: 11.302642950785
+c_light: 15.984350951661
 logLambda_ee: -11.781233290653
 n0: 1.5e+21 / cubic_centimeter
 nuee: -574949910190.1326 hertz
 sim_duration: 0.21980127811958367 picosecond
 tp0: 0.45768095391896646 femtosecond
-v0: 26524102.30999721 meter / second
+v0: 18755372.608284798 meter / second
 wp0: 2184928150138955.5 radian / second
-x0: 12.139576447083783 nanometer
+x0: 8.58397682646544 nanometer


### PR DESCRIPTION
## Summary

`electron_debye_normalization()` in `adept/normalization.py` defined the velocity unit as `v0 = sqrt(2*T0/m_e)` (most-probable-speed convention), but the entire `_vlasov1d` module — the distribution initializer (`helpers.py`), the Lenard-Bernstein/Dougherty collision operators, the Landau-damping and ion-acoustic dispersion tests, and every shipped example config — actually runs in `v0 = sqrt(T0/m_e)` (RMS/std-dev convention, Maxwellian `∝ e^{-v²/2}` at `T̂=1`).

Numeric (dimensionless) config inputs bypass `normalize()` entirely, so this never corrupted solver dynamics. But every **dimensional-string** input (temperatures, box sizes, gradient scale lengths, laser wavelengths) and every **logged physical unit** (`v0`, `x0`, `c_light`, `box_length`, `nuee`) was off by √2 — e.g. a `normalizing_temperature: 2000eV` run was actually a 4000 eV plasma, and the logged Debye length was √2 too large.

- Drop the `2.0 *` in `v0 = ((2.0 * T0 / UREG.m_e) ** 0.5)` → `v0 = ((T0 / UREG.m_e) ** 0.5)`. `x0` (Debye length) derives from `v0` automatically.
- `vth_norm()` is intentionally **untouched** — it's used only by the unrelated `vfp1d` solver, which is self-consistently built on the `sqrt(2T/m)` convention via its own initializer; changing it would silently halve VFP-1D's simulated temperature.
- Regenerated the 3 `tests/test_vlasov1d/test_config_regression/*` fixture sets (`_units.yml`, `_derived_config.yml`, `_array_config.yml` for `resonance`, `multispecies_ion_acoustic`, `fokker_planck_conservation`) — new values match the corrected convention exactly (e.g. `v0: 26524102 m/s → 18755372 m/s`, `x0: 12.14nm → 8.58nm`, `c_light: 11.30 → 15.98`).
- Documented the normalization explicitly in `docs/source/solvers/vlasov1d/overview.md` so it doesn't silently drift again.

## Test plan
- [x] `tests/test_vlasov1d` full suite (74 passed, 1 xpassed, 7 deselected/GPU) — Landau damping, ion-acoustic, EM dispersion, Fokker-Planck conservation, multispecies, etc. all pass **unchanged**, since they already pinned the RMS convention.
- [x] `tests/test_vlasov1d/test_config_regression.py` regenerated via `--force-regen`, then reran clean (12/12 passed).
- [ ] Downstream consumers of `electron_debye_normalization` (kinetic-srs's `ProbedVlasov1D`, which independently re-derives `v0` for grid pre-normalization) need a matching one-line fix — companion PR: ergodicio/kinetic-srs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)