### PR TITLE
docs(vlasov1d): document grid.parallel multi-GPU sharding

### DIFF
--- a/docs/source/solvers/vlasov1d/config.md
+++ b/docs/source/solvers/vlasov1d/config.md
@@ -222,7 +222,7 @@ Simulation grid parameters.
 | `vmin` | float | Lower bound of the velocity grid. Optional; defaults to `-vmax` (symmetric grid). Use to specify an asymmetric velocity extent (not needed for multispecies). |
 | `xmin` | float | Domain minimum x |
 | `xmax` | float | Domain maximum x |
-| `parallel` | `false` or list of `"x"`, `"v"` | Axes to parallelize across devices using `jax.shard_map`. `"x"` shards the `edfdv` push and collision operator along the spatial axis; `"v"` shards the `vdfdx` push along the velocity axis. Requires the corresponding dimension (`nx` or `nv`) to be divisible by the number of JAX devices. Defaults to `false`. |
+| `parallel` | `false` or list of `"x"`, `"v"` | Axes to parallelize across devices using `jax.shard_map`. `"x"` shards the `edfdv` push and collision operator along the spatial axis; `"v"` shards the `vdfdx` push along the velocity axis. Requires the corresponding dimension (`nx` or `nv`) to be divisible by the number of JAX devices. Defaults to `false`. See [Running on Multiple GPUs](overview.md#running-on-multiple-gpus) for the memory model, the launch command, and the reverse-mode AD caveat on `"v"`. |
 
 The velocity grid is uniform and cell-centered: `dv = (vmax - vmin) / nv` with cell centers spanning `vmin + dv/2` to `vmax - dv/2`. An asymmetric grid (`vmin != -vmax`) is useful, for example, for a bump-on-tail distribution where less resolution is needed on one side. As with `vmax`, choose bounds wide enough that `f ~ 0` at *both* edges so that the spectral velocity push and the zero-flux collision boundary conditions remain accurate.
 

--- a/docs/source/solvers/vlasov1d/overview.md
+++ b/docs/source/solvers/vlasov1d/overview.md
@@ -138,6 +138,63 @@ Timing metrics (`run_time`, `postprocess_time_min`, `total_time`) go to MLflow a
 files. Which streams exist, and at what cadence, is entirely determined by the `save` block — see the
 [Configuration Reference](config.md#save).
 
+## Running on Multiple GPUs
+
+`grid.parallel` splits the phase-space pushes across every GPU that the process can see. It is a
+deliberately naive scheme: **one process, one node, no distributed memory**. It buys throughput on a
+distribution function that already fits in a single GPU's memory; it does not let you run a bigger one.
+
+Set it to the list of axes to split over:
+
+```yaml
+grid:
+  nx: 17280
+  parallel: ["x", "v"]
+```
+
+### What gets split
+
+Each pusher is wrapped in `jax.shard_map` over a one-dimensional mesh of `jax.devices()`:
+
+| Axis | Operators | Why no halo is needed |
+|---|---|---|
+| `"x"` | `edfdv` (`exponential` and `cubic-spline`) and the collision operator (Fokker-Planck + Krook) | Both are pointwise in $x$ — an independent velocity-space solve per spatial cell |
+| `"v"` | `vdfdx` (`exponential`) | The spectral $x$-advection is an independent phase rotation per velocity |
+
+Because the two axes are different, `["x", "v"]` makes XLA insert an all-to-all between the velocity
+and spatial pushes on every step. That transpose is the entire cost of the scheme, so it pays off only
+when $f$ is large enough that the per-device push dominates the reshuffle. Splitting a single axis
+(`["x"]`) avoids the transpose but leaves the other push serial.
+
+Everything else — the Poisson/Ampère solve, the Hou-Li filter, the drivers, the diagnostics, and the
+saves — operates on the global array and is gathered by XLA as needed. Nothing about `save` or
+post-processing changes: the state `diffrax` carries is an ordinary global array, so netCDF output is
+byte-for-byte the same as a serial run's.
+
+### Requirements and limits
+
+- `nx` must be divisible by the device count for `"x"`, and *every* species' `nv` for `"v"`. Otherwise
+  `shard_map` raises at trace time, naming the offending axis and size.
+- One process must see all the GPUs. On a NERSC Perlmutter node that means requesting the four GPUs
+  and launching **one** task — no `srun -n 4`:
+
+  ```bash
+  srun -n 1 -c 32 -G 4 uv run run.py --cfg configs/vlasov-1d/my-deck
+  ```
+
+- The full $f$ is allocated on the default device at initialization, so it must fit on one GPU. This is
+  the "naive" part, and the reason sharded initialization and sharded checkpointing are not involved.
+- Results match the serial path to round-off. The pushes are bitwise identical per step; over a run,
+  reduction reordering inside the shards leaves a drift of order $10^{-15}$ in $E$.
+- **`"v"` breaks reverse-mode AD.** `jax.grad` through the $v$-sharded `vdfdx` fails on jax 0.9.0.1
+  with a cotangent-type mismatch from the FFT along the unsharded axis (an upstream `shard_map`
+  limitation, reproducible in a few lines of pure JAX). Forward mode (`jax.jvp`) is fine, and the
+  $x$-sharded operators differentiate correctly in both modes with gradients identical to serial. For
+  gradient work, use `parallel: ["x"]`.
+
+For scale: an electron + ion deck at `nx: 17280`, `nv: 2048` with `parallel: ["x", "v"]` ran at
+roughly 45 ms/step on four A100s.
+
 ## Practical Notes
 
 **Density profile.** Uniform is easy. For a non-uniform profile you have to specify the parameters of


### PR DESCRIPTION
## Why

`grid.parallel` — the naive multi-GPU option added in #212 and fixed in #220 — is alive and working on `main`, but the only trace of it in the docs is one row of the `grid` config table. That was enough to make it look like the feature had been removed. Nothing told you what memory model it implies, how to launch it, or whether it was safe to switch on for an existing deck.

Docs only. No behavior change.

## What

- New **Running on Multiple GPUs** section in `docs/source/solvers/vlasov1d/overview.md`: what each axis shards and why neither needs a halo, the all-to-all that `["x", "v"]` costs per step, the one-process/one-node memory model, the `nx`/`nv` divisibility requirement, the Perlmutter launch command (`srun -n 1 -G 4`, *not* `-n 4`), and the reverse-mode AD caveat.
- The `parallel` row in `config.md` now links to it.

## Verification

Everything asserted in the new section was measured on jax 0.9.0.1 with four devices (`XLA_FLAGS=--xla_force_host_platform_device_count=4`):

| Check | Result |
|---|---|
| `VelocityExponential` x-sharded | bitwise identical to serial |
| `VelocityCubicSpline` x-sharded | bitwise identical to serial |
| `Collisions` (Dougherty) x-sharded | bitwise identical to serial |
| `SpaceExponential` v-sharded, forward | bitwise identical to serial |
| `jax.grad` through x-sharded pushers | matches serial to 1e-16 |
| `jax.jvp` through v-sharded `vdfdx` | matches serial |
| `jax.grad` through v-sharded `vdfdx` | **fails** — see below |
| full `resonance.yaml` run, FP + Krook on, 160 steps, `parallel: ["x", "v"]` | `max abs(dE)` = 3.2e-15 vs serial; netCDF saves and postprocessing unaffected |

The one real limitation found: `jax.grad` through the $v$-sharded `vdfdx` raises `TypeError: cotangent type does not match function output, expected ShapedArray(complex128[4,17]) but got JitTracer(complex128[4,17]{V:device})`. It is upstream, not ours — it reduces to `jax.grad` over `shard_map(lambda f: irfft(rfft(f, axis=0), axis=0), in_specs=P(None, "device"))`, no adept involved. Forward mode is unaffected, so the guidance in the docs is `parallel: ["x"]` for gradient work.

## Not in this PR

- A regression test for the sharded path (there is currently none, which is how it rotted into looking deleted).
- The 4-GPU production deck and sbatch launcher that produced the ~45 ms/step figure quoted in the section; they still live only on the unmerged `claude/vlasov1d-boltzmann-electrons-eba310`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)