### PR TITLE
fix: vlasov1d dfdt diagnostics broke the solve due to suffixed pytree keys

### DIFF
--- a/adept/_vlasov1d/modules.py
+++ b/adept/_vlasov1d/modules.py
@@ -289,10 +289,12 @@ class BaseVlasov1D(ADEPTModule):
         for species_name, (n_prof, f_s, v_ax) in dist_result.items():
             state[species_name] = jnp.array(f_s)
 
-        # Reference distribution for diagnostics (use first species)
+        # Reference distribution for diagnostics — must match the reference species
+        # used by VlasovPoissonFokkerPlanck for the dfdt diagnostics and the electron
+        # grid used by the diag save machinery in storage.py.
         # TODO(gh-174): Store species distributions separately for multi-species diagnostics
-        first_species_name = next(iter(dist_result.keys()))
-        f_ref = dist_result[first_species_name][1]
+        ref_species = "electron" if "electron" in dist_result else next(iter(dist_result.keys()))
+        f_ref = dist_result[ref_species][1]
 
         # Field quantities (same for all modes)
         for field in ["e", "de"]:

--- a/adept/_vlasov1d/solvers/vector_field.py
+++ b/adept/_vlasov1d/solvers/vector_field.py
@@ -242,14 +242,13 @@ class VlasovPoissonFokkerPlanck:
 
         diags = {}
 
+        # Diagnostics use a single reference species and unsuffixed keys to match
+        # the state built in modules.init_state and the save machinery (gh-174).
+        ref_species = "electron" if "electron" in f_dict else next(iter(f_dict))
         if self.vlasov_dfdt:
-            # Compute diagnostics for each species
-            for species_name in f_dict.keys():
-                diags[f"diag-vlasov-dfdt-{species_name}"] = (f_vlasov[species_name] - f_dict[species_name]) / self.dt
+            diags["diag-vlasov-dfdt"] = (f_vlasov[ref_species] - f_dict[ref_species]) / self.dt
         if self.fp_dfdt:
-            # Compute diagnostics for each species
-            for species_name in f_dict.keys():
-                diags[f"diag-fp-dfdt-{species_name}"] = (f_fp[species_name] - f_vlasov[species_name]) / self.dt
+            diags["diag-fp-dfdt"] = (f_fp[ref_species] - f_vlasov[ref_species]) / self.dt
 
         return e, f_fp, diags
 

--- a/tests/test_vlasov1d/test_dfdt_diagnostics.py
+++ b/tests/test_vlasov1d/test_dfdt_diagnostics.py
@@ -1,0 +1,75 @@
+"""Regression test for the dfdt diagnostics (``diag-vlasov-dfdt`` / ``diag-fp-dfdt``).
+
+``VlasovPoissonFokkerPlanck`` once emitted per-species diagnostic keys
+(``diag-vlasov-dfdt-electron``) while ``init_state_and_args`` and the save
+machinery use the unsuffixed keys (``diag-vlasov-dfdt`` / ``diag-fp-dfdt``), so
+enabling either diagnostic made diffrax raise "The vector field inside ODETerm
+must return a pytree with the same structure as y0".  No stock config enables
+these diagnostics, so the mismatch went unnoticed.
+
+This runs a few steps of a tiny simulation with both diagnostics enabled and
+checks that the solve completes and the saved dfdt arrays are populated.  The
+initial condition is a noisy super-Gaussian so that both the Vlasov term
+(advection of the density noise) and the Fokker-Planck term (relaxation toward
+a Maxwellian) produce a nonzero df/dt from the first step.
+"""
+
+import numpy as np
+import pytest
+import yaml
+
+from adept import ergoExo
+
+NX = 8
+NV = 64
+TMAX = 1.0
+NT_SAVE = 3
+
+
+@pytest.fixture
+def cfg():
+    with open("tests/test_vlasov1d/configs/fokker_planck_conservation.yaml") as f:
+        cfg = yaml.safe_load(f)
+
+    cfg["grid"]["nx"] = NX
+    cfg["grid"]["nv"] = NV
+    cfg["grid"]["tmax"] = TMAX
+
+    # Density noise -> spatial gradients -> nonzero Vlasov df/dt.
+    # Super-Gaussian (m=3) initial condition -> nonzero Fokker-Planck df/dt.
+    cfg["density"]["species-background"]["noise_val"] = 1.0e-3
+    cfg["density"]["species-background"]["m"] = 3.0
+    cfg["terms"]["fokker_planck"]["space"]["baseline"] = 1.0e-2
+
+    cfg["diagnostics"] = {"diag-vlasov-dfdt": True, "diag-fp-dfdt": True}
+
+    t_save = {"tmin": 0.0, "tmax": TMAX, "nt": NT_SAVE}
+    cfg["save"] = {
+        "fields": {"t": dict(t_save)},
+        "diag-vlasov-dfdt": {"t": dict(t_save)},
+        "diag-fp-dfdt": {"t": dict(t_save)},
+    }
+
+    cfg["mlflow"] = {"experiment": "vlasov1d-test-dfdt-diags", "run": "dfdt-diagnostics"}
+    return cfg
+
+
+def test_dfdt_diagnostics_run_and_save(cfg):
+    """Both dfdt diagnostics solve to completion and save populated arrays."""
+    exo = ergoExo()
+    exo.setup(cfg)
+    result, datasets, _ = exo(None)
+
+    solver_result = result["solver result"]
+    for key in ("diag-vlasov-dfdt", "diag-fp-dfdt"):
+        assert key in solver_result.ys
+        arr = np.asarray(solver_result.ys[key])
+        assert arr.shape == (NT_SAVE, NX, NV)
+        assert np.all(np.isfinite(arr))
+        # The t=0 snapshot is the zero-initialized state; every later snapshot
+        # must contain actual df/dt data.
+        assert np.all(np.abs(arr[1:]).max(axis=(1, 2)) > 0.0), f"{key} saves are all zero"
+
+        # The diagnostic also flows through the dist-save post-processing.
+        assert key in datasets["dists"]
+        assert key in datasets["dists"][key].data_vars


### PR DESCRIPTION
## Summary

Enabling `diag-vlasov-dfdt` or `diag-fp-dfdt` in a vlasov-1d config made diffrax raise

> The vector field inside `ODETerm` must return a pytree with the same structure as `y0`.

`VlasovPoissonFokkerPlanck.__call__` emitted per-species diagnostic keys (`diag-vlasov-dfdt-<species>`), while `init_state_and_args` and the save machinery in `storage.py` use the unsuffixed keys (`diag-vlasov-dfdt` / `diag-fp-dfdt`). No stock config enables these diagnostics, so CI never caught the mismatch.

## Fix

- The dfdt diagnostics now use a single reference species (electron when present, matching the electron grid hard-coded in the diag save path) and emit the unsuffixed keys.
- `init_state_and_args` uses the same electron-preferred reference-species rule for the zero-initialized diagnostic state, so producer, `y0`, and save machinery agree even when electron is not the first species in a multi-species config.
- Per-species dfdt diagnostics remain future work (gh-174).

## Test plan

- New regression test `tests/test_vlasov1d/test_dfdt_diagnostics.py`: runs 10 steps on a tiny 8×64 grid with both diagnostics enabled, using a noisy super-Gaussian initial condition so both the Vlasov term (advection of density noise) and the Fokker-Planck term (relaxation toward Maxwellian) produce genuinely nonzero df/dt. Asserts the solve completes, each post-t0 snapshot of both saved arrays is finite and nonzero, and the diag keys flow through the dist-save post-processing.
- Verified the test fails at the unfixed HEAD with exactly the error above, and passes with the fix.
- Sanity sweep: multispecies init/config, config validation, FP conservation, and multi-dist-save suites all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)