### PR TITLE
fix(tf1d): realign ConfigModel with the solver and shipped configs

### DIFF
--- a/adept/_base_.py
+++ b/adept/_base_.py
@@ -293,8 +293,9 @@ class ergoExo:
 
         if cfg["solver"] == "tf-1d":
             from adept.tf1d import BaseTwoFluid1D as this_module
+            from adept.tf1d import ConfigModel
 
-            # config = ConfigModel(**cfg)
+            ConfigModel(**cfg)  # validate the config, raises pydantic.ValidationError on a bad one
 
         elif cfg["solver"] == "vlasov-1d":
             from adept.vlasov1d import BaseVlasov1D as this_module

--- a/adept/_tf1d/datamodel.py
+++ b/adept/_tf1d/datamodel.py
@@ -1,3 +1,7 @@
+"""Pydantic configuration models for the two-fluid 1D (`tf-1d`) solver."""
+
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -20,8 +24,11 @@ class GridModel(BaseModel):
 
 
 class TimeSaveModel(BaseModel):
-    tmin: float | None = None  # Optional: defaults to grid.tmin at runtime
-    tmax: float | None = None  # Optional: defaults to grid.tmax at runtime
+    # All three are required: `BaseTwoFluid1D.init_diffeqsolve` reads them
+    # unconditionally. The tmin/tmax defaulting in `get_derived_quantities`
+    # targets a nested `save.<name>.t` layout, which tf-1d does not use.
+    tmin: float
+    tmax: float
     nt: int
 
 
@@ -40,12 +47,21 @@ class KxSaveModel(BaseModel):
 class SaveModel(BaseModel):
     t: TimeSaveModel
     x: SpaceSaveModel
-    kx: KxSaveModel
+    kx: KxSaveModel | None = None  # Optional: omit to skip the k-space diagnostic
 
 
 class TrappingModel(BaseModel):
     is_on: bool
     kld: float
+    # Damping-reduction model applied by `VelocityStepper.landau_damping_term`.
+    # Only read when `is_on` is True.
+    model: Literal["none", "zk", "delta"] = "none"
+    # Electron-electron collision frequency used by the trapping models.
+    # Only read when `is_on` is True.
+    nuee: float | None = None
+    # Legacy neural-network shape hint (e.g. "8|8"). Present in the shipped
+    # configs but not currently read by the solver.
+    nn: str | None = None
 
 
 class IonModel(BaseModel):
@@ -54,7 +70,7 @@ class IonModel(BaseModel):
     mass: float
     T0: float
     charge: float
-    gamma: int | str
+    gamma: int | float | str
     trapping: TrappingModel
 
 
@@ -64,7 +80,7 @@ class ElectronModel(BaseModel):
     T0: float
     mass: float
     charge: float
-    gamma: int | str
+    gamma: int | float | str
     trapping: TrappingModel
 
 
@@ -90,12 +106,32 @@ class DriversModel(BaseModel):
     ex: dict[str, ExDriverModel]
 
 
+class NNModel(BaseModel):
+    """An `equinox.nn.MLP` specification for a learned closure term."""
+
+    in_size: int
+    out_size: int
+    width_size: int
+    depth: int
+    activation: str
+    final_activation: str | None = None
+
+
+class ModelsModel(BaseModel):
+    """Learned-closure models. Set `models: false` to disable them entirely."""
+
+    file: str | bool = False  # path to serialized weights, or false for untrained
+    nu_g: NNModel | None = None
+    nu_d: NNModel | None = None
+
+
 class ConfigModel(BaseModel):
     solver: str
     mlflow: MLFlowModel
-    adjoint: bool
     units: UnitsModel
     grid: GridModel
     save: SaveModel
     physics: PhysicsModel
     drivers: DriversModel
+    adjoint: bool | str | None = None
+    models: ModelsModel | bool | None = None

--- a/adept/_tf1d/solvers/pushers.py
+++ b/adept/_tf1d/solvers/pushers.py
@@ -186,7 +186,7 @@ class VelocityStepper(eqx.Module):
 
         if physics["trapping"]["is_on"]:
             self.nuee = physics["trapping"]["nuee"]
-            self.trapping_model = physics["trapping"]["model"]
+            self.trapping_model = physics["trapping"].get("model", "none")
             self.model_kld = physics["trapping"]["kld"]
             # table_klds = table_klds
             self.vph = jnp.interp(self.model_kld, table_klds, table_wrs, left=1.0, right=table_wrs[-1]) / self.model_kld
@@ -296,7 +296,9 @@ class ParticleTrapper(eqx.Module):
     norm_kld: float
     norm_nuee: float
     vph: float
-    nu_g_model: eqx.Module
+    # The growth-rate model is passed in through `args["nu_g"]` at call time, not
+    # stored on the Module. Declaring an un-assigned `nu_g_model` field here made
+    # every `trapping.is_on: true` config fail to construct.
     # nu_d_model: eqx.Module
 
     def __init__(self, cfg, species="electron"):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,3 +18,4 @@ Quick links to configuration references:
 - [LPSE-2D Config](source/solvers/lpse2d/config.md)
 - [Spectrax-1D Config](source/solvers/spectrax1d/config.md)
 - [Hermite-Legendre-1D Config](source/solvers/hermite_legendre_1d/config.md)
+- [Two-Fluid-1D Config](source/solvers/tf1d/config.md)

--- a/docs/RUNNING_A_SIM.md
+++ b/docs/RUNNING_A_SIM.md
@@ -13,5 +13,6 @@ uv run run.py --cfg path_to_my_config
 - [LPSE-2D (Envelope-2D)](source/solvers/lpse2d/config.md) - 2D laser-plasma envelope solver for TPD/SRS
 - [Spectrax-1D](source/solvers/spectrax1d/config.md) - 1D Hermite-Fourier Vlasov-Maxwell solver
 - [Hermite-Legendre-1D](source/solvers/hermite_legendre_1d/config.md) - 1D-1V mixed Hermite-Legendre electrostatic Vlasov-Poisson solver
+- [Two-Fluid-1D](source/solvers/tf1d/config.md) - 1D electrostatic two-fluid solver with kinetic closure and particle trapping
 
 See the [full documentation](https://ergodicio.github.io/adept/) for detailed guides and API reference.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ Documentation
    solvers/vlasov1d/config
    solvers/vlasov2d/config
    solvers/lpse2d/config
+   solvers/tf1d/config
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/solvers/tf1d/config.md
+++ b/docs/source/solvers/tf1d/config.md
@@ -1,0 +1,227 @@
+# Two-Fluid-1D Configuration Reference
+
+The `tf-1d` solver evolves a 1D electrostatic two-fluid (electron + ion) system
+closed with a kinetic dispersion table and an optional particle-trapping model:
+
+```
+∂n/∂t + ∂x(n u) = 0
+∂u/∂t + u ∂x u = −(∂x p)/n − (q/m) E + ν_L[u, E, δ]
+∂p/∂t + u ∂x p + γ p ∂x u = −2 n u (q/m) E
+∂δ/∂t = −v_φ ∂x δ + Γ(E) |E| / (1 + δ²)
+```
+
+with `p ≡ P/m` the mass-normalized pressure. The field is obtained spectrally
+from the charge density, `E_k = i (q_i n_{i,k} + q_e n_{e,k}) / k`.
+
+The Landau damping term `ν_L` is interpolated from a complex-frequency table
+(see `adept.electrostatic.get_complex_frequency_table`) and may be reduced
+locally by the trapping variable `δ`, whose growth rate `Γ` comes from the
+optional learned closure (see [`models`](#models)).
+
+Example configs live in `configs/tf-1d/`.
+
+## Top-level keys
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `solver` | yes | Must be `tf-1d`. |
+| `mlflow` | yes | Experiment name and run name. |
+| `units` | yes | Plasma normalization. |
+| `grid` | yes | Spatial and temporal grid. |
+| `save` | yes | Output / diagnostic save points. |
+| `physics` | yes | Per-species fluid and closure parameters. |
+| `drivers` | yes | External electrostatic drivers. |
+| `models` | no | Learned-closure (neural network) specification. |
+| `adjoint` | no | Adjoint method hint. Currently unused by the solver. |
+
+## `mlflow`
+
+```yaml
+mlflow:
+  experiment: tf1d-epw-test
+  run: test
+```
+
+## `units`
+
+```yaml
+units:
+  normalizing_temperature: 2000eV
+  normalizing_density: 1.5e21/cc
+```
+
+Sets `n0`, `T0`, `v0 = √(T0/m_e)`, `ωp0`, and `x0 = v0/ωp0`. Lengths in the
+config are in Debye lengths and times in `1/ωp0`.
+
+## `grid`
+
+```yaml
+grid:
+  nx: 16
+  xmin: 0.0
+  xmax: 20.94
+  tmin: 0.0
+  tmax: 500.0
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `nx` | int | Number of spatial cells (periodic, spectral derivatives). |
+| `xmin`, `xmax` | float | Box extent in Debye lengths. |
+| `tmin`, `tmax` | float | Simulation time window in `1/ωp0`. |
+
+`dx`, `dt = 0.05 dx`, and `nt` are derived at runtime; `tmax` is snapped to a
+whole number of steps and the step count is capped at `1e6`.
+
+## `save`
+
+```yaml
+save:
+  t:
+    tmin: 0.5
+    tmax: 500.0
+    nt: 1000
+  x:
+    xmin: 0.0
+    xmax: 20.94
+    nx: 16
+  kx:            # optional
+    kxmin: 0.0
+    kxmax: 0.3
+    nkx: 2
+```
+
+| Block | Required | Fields | Description |
+| --- | --- | --- | --- |
+| `t` | yes | `tmin`, `tmax`, `nt` | Save times. All three are required — `tf-1d` does not fall back to the `grid` values. |
+| `x` | yes | `xmin`, `xmax`, `nx` | Real-space interpolation grid for the saved fields. |
+| `kx` | no | `kxmin`, `kxmax`, `nkx` | k-space diagnostic. Omit the block entirely to skip it. |
+
+## `physics`
+
+Both `ion` and `electron` blocks are required, even when a species is frozen
+with `is_on: false`.
+
+```yaml
+physics:
+  electron:
+    is_on: true
+    landau_damping: true
+    mass: 1.0
+    charge: -1.0
+    T0: 1.0
+    gamma: kinetic
+    trapping:
+      is_on: true
+      model: zk
+      kld: 0.3
+      nuee: 1.0e-7
+      nn: 8|8
+  ion:
+    is_on: false
+    landau_damping: false
+    mass: 1836.0
+    charge: 1.0
+    T0: 1.0
+    gamma: 3
+    trapping:
+      is_on: false
+      kld: 0.3
+      nuee: 1.0e-9
+```
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `is_on` | bool | — | Evolve this species. When false, `dn/dt = du/dt = dP/dt = 0`. |
+| `landau_damping` | bool | — | Apply the tabulated Landau damping rate `ω_i(k)` to the momentum equation. |
+| `mass` | float | — | Species mass normalized to `m_e`. |
+| `charge` | float | — | Species charge normalized to `e` (electrons are `-1.0`). |
+| `T0` | float | — | Initial temperature normalized to the reference `T0`. |
+| `gamma` | int \| float \| str | — | Adiabatic index. The literal string `kinetic` uses the kinetic EPW dispersion table for the restoring force instead of a fixed `γ`. |
+| `trapping` | block | — | Particle trapping model, see below. |
+
+### `physics.<species>.trapping`
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `is_on` | bool | — | Evolve the trapping variable `δ` and modify the damping term. |
+| `kld` | float | — | `kλ_D` at which the trapping model is evaluated (sets `v_φ` and the model normalization). |
+| `model` | `none` \| `zk` \| `delta` | `none` | Damping-reduction model. Only read when `is_on` is true. `delta` scales the damping by `1/(1 + δ²)`; `zk` uses the Zakharov–Karpman collision frequency (work in progress); `none` leaves the damping unmodified. |
+| `nuee` | float | `null` | Electron–electron collision frequency normalized to `ωp0`. Required in practice when `is_on` is true — it sets the trapping growth-rate normalization. |
+| `nn` | str | `null` | Legacy neural-network shape hint (e.g. `8|8`). Accepted for backwards compatibility with the shipped configs but not read by the solver. |
+
+```{note}
+`trapping.is_on: true` with no `model` key falls back to `none`, meaning `δ` is
+evolved but does not feed back on the damping rate. Set `model` explicitly if
+you want trapping to modify the physics.
+```
+
+```{warning}
+`trapping.is_on: true` is currently **not runnable**. `ParticleTrapper` reads
+the growth-rate network from `args["nu_g"]`, but nothing in the live code path
+builds it from the `models` block, so the solve fails with `KeyError: 'nu_g'`
+on the first step. Only `trapping.is_on: false` configs run end to end today.
+```
+
+## `drivers`
+
+```yaml
+drivers:
+  ex:
+    "0":
+      k0: 0.3
+      w0: 1.1598
+      dw0: 0.0
+      t_c: 80
+      t_w: 100
+      t_r: 20
+      x_c: 600
+      x_w: 800
+      x_r: 80
+      a0: 4.e-3
+```
+
+`drivers.ex` is a dictionary of independently-enveloped electrostatic drivers
+keyed by a string index; their contributions are summed.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `k0` | float | Wavenumber in `1/λ_D`. |
+| `w0` | float | Angular frequency in `ωp0`. |
+| `dw0` | float | Frequency offset added to `w0`. |
+| `t_c`, `t_w`, `t_r` | float | Temporal envelope center, width, and rise/fall length. |
+| `x_c`, `x_w`, `x_r` | float | Spatial envelope center, width, and rise/fall length. Use a very large `x_w` for a spatially uniform drive. |
+| `a0` | float | Driver amplitude. The applied field is scaled by `|k0| * a0`, not `a0` alone. |
+
+## `models`
+
+Optional learned-closure specification used by the trapping growth rate
+`nu_g` (and, when implemented, a damping model `nu_d`). Set `models: false` to
+disable learned closures entirely.
+
+```{warning}
+This block is currently accepted and validated but not consumed — the live
+solver never instantiates these networks. See the warning under
+[`trapping`](#physicsspeciestrapping).
+```
+
+```yaml
+models:
+  file: models/weights.eqx     # or false for untrained weights
+  nu_g:
+    in_size: 3
+    out_size: 1
+    width_size: 8
+    depth: 4
+    activation: tanh
+    final_activation: tanh
+```
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `file` | str \| bool | `false` | Path to serialized `equinox` weights, or `false` to start untrained. |
+| `nu_g` | block | `null` | `equinox.nn.MLP` spec for the trapping growth rate. |
+| `nu_d` | block | `null` | `equinox.nn.MLP` spec for a learned damping rate. |
+
+Each MLP block takes `in_size`, `out_size`, `width_size`, `depth`, `activation`,
+and an optional `final_activation`.


### PR DESCRIPTION
## Problem

`adept/_tf1d/datamodel.py` had drifted from both what the solver reads and what `configs/tf-1d/*.yaml` contains. This went unnoticed because the `ConfigModel(**cfg)` call in `adept/_base_.py` was commented out for the `tf-1d` branch — had it ever been enabled, **every** shipped tf-1d config would have failed validation.

## Schema changes

Each one is driven by validating all 7 tf-1d yamls (4 in `configs/tf-1d/`, 3 in `tests/test_tf1d/configs/`):

| Field | Change | Why |
| --- | --- | --- |
| `trapping.model` | added, `Literal["none","zk","delta"]`, default `"none"` | read at `pushers.py:189`; values match the branches in `VelocityStepper.landau_damping_term` |
| `trapping.nuee` | added, optional | read at `pushers.py:188` and in `ParticleTrapper.__init__` |
| `trapping.nn` | added, optional `str` | `nn: 8\|8` parses as the string `"8\|8"`; present in shipped configs, read by nothing |
| `models` | added, `ModelsModel \| bool \| None` | `configs/tf-1d/*.yaml` provide a dict; two test configs use `models: False` |
| `adjoint` | **required → optional**, `bool \| str \| None` | no shipped config sets it, nothing in `adept/` reads `cfg["adjoint"]`, and `resonance_search.yaml` sets it to the *string* `Backsolve` |
| `save.kx` | **required → optional** | `epw.yaml` omits it |
| `save.t.tmin`/`tmax` | **optional → required** | see below |
| `gamma` | `int \| str` → `int \| float \| str` | `tf1d.yaml` uses `3.0` |

The `save.t` tightening is the one that goes the other way. The existing comment claimed these default to the `grid` values at runtime, but that's wrong for this solver: the defaulting loop in `BaseTwoFluid1D.get_derived_quantities` targets a *nested* `save.<name>.t` layout, while tf-1d uses a *flat* `save.t`. It never fires, and `init_diffeqsolve` reads both unconditionally. Making them required converts a runtime `KeyError` into a clear config error; all 7 configs already set them.

Validation is re-enabled in `_base_.py`.

## Two latent crashes this surfaced

Both pre-existing, both confirmed against a stashed tree:

1. `VelocityStepper` read `physics["trapping"]["model"]` unconditionally → `KeyError` on `configs/tf-1d/tf1d.yaml`, which enables trapping but omits `model`. Now falls back to `"none"`, matching the schema default.
2. `ParticleTrapper` declared `nu_g_model: eqx.Module` with its assignment commented out, so equinox raised `Field 'nu_g_model' was not initialized` for **every** trapping-on config, `damping.yaml` included. The field is vestigial — `__call__` uses `args["nu_g"]`, and `_lpse2d/core/trapper.py` has the same commented block with no such declaration.

## Known limitation: trapping still isn't runnable

`init_state_and_args` sets `args = {"drivers": ...}` only, so trapping-on configs now validate and construct but die on the first step with `KeyError: 'nu_g'`. Nothing in the live code path builds the MLPs from the `models` block — its only consumer, `train_damping.py`, calls `helpers.get_models`, which does not exist anywhere in the repo. Wiring that up (or removing the feature) is a real design decision, so it is left out of this PR and documented as a `{warning}` in the new config reference.

Relatedly, `configs/tf-1d/tf1d.yaml` enables trapping with no `model`, so it now falls back to `"none"` — δ evolves but doesn't damp. That looks unintended for a run named `single-k=0.3-finite-amplitude-fluid-trapping`, but picking the right value is a physics call, so the config is untouched.

## Docs

`docs/source/solvers/tf1d/config.md` did not exist. Added it following the other solvers' config references, and registered it in `docs/source/index.rst`, `docs/ARCHITECTURE.md`, and `docs/RUNNING_A_SIM.md`.

## Testing

- All 7 tf-1d yamls pass `ConfigModel(**cfg)` and construct through the real `ergoExo._get_adept_module_` path.
- All 4 configs in `configs/tf-1d/` now build a `VectorField` (previously 2 of 4 crashed).
- Malformed configs fail cleanly: `Input should be 'none', 'zk' or 'delta'`, `('save','t','tmin') Field required`.
- `tests/test_tf1d/`: `test_against_vlasov` and `test_resonance_search` (4 tests, 34 min) pass. `test_landau_damping` and `test_resonance` fail with `KeyError: 'ax'` — **pre-existing and unrelated**, verified identical on a stashed tree; those tests read `mod_defaults["save"]["x"]["ax"]` from their own local dict, but `ax` is only written onto the module's copy of the cfg by `get_save_func`.
- `ruff check` findings unchanged from baseline; `datamodel.py` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)