### PR TITLE
test(vlasov1d,vlasov2d): guard the Hou-Li velocity-space rejection

### DIFF
--- a/tests/test_vlasov1d/test_config_validation.py
+++ b/tests/test_vlasov1d/test_config_validation.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
+from adept._vlasov1d.datamodel import HouLiFilterConfig
 from adept.vlasov1d import BaseVlasov1D
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
@@ -34,3 +36,29 @@ def test_config_validates_and_constructs(config_path: Path):
 
     # This should not raise - if it does, the config doesn't match the schema
     BaseVlasov1D(cfg)
+
+
+# --- Hou-Li filter: configuration space only -------------------------------------------
+#
+# The Hou-Li filter is FFT-based, hence periodic in whichever axis it filters. x is
+# periodic so filtering there is correct; v is a bounded domain (f -> 0 at +/-vmax), so
+# an FFT filter in v wraps the forward tail onto the -v edge and corrupts f(v). Velocity
+# -space filtering was therefore removed outright, and the config validator is what keeps
+# it from being reintroduced from a deck. These tests guard that validator.
+
+
+@pytest.mark.parametrize("dimensions", [["v"], ["x", "v"], ["v", "x"]])
+def test_hou_li_filter_rejects_velocity_dimensions(dimensions: list[str]):
+    """Velocity-space Hou-Li filtering must be rejected at config validation."""
+    with pytest.raises(ValidationError, match="velocity-space Hou-Li filtering has been removed"):
+        HouLiFilterConfig(is_on=True, dimensions=dimensions)
+
+
+def test_hou_li_filter_accepts_configuration_space():
+    """Filtering in x is the supported case and must still validate."""
+    assert HouLiFilterConfig(is_on=True, dimensions=["x"]).dimensions == ["x"]
+
+
+def test_hou_li_filter_defaults_to_configuration_space():
+    """The default must be x-only so an unspecified deck cannot filter in v."""
+    assert HouLiFilterConfig(is_on=False).dimensions == ["x"]

--- a/tests/test_vlasov2d/test_hou_li_filter_config.py
+++ b/tests/test_vlasov2d/test_hou_li_filter_config.py
@@ -1,0 +1,34 @@
+"""Tests that vlasov-2d Hou-Li filtering stays confined to configuration space.
+
+The Hou-Li filter is FFT-based, hence periodic in whichever axis it filters. x and y are
+periodic so filtering there is correct; vx/vy are bounded domains (f -> 0 at the velocity
+edges), so an FFT filter in velocity wraps the forward tail onto the opposite edge and
+corrupts f(v). Velocity-space filtering was removed outright, and the config validator is
+what keeps it from being reintroduced from a deck. These tests guard that validator.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from adept._vlasov2d.datamodel import HouLiFilterConfig
+
+
+@pytest.mark.parametrize(
+    "dimensions",
+    [["vx"], ["vy"], ["vx", "vy"], ["x", "y", "vx", "vy"], ["x", "vx"]],
+)
+def test_hou_li_filter_rejects_velocity_dimensions(dimensions: list[str]):
+    """Velocity-space Hou-Li filtering must be rejected at config validation."""
+    with pytest.raises(ValidationError, match="velocity-space Hou-Li filtering has been removed"):
+        HouLiFilterConfig(is_on=True, dimensions=dimensions)
+
+
+@pytest.mark.parametrize("dimensions", [["x"], ["y"], ["x", "y"]])
+def test_hou_li_filter_accepts_configuration_space(dimensions: list[str]):
+    """Filtering in x and/or y is the supported case and must still validate."""
+    assert HouLiFilterConfig(is_on=True, dimensions=dimensions).dimensions == dimensions
+
+
+def test_hou_li_filter_defaults_to_configuration_space():
+    """The default must be spatial-only so an unspecified deck cannot filter in velocity."""
+    assert HouLiFilterConfig().dimensions == ["x", "y"]


### PR DESCRIPTION
PR #305 removed velocity-space Hou-Li filtering. The filter is FFT-based, hence periodic in whichever axis it filters, and `v` is a bounded domain (`f -> 0` at `±vmax`) — so filtering in `v` wraps the forward tail onto the `-v` edge and corrupts `f(v)`. `x` (and `x`/`y` in 2d) are periodic, so filtering there is correct and is unchanged.

What prevents that from being reintroduced from a deck is the `HouLiFilterConfig.dimensions` validator — and nothing tested it. Since #305 also deleted the velocity kernel precompute, a re-added velocity dimension would not fail loudly at construction; it would depend entirely on the validator still being there.

## What this adds

Test-only. No source changes.

- `tests/test_vlasov1d/test_config_validation.py` — velocity dimensions rejected (`["v"]`, `["x","v"]`, `["v","x"]`); `["x"]` still validates; default stays `["x"]`.
- `tests/test_vlasov2d/test_hou_li_filter_config.py` (new) — `vx`/`vy` and mixed spatial+velocity lists rejected; `["x"]`/`["y"]`/`["x","y"]` still validate; default stays `["x","y"]`.

The tests assert on the pydantic `ValidationError` message, so they pin the diagnostic a user actually sees, not just the failure.

## Verification

- 31 passed (`tests/test_vlasov1d/test_config_validation.py` + the new 2d file).
- Confirmed these are genuine guards, not tautologies: against the pre-#305 datamodel (`57b0bce`) `HouLiFilterConfig(is_on=True, dimensions=["v"])` constructs successfully and the default is `["x","v"]`, so both tests fail there.
- `ruff check` / `ruff format --check` clean.

## How this surfaced

Auditing a downstream repo that had selected the Hou-Li filter as a grid-scale sink **in v** for a large-box two-stream run, before #305 landed. Upstream had already reached the same conclusion and removed it; the downstream configs then failed validation on a compute node. The removal is right — this just makes sure it stays removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)