### PR TITLE
feat(vlasov1d): dougherty_nodrag Fokker-Planck operator

### DIFF
--- a/adept/_vlasov1d/solvers/pushers/fokker_planck.py
+++ b/adept/_vlasov1d/solvers/pushers/fokker_planck.py
@@ -266,6 +266,7 @@ class Collisions:
         """
         self.cfg = cfg
         self.fp_model, self.fp_scheme = self.__init_fp_operator__()
+        self._nodrag = cfg["terms"]["fokker_planck"].get("type", "").casefold() == "dougherty_nodrag"
         self.krook = Krook(self.cfg)
 
         v = cfg["grid"]["species_grids"]["electron"]["v"]
@@ -313,6 +314,15 @@ class Collisions:
             m = float(self.cfg["terms"]["fokker_planck"].get("m", 2.0))
             model = SuperGaussianDougherty(v=v, dv=dv, m=m)
             return model, ChangCooper(dv=dv)
+        elif fp_type == "dougherty_nodrag":
+            # Diffusion-of-the-deviation operator: nu * T * d^2/dv^2 (f - f_M[n, u, T]).
+            # Same moments machinery as Dougherty, but the implicit solve runs with
+            # C_edge = 0 (pure diffusion) and the analytic Maxwellian diffusion is
+            # subtracted explicitly with the same discrete stencil, so that
+            # C[f_M] = 0 and n, P, E are conserved while the operator carries NO
+            # drag acting on the deviation (parity-preserving in v - vph).
+            model = Dougherty(v=v, dv=dv)
+            return model, CentralDifferencing(dv=dv)
         else:
             raise NotImplementedError(f"Unknown Fokker-Planck type: {fp_type}")
 
@@ -383,7 +393,24 @@ class Collisions:
                         max_steps=self._sc_max_steps,
                     )
                 C_edge, D = self.fp_model.compute_C_and_D(f_shard, beta)
-                f_shard = vmap(self._solve_one_x, in_axes=(0, 0, 0, 0, None))(C_edge, D, nu_fp_shard, f_shard, dt)
+                if self._nodrag:
+                    C_edge = jnp.zeros_like(C_edge)
+                f_new = vmap(self._solve_one_x, in_axes=(0, 0, 0, 0, None))(C_edge, D, nu_fp_shard, f_shard, dt)
+                if self._nodrag:
+                    # subtract the diffusion of the self-consistent Maxwellian using
+                    # the SAME zero-flux stencil as the implicit operator, so f_M is
+                    # a discrete fixed point and n, P, E are conserved.
+                    vbar_col = vbar[..., None]
+                    n_prof = jnp.sum(f_shard, axis=-1) * dv
+                    f_mx = jnp.exp(-beta[..., None] * (v[None, :] - vbar_col) ** 2)
+                    f_mx = f_mx * (n_prof / (jnp.sum(f_mx, axis=-1) * dv))[..., None]
+                    DfM = D[..., None] * f_mx
+                    lap = jnp.zeros_like(DfM)
+                    lap = lap.at[..., 1:-1].set((DfM[..., 2:] - 2.0 * DfM[..., 1:-1] + DfM[..., :-2]) / dv**2)
+                    lap = lap.at[..., 0].set((DfM[..., 1] - DfM[..., 0]) / dv**2)
+                    lap = lap.at[..., -1].set((DfM[..., -2] - DfM[..., -1]) / dv**2)
+                    f_new = f_new - dt * nu_fp_shard[..., None] * lap
+                f_shard = f_new
 
             if self.cfg["terms"]["krook"]["is_on"]:
                 f_shard = self.krook(nu_K_shard, f_shard, dt)

--- a/docs/source/solvers/vlasov1d/config.md
+++ b/docs/source/solvers/vlasov1d/config.md
@@ -551,6 +551,7 @@ Available `type` values (case-insensitive):
 | `chang_cooper` | Lenard-Bernstein | Chang-Cooper | Maxwellian at v=0 |
 | `dougherty` | Dougherty | central differencing | Maxwellian at $\bar v$ |
 | `chang_cooper_dougherty` | Dougherty | Chang-Cooper | Maxwellian at $\bar v$ |
+| `dougherty_nodrag` | Dougherty (diffusion of the deviation) | central differencing | Maxwellian at $\bar v$ |
 | `super_gaussian` | Super-Gaussian Dougherty | Chang-Cooper | Super-Gaussian of order `m` at $\bar v$ |
 
 The Chang-Cooper scheme is positivity-preserving and conserves density exactly; central differencing is provided for comparison only.
@@ -610,6 +611,19 @@ terms:
       baseline: 1.0
       # ...
 ```
+
+#### dougherty_nodrag
+
+Diffusion-of-the-deviation operator
+$C[f] = \nu\, T\, \partial_v^2 \left(f - f_M[n, \bar v, T]\right)$.
+It uses the same moments machinery as `dougherty`, but the implicit solve runs
+with the drag coefficient zeroed (pure diffusion) and the diffusion of the
+self-consistent Maxwellian is subtracted explicitly using the same discrete
+zero-flux stencil, so $f_M$ is a discrete fixed point and $n$, $P$, and $E$
+are conserved. Because the operator carries no drag acting on the deviation,
+it is parity-preserving in $v - v_\phi$ — useful as a control for isolating
+the role of collisional drag (e.g. in ratchet/pawl-style transport
+experiments) while retaining Maxwellian-preserving velocity diffusion.
 
 #### self_consistent_beta
 

--- a/tests/test_vlasov1d/test_fokker_planck_conservation.py
+++ b/tests/test_vlasov1d/test_fokker_planck_conservation.py
@@ -22,7 +22,9 @@ import yaml
 from adept import ergoExo
 
 
-@pytest.mark.parametrize("operator_type", ["chang_cooper_dougherty", "chang_cooper", "Dougherty", "Lenard_Bernstein"])
+@pytest.mark.parametrize(
+    "operator_type", ["chang_cooper_dougherty", "chang_cooper", "Dougherty", "Lenard_Bernstein", "dougherty_nodrag"]
+)
 def test_fokker_planck_conservation(operator_type):
     """
     Test that Fokker-Planck operators conserve density and energy.


### PR DESCRIPTION
## Summary

Extracts the last unmerged piece of `feat/vfp1d-spherical`: the **dougherty_nodrag** Fokker-Planck type — a diffusion-of-the-deviation operator $C[f] = \nu T \partial_v^2(f - f_M[n, \bar v, T])$.

- Same moments machinery as `dougherty`, but the implicit solve runs with `C_edge = 0` (pure diffusion) and the diffusion of the self-consistent Maxwellian is subtracted explicitly with the same discrete zero-flux stencil, so $f_M$ is a discrete fixed point and n, P, E are conserved while **no drag acts on the deviation** (parity-preserving in $v - v_\phi$).
- The dfdt-diagnostics half of the original commit already landed via #322; `vector_field.py` reduces to a no-op here.
- Adds the missing config-reference docs (type table + subsection) and `dougherty_nodrag` coverage in `test_fokker_planck_conservation.py`.

## Test plan

- [x] `test_fokker_planck_conservation.py` incl. new `dougherty_nodrag` case (density + energy conserved)
- [x] `test_fp_momentum_conservation.py`, `test_fp_relaxation.py` — 14 passed
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)