### PR TITLE
feat(vlasov1d): ion-referenced normalization (units.reference: ion)

### DIFF
--- a/adept/_pic1d/simulation.py
+++ b/adept/_pic1d/simulation.py
@@ -11,7 +11,7 @@ from adept._vlasov1d.simulation import (
     EMDriverSet,
     SubspeciesDistributionSpec,
 )
-from adept.normalization import PlasmaNormalization, electron_debye_normalization
+from adept.normalization import PlasmaNormalization
 
 
 class PICSpecies:
@@ -75,10 +75,7 @@ def _density_component_names(cfg: PIC1DConfig) -> list[str]:
 
 
 def sim_from_config(cfg: PIC1DConfig) -> PIC1DSimulation:
-    plasma_norm = electron_debye_normalization(
-        cfg.units.normalizing_density,
-        cfg.units.normalizing_temperature,
-    )
+    plasma_norm = cfg.units.make_normalization()
     # If a transverse EM driver is configured we also evolve a vector potential
     # ``a(x)`` via a wave equation; in that case dt must satisfy the EM CFL.
     has_ey_driver = len(cfg.drivers.ey) > 0

--- a/adept/_vlasov1d/datamodel.py
+++ b/adept/_vlasov1d/datamodel.py
@@ -5,6 +5,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from adept.functions import EnvelopeConfig, SpaceTimeEnvelopeConfig
+from adept.normalization import PlasmaNormalization, electron_debye_normalization, ion_debye_normalization
 
 
 # TODO(gh-250): refactor to use a nested SpaceTimeEnvelopeConfig instead of inlining
@@ -56,6 +57,23 @@ class UnitsConfig(BaseModel):
 
     normalizing_temperature: str
     normalizing_density: str
+    # Reference species for the normalization. The default "electron" gives
+    # electron units (t in 1/omega_pe, v in sqrt(T0/m_e), L0 = lambda_De).
+    # "ion" gives the ion analogue (t in 1/omega_pi, v in v_ti = sqrt(T0/m_i))
+    # for kinetic-ion runs such as `terms.field: poisson-boltzmann`; there
+    # normalizing_density and normalizing_temperature are the *ion* density
+    # and temperature.
+    reference: Literal["electron", "ion"] = "electron"
+    # Ion mass number (m_i = A m_p) and charge state (q_i = Z e).
+    # Only used when reference == "ion".
+    A: float = Field(default=1.0, gt=0)
+    Z: float = Field(default=1.0, gt=0)
+
+    def make_normalization(self) -> PlasmaNormalization:
+        """Build the reference-species normalization described by this config."""
+        if self.reference == "ion":
+            return ion_debye_normalization(self.normalizing_density, self.normalizing_temperature, A=self.A, Z=self.Z)
+        return electron_debye_normalization(self.normalizing_density, self.normalizing_temperature)
 
 
 class GridConfig(BaseModel):

--- a/adept/_vlasov1d/modules.py
+++ b/adept/_vlasov1d/modules.py
@@ -19,7 +19,6 @@ from adept._vlasov1d.simulation import EMDriverSet, Species, SubspeciesDistribut
 from adept._vlasov1d.solvers.vector_field import VlasovMaxwell
 from adept._vlasov1d.storage import get_save_quantities
 from adept.functions import SpaceTimeEnvelopeConfig, SpaceTimeEnvelopeFunction
-from adept.normalization import electron_debye_normalization
 from adept.utils import filter_scalars
 
 
@@ -52,10 +51,7 @@ def sim_from_config(
     cfg: Vlasov1DConfig,
 ) -> Vlasov1DSimulation:
     """Construct a Vlasov1DSimulation from a Vlasov1DConfig."""
-    plasma_norm = electron_debye_normalization(
-        cfg.units.normalizing_density,
-        cfg.units.normalizing_temperature,
-    )
+    plasma_norm = cfg.units.make_normalization()
     beta = 1.0 / plasma_norm.speed_of_light_norm()
     has_ey_driver = len(cfg.drivers.ey) > 0
     grid = Grid.from_config(cfg.grid, beta, should_override_dt_for_em_waves=has_ey_driver, norm=plasma_norm)
@@ -117,13 +113,10 @@ class BaseVlasov1D(ADEPTModule):
             box_width = "inf"
         sim_duration = (grid.tmax * norm.tau).to("ps")
 
-        nu_ee = norm.approximate_ee_collision_frequency()
-        # e-e collision rate in code units (1/wp0). This is what the FP/Krook
-        # `baseline` rates should be compared against.
-        nu_ee_norm = (nu_ee * norm.tau).to("").magnitude
-
         beta = 1.0 / norm.speed_of_light_norm()
 
+        # wp0/tp0/v0/x0 are the plasma frequency, thermal speed, and Debye length
+        # of the reference species selected by units.reference (electron or ion).
         all_quantities = {
             "wp0": (1 / norm.tau).to("rad/s"),
             "tp0": norm.tau.to("fs"),
@@ -133,13 +126,25 @@ class BaseVlasov1D(ADEPTModule):
             "c_light": norm.speed_of_light_norm(),
             "beta": beta,
             "x0": norm.L0.to("nm"),
-            "nuee": nu_ee.to("Hz"),
-            "nuee_norm": nu_ee_norm,
-            "logLambda_ee": norm.logLambda_ee(),
             "box_length": box_length,
             "box_width": box_width,
             "sim_duration": sim_duration,
         }
+
+        if self.config_model.units.reference == "ion":
+            nu_ii = norm.approximate_ii_collision_frequency()
+            all_quantities["reference_species"] = "ion"
+            all_quantities["nuii"] = nu_ii.to("Hz")
+            # i-i collision rate in code units (1/wpi) — the ion analogue of nuee_norm.
+            all_quantities["nuii_norm"] = (nu_ii * norm.tau).to("").magnitude
+            all_quantities["logLambda_ii"] = norm.logLambda_ii()
+        else:
+            nu_ee = norm.approximate_ee_collision_frequency()
+            all_quantities["nuee"] = nu_ee.to("Hz")
+            # e-e collision rate in code units (1/wp0). This is what the FP/Krook
+            # `baseline` rates should be compared against.
+            all_quantities["nuee_norm"] = (nu_ee * norm.tau).to("").magnitude
+            all_quantities["logLambda_ee"] = norm.logLambda_ee()
 
         self.cfg["units"]["derived"] = all_quantities
 

--- a/adept/normalization.py
+++ b/adept/normalization.py
@@ -45,6 +45,29 @@ class PlasmaNormalization:
         nu_ee = UREG.Quantity(2.91e-6 * n0_cc * logLambda_ee / T0_eV**1.5, "Hz")
         return nu_ee
 
+    def logLambda_ii(self) -> float:
+        """NRL formulary ion-ion Coulomb logarithm for a single ion species.
+
+        lambda_ii = 23 - ln(Z^3 sqrt(2 n_i) / T_i^{3/2}), n_i in 1/cc, T_i in eV.
+        Only meaningful when (n0, T0, q0) describe the ion species.
+        """
+        n0_cc = self.n0.to("1/cc").magnitude
+        T0_eV = self.T0.to("eV").magnitude
+        Z = (1.0 * self.q0 / (1.0 * UREG.e)).to("").magnitude
+        return 23.0 - jnp.log(Z**3.0 * (2.0 * n0_cc) ** 0.5 * T0_eV**-1.5)
+
+    def approximate_ii_collision_frequency(self) -> UREG.Quantity:
+        """NRL formulary ion collision rate: nu_i = 4.80e-8 Z^4 mu^-1/2 n_i lambda_ii T_i^-3/2 Hz.
+
+        mu = m_i/m_p. Only meaningful when (m0, q0, n0, T0) describe the ion species.
+        """
+        n0_cc = self.n0.to("1/cc").magnitude
+        T0_eV = self.T0.to("eV").magnitude
+        Z = (1.0 * self.q0 / (1.0 * UREG.e)).to("").magnitude
+        mu = (1.0 * self.m0 / (1.0 * UREG.m_p)).to("").magnitude
+        nu_ii = UREG.Quantity(4.80e-8 * Z**4.0 * mu**-0.5 * n0_cc * self.logLambda_ii() / T0_eV**1.5, "Hz")
+        return nu_ii
+
     def vth_norm(self) -> float:
         """Thermal velocity in normalized units: vth / v0."""
         return ((2.0 * self.T0 / self.m0) ** 0.5 / self.v0).to("").magnitude
@@ -96,6 +119,36 @@ def electron_debye_normalization(n0_str, T0_str):
     x0 = (v0 / wp0).to("nm")
 
     return PlasmaNormalization(m0=UREG.m_e, q0=UREG.e, n0=n0, T0=T0, L0=x0, v0=v0, tau=tau)
+
+
+def ion_debye_normalization(n0_str, T0_str, A=1.0, Z=1.0):
+    """
+    Returns the ion thermal normalization for the given ion density and temperature.
+
+    The reference species is an ion with mass m_i = A m_p and charge Z e; `n0_str`
+    is the ion number density n_i and `T0_str` the ion temperature T_i.
+    Unit quantities are:
+        - L0 = ion Debye length, sqrt(eps0 T0 / (n0 Z^2 e^2))
+        - v0 = ion thermal velocity sqrt(T0/m_i) (same RMS / standard-deviation
+          convention as `electron_debye_normalization`)
+        - tau = 1/wpi, wpi = sqrt(n0 Z^2 e^2 / (eps0 m_i))
+
+    Under this convention code time is in 1/omega_pi and code velocity in v_ti —
+    the ion-unit convention used for kinetic-ion runs such as the Boltzmann
+    electron closure in Vlasov-1D.
+    """
+    n0 = UREG.Quantity(n0_str)
+    T0 = UREG.Quantity(T0_str)
+    m0 = A * UREG.m_p
+    q0 = Z * UREG.e
+
+    wpi = ((n0 * q0**2.0 / (m0 * UREG.epsilon_0)) ** 0.5).to("rad/s")
+    tau = 1 / wpi
+
+    v0 = ((T0 / m0) ** 0.5).to("m/s")
+    x0 = (v0 / wpi).to("nm")
+
+    return PlasmaNormalization(m0=m0, q0=q0, n0=n0, T0=T0, L0=x0, v0=v0, tau=tau)
 
 
 def laser_normalization(laser_wavelength_str, T0_str):

--- a/configs/vlasov-1d/iaw-turbulence-big-bench.yaml
+++ b/configs/vlasov-1d/iaw-turbulence-big-bench.yaml
@@ -1,6 +1,9 @@
 units:
   normalizing_temperature: 1000eV
   normalizing_density: 1.0e19/cc
+  reference: ion
+  A: 1.0
+  Z: 1.0
 density:
   quasineutrality: true
   species-ion-background:

--- a/configs/vlasov-1d/iaw-turbulence-big.yaml
+++ b/configs/vlasov-1d/iaw-turbulence-big.yaml
@@ -1,6 +1,9 @@
 units:
   normalizing_temperature: 1000eV
   normalizing_density: 1.0e19/cc
+  reference: ion
+  A: 1.0
+  Z: 1.0
 density:
   quasineutrality: true
   species-ion-background:

--- a/configs/vlasov-1d/iaw-turbulence.yaml
+++ b/configs/vlasov-1d/iaw-turbulence.yaml
@@ -1,6 +1,12 @@
+# reference: ion makes the normalization ion-referenced (t in 1/omega_pi,
+# v in v_ti), so normalizing_temperature/density label the ion temperature
+# and density and write_units() reports ion-referenced physical quantities.
 units:
   normalizing_temperature: 1000eV
   normalizing_density: 1.0e19/cc
+  reference: ion
+  A: 1.0
+  Z: 1.0
 density:
   quasineutrality: true
   species-ion-background:

--- a/configs/vlasov-1d/iaw-vortex-test-leapfrog.yaml
+++ b/configs/vlasov-1d/iaw-vortex-test-leapfrog.yaml
@@ -1,6 +1,9 @@
 units:
   normalizing_temperature: 1000eV
   normalizing_density: 1.0e19/cc
+  reference: ion
+  A: 1.0
+  Z: 1.0
 density:
   quasineutrality: true
   species-ion-background:

--- a/configs/vlasov-1d/iaw-vortex-test.yaml
+++ b/configs/vlasov-1d/iaw-vortex-test.yaml
@@ -1,6 +1,9 @@
 units:
   normalizing_temperature: 1000eV
   normalizing_density: 1.0e19/cc
+  reference: ion
+  A: 1.0
+  Z: 1.0
 density:
   quasineutrality: true
   species-ion-background:

--- a/docs/source/solvers/vlasov1d/config.md
+++ b/docs/source/solvers/vlasov1d/config.md
@@ -40,6 +40,9 @@ Physical unit normalizations for the simulation.
 |-------|------|-------------|
 | `normalizing_temperature` | string | Reference temperature with unit, e.g., `"2000eV"` |
 | `normalizing_density` | string | Reference density with unit, e.g., `"1.5e21/cc"` |
+| `reference` | string | Reference species for the normalization: `"electron"` (default) or `"ion"` |
+| `A` | float | Ion mass number, $m_i = A\,m_p$ (only used with `reference: ion`; default `1.0`) |
+| `Z` | float | Ion charge state, $q_i = Z e$ (only used with `reference: ion`; default `1.0`) |
 
 Example:
 ```yaml
@@ -69,6 +72,37 @@ Consequences of the $v_0 = \sqrt{T_0/m_e}$ (σ) convention:
 Dimensional inputs (strings with units, e.g. `xmax: 100um`) are converted with these
 units; plain numeric inputs are taken to already be in code units and pass through
 unchanged.
+
+### Ion reference (`reference: ion`)
+
+For runs where only ions are evolved kinetically (e.g. `terms.field:
+poisson-boltzmann`), set `reference: ion` to build the normalization from the ion
+species instead:
+
+| Unit | Definition | Meaning |
+|------|-----------|---------|
+| time | $\tau = 1/\omega_{pi}$, $\omega_{pi} = \sqrt{n_i Z^2 e^2/(\epsilon_0 m_i)}$ | inverse ion plasma frequency |
+| velocity | $v_0 = \sqrt{T_0/m_i}$ | ion thermal speed (same σ convention) |
+| length | $L_0 = v_0/\omega_{pi}$ | ion Debye length |
+
+with $m_i = A\,m_p$ and charge $Z e$; `normalizing_density` and
+`normalizing_temperature` are then the ion density $n_i$ and ion temperature
+$T_i$. Dimensional string inputs (e.g. `xmax: 300um`, `tmax: 50ps`) convert with
+these ion units, and the physical quantities logged by `write_units()` (`wp0`,
+`tp0`, `x0`, `v0`, ...) refer to the ion reference. The electron-specific
+collision entries (`nuee`, `nuee_norm`, `logLambda_ee`) are replaced by their
+ion-ion counterparts (`nuii`, `nuii_norm`, `logLambda_ii`, from the NRL
+formulary).
+
+Example (deuterium):
+```yaml
+units:
+  normalizing_temperature: 100eV   # T_i
+  normalizing_density: 1.0e20/cc   # n_i
+  reference: ion
+  A: 2.0
+  Z: 1.0
+```
 
 ## density
 
@@ -562,9 +596,11 @@ species must have positive charge (electrons are the closure, not a species).
 and `T0: 1.0`, code time is `1/omega_pi`, velocity is the ion thermal speed
 `v_ti`, and length is `v_ti/omega_pi`. Then `Te` is the electron-to-ion
 temperature ratio `Te/Ti`, the sound speed is `c_s = sqrt(Te)`, and the electron
-Debye length is `lambda_De = sqrt(Te)` in code units. Note that the physical
-quantities reported by `write_units()` assume an electron reference species and
-are nominal for such runs.
+Debye length is `lambda_De = sqrt(Te)` in code units. Set `units.reference: ion`
+(see [units](#units)) so that dimensional string inputs and the physical
+quantities reported by `write_units()` follow this same ion convention — with
+the default electron reference they are electron-referenced and therefore
+nominal for such runs.
 
 Example (ion-acoustic turbulence, `Te/Ti = 0.05`):
 ```yaml

--- a/tests/test_vlasov1d/configs/boltzmann_iaw.yaml
+++ b/tests/test_vlasov1d/configs/boltzmann_iaw.yaml
@@ -1,6 +1,7 @@
 units:
   normalizing_temperature: 2000eV
   normalizing_density: 1.5e21/cc
+  reference: ion
 
 
 # Kinetic ions with linearized Boltzmann electrons, in ion units:

--- a/tests/test_vlasov1d/test_units_boundary.py
+++ b/tests/test_vlasov1d/test_units_boundary.py
@@ -14,14 +14,24 @@ The engine convention under test: v0 = sqrt(T0/m_e) (RMS / standard-deviation
 thermal speed), L0 = v0/wp0 = lambda_De, Maxwellian exp(-v^2/2) at T=1.
 """
 
+from pathlib import Path
+
 import numpy as np
+import yaml
 from scipy import constants as csts
 
-from adept.normalization import electron_debye_normalization, normalize
+from adept.normalization import electron_debye_normalization, ion_debye_normalization, normalize
 
 N0_STR, T0_STR = "1.5e21/cc", "2000eV"
 N0_SI = 1.5e21 * 1e6  # 1/m^3
 T0_J = 2000.0 * csts.e
+
+# Ion reference: deuterium at ion density n_i and ion temperature T_i
+A_ION, Z_ION = 2.0, 1.0
+NI_STR, TI_STR = "1.0e20/cc", "100eV"
+NI_SI = 1.0e20 * 1e6  # 1/m^3
+TI_J = 100.0 * csts.e
+M_ION = A_ION * csts.m_p
 
 
 def test_debye_normalization_against_codata():
@@ -72,3 +82,93 @@ def test_logged_collision_frequency_is_physical():
     np.testing.assert_allclose(log_lambda, expected, rtol=1e-10)
     assert log_lambda > 0
     assert norm.approximate_ee_collision_frequency().to("Hz").magnitude > 0
+
+
+def test_ion_debye_normalization_against_codata():
+    """Ion v0, L0, tau, and c_hat must match hand-computed CODATA values."""
+    norm = ion_debye_normalization(NI_STR, TI_STR, A=A_ION, Z=Z_ION)
+
+    v_ti = np.sqrt(TI_J / M_ION)  # sigma convention: sqrt(T/m_i)
+    wpi = np.sqrt(NI_SI * (Z_ION * csts.e) ** 2 / (csts.epsilon_0 * M_ION))
+    lambda_di = v_ti / wpi
+
+    np.testing.assert_allclose(norm.v0.to("m/s").magnitude, v_ti, rtol=1e-6)
+    np.testing.assert_allclose(norm.L0.to("m").magnitude, lambda_di, rtol=1e-6)
+    np.testing.assert_allclose(norm.tau.to("s").magnitude, 1.0 / wpi, rtol=1e-6)
+    np.testing.assert_allclose(norm.speed_of_light_norm(), csts.c / v_ti, rtol=1e-6)
+    # A Z=1 ion normalization at (n, T) shares the Debye length with the electron
+    # one but the plasma frequency is sqrt(m_e/m_i) smaller
+    e_norm = electron_debye_normalization(NI_STR, TI_STR)
+    np.testing.assert_allclose(norm.L0.to("m").magnitude, e_norm.L0.to("m").magnitude, rtol=1e-6)
+    np.testing.assert_allclose((norm.tau / e_norm.tau).to("").magnitude, np.sqrt(M_ION / csts.m_e), rtol=1e-6)
+
+
+def test_ion_dimensional_string_round_trip():
+    """String inputs must convert with the ion units (L0 = lambda_Di, tau = 1/wpi)."""
+    norm = ion_debye_normalization(NI_STR, TI_STR, A=A_ION, Z=Z_ION)
+
+    v_ti = np.sqrt(TI_J / M_ION)
+    wpi = np.sqrt(NI_SI * (Z_ION * csts.e) ** 2 / (csts.epsilon_0 * M_ION))
+    lambda_di = v_ti / wpi
+
+    np.testing.assert_allclose(normalize("300um", norm, dim="x"), 300e-6 / lambda_di, rtol=1e-6)
+    np.testing.assert_allclose(normalize("50ps", norm, dim="t"), wpi * 50e-12, rtol=1e-6)
+    np.testing.assert_allclose(normalize("1/um", norm, dim="k"), lambda_di / 1e-6, rtol=1e-6)
+    np.testing.assert_allclose(normalize("100km/s", norm, dim="v"), 100e3 / v_ti, rtol=1e-6)
+    assert normalize(3.25, norm, dim="x") == 3.25
+
+
+def test_ion_collision_frequency_against_nrl():
+    """logLambda_ii and nu_ii must match the NRL formulary expressions."""
+    norm = ion_debye_normalization(NI_STR, TI_STR, A=A_ION, Z=Z_ION)
+
+    # NRL single-species ii Coulomb log: 23 - ln(Z^3 sqrt(2 n_i) / T_i^3/2)
+    expected_log = 23.0 - np.log(Z_ION**3 * np.sqrt(2.0 * 1.0e20) * 100.0**-1.5)
+    np.testing.assert_allclose(float(norm.logLambda_ii()), expected_log, rtol=1e-10)
+    assert expected_log > 0
+
+    # NRL ion collision rate: 4.80e-8 Z^4 mu^-1/2 n_i lambda_ii T_i^-3/2 Hz
+    expected_nu = 4.80e-8 * Z_ION**4 / np.sqrt(A_ION) * 1.0e20 * expected_log * 100.0**-1.5
+    np.testing.assert_allclose(norm.approximate_ii_collision_frequency().to("Hz").magnitude, expected_nu, rtol=1e-10)
+
+
+def test_ion_reference_config_round_trip():
+    """A full ion-reference config converts dimensional grid inputs with ion units,
+    and write_units() reports ion-referenced quantities."""
+    from adept._vlasov1d.modules import BaseVlasov1D
+
+    with open(Path(__file__).parent / "configs" / "boltzmann_iaw.yaml") as f:
+        cfg = yaml.safe_load(f)
+
+    cfg["units"] = {
+        "normalizing_temperature": TI_STR,
+        "normalizing_density": NI_STR,
+        "reference": "ion",
+        "A": A_ION,
+        "Z": Z_ION,
+    }
+    cfg["grid"]["xmax"] = "300um"
+    cfg["grid"]["tmax"] = "50ps"
+
+    module = BaseVlasov1D(cfg)
+    norm = module.simulation.plasma_norm
+    grid = module.simulation.grid
+
+    v_ti = np.sqrt(TI_J / M_ION)
+    wpi = np.sqrt(NI_SI * (Z_ION * csts.e) ** 2 / (csts.epsilon_0 * M_ION))
+
+    # x round trip: grid.xmax (code units) * L0 must be the 300 um we asked for
+    np.testing.assert_allclose(grid.xmax * norm.L0.to("m").magnitude, 300e-6, rtol=1e-6)
+    # t: tmax is realigned to a whole number of steps, so compare to within one dt
+    assert abs(grid.tmax - wpi * 50e-12) <= grid.dt
+
+    units = module.write_units()
+    np.testing.assert_allclose(units["wp0"].to("rad/s").magnitude, wpi, rtol=1e-6)
+    np.testing.assert_allclose(units["v0"].to("m/s").magnitude, v_ti, rtol=1e-6)
+    np.testing.assert_allclose(units["x0"].to("m").magnitude, v_ti / wpi, rtol=1e-6)
+    np.testing.assert_allclose(units["box_length"].to("m").magnitude, 300e-6, rtol=1e-6)
+    np.testing.assert_allclose(units["sim_duration"].to("s").magnitude, grid.tmax / wpi, rtol=1e-6)
+    # Electron-specific collision entries are replaced by ion-ion ones
+    assert units["reference_species"] == "ion"
+    assert "nuii" in units and "nuii_norm" in units and "logLambda_ii" in units
+    assert "nuee" not in units and "nuee_norm" not in units and "logLambda_ee" not in units


### PR DESCRIPTION
## Summary

Follow-up to #324. Ion-unit runs (kinetic ions with Boltzmann electrons) previously logged electron-referenced — i.e. nominal — physical quantities from `write_units()`, and dimensional string inputs (`xmax: 300um`, `tmax: 50ps`) converted with electron units.

- **`adept/normalization.py`**: new `ion_debye_normalization(n0_str, T0_str, A=1.0, Z=1.0)` with `m0 = A·m_p`, `q0 = Z·e`, `tau = 1/ω_pi`, `v0 = √(T0/m_i)` (same σ/RMS thermal convention as the electron normalization), `L0 = v0·tau`; plus NRL-formulary `logLambda_ii()` and `approximate_ii_collision_frequency()` on `PlasmaNormalization`.
- **`UnitsConfig`** gains an opt-in `reference: electron | ion` selector (default `electron` — existing configs untouched) plus `A`/`Z`, with the dispatch on `UnitsConfig.make_normalization()`. Both vlasov1d and pic1d (which shares the model) use it, so `reference: ion` is never silently ignored.
- **`BaseVlasov1D.write_units()`** (inherited by `IAWTurbulence1D`): for the ion reference, `wp0`/`tp0`/`x0`/`v0` are the ion-referenced quantities (tagged `reference_species: ion`), and the electron-specific `nuee`/`nuee_norm`/`logLambda_ee` are replaced by `nuii`/`nuii_norm`/`logLambda_ii`. Electron-reference output is byte-identical to before, so the config regression baselines are unchanged.
- **Docs**: units reference table + "Ion reference" section in the Vlasov-1D config reference; the boltzmann_electrons note now points at `units.reference: ion` instead of calling `write_units()` nominal.
- **Configs**: all five IAW decks (`iaw-turbulence*.yaml`, `iaw-vortex-test*.yaml`) and the `boltzmann_iaw.yaml` test config now set `reference: ion` (pure relabeling — the decks are numeric code units throughout, so solver behavior is unchanged).

## Test plan

- New in `tests/test_vlasov1d/test_units_boundary.py`: CODATA cross-check of the ion normalization (incl. ω_pe/ω_pi = √(m_i/m_e)), dimensional string round-trips, NRL cross-check of ν_ii/λ_ii, and a full-config round-trip through `BaseVlasov1D` (300 µm box / 50 ps duration recovered from grid values; ion collision keys present, electron ones absent).
- Green: `test_config_regression` (baselines untouched), `test_config_validation`, `test_boltzmann_electrons` (now runs end-to-end with `reference: ion`), `test_iaw_module`, `test_units_boundary`, `test_pic1d` — 48 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)