### PR TITLE
fix(vlasov1d): clamp interpolated-save query points to the solver grid

### DIFF
--- a/adept/_vlasov1d/storage.py
+++ b/adept/_vlasov1d/storage.py
@@ -162,6 +162,25 @@ def get_field_save_func(cfg):
     return fields_save_func
 
 
+def _clamp_to_knots(q: jnp.ndarray, knots: jnp.ndarray) -> jnp.ndarray:
+    """Clamp interpolation query points into the range spanned by ``knots``.
+
+    Save axes built by :func:`_add_dim_axes` are endpoint-inclusive, while the
+    solver's own x and v axes are cell-centred.  A save axis that spans the full
+    domain therefore overhangs the outermost solver cell centres by half a solver
+    cell at each end -- for example a ``v: {vmin: -15, vmax: 15}`` save against a
+    ``vmax: 15`` solver grid queries exactly +/-15, which lies outside the
+    solver's outermost cell centres no matter how fine the grid is.  ``interp2d``
+    defaults to ``extrap=False`` and returns NaN there, which would silently
+    poison the edge rows/columns of every interpolated save.  Clamping gives
+    those cells the nearest solver-cell value instead.
+
+    ``min``/``max`` rather than the first/last element, so a descending or
+    otherwise unordered axis still yields the true range.
+    """
+    return jnp.clip(q, jnp.min(knots), jnp.max(knots))
+
+
 def get_dist_save_func(axes, dist_save_config, dist_key):
     """Build a save callback for full or interpolated distribution-function output."""
     if {"t"} == set(dist_save_config.keys()):
@@ -172,8 +191,9 @@ def get_dist_save_func(axes, dist_save_config, dist_key):
 
     elif {"t", "x", "v"} == set(dist_save_config.keys()):
         xq, vq = jnp.meshgrid(dist_save_config["x"]["ax"], dist_save_config["v"]["ax"], indexing="ij")
-        xq_flat, vq_flat = xq.ravel(), vq.ravel()
         out_shape = xq.shape
+        xq_flat = _clamp_to_knots(xq.ravel(), axes["x"])
+        vq_flat = _clamp_to_knots(vq.ravel(), axes["v"])
 
         def dist_save_func(t, y, args):
             """Return the distribution interpolated on configured x-v sample points."""
@@ -181,8 +201,9 @@ def get_dist_save_func(axes, dist_save_config, dist_key):
 
     elif {"t", "kx", "v"} == set(dist_save_config.keys()):
         kxq, vq = jnp.meshgrid(dist_save_config["kx"]["ax"], dist_save_config["v"]["ax"], indexing="ij")
-        kxq_flat, vq_flat = kxq.ravel(), vq.ravel()
         out_shape = kxq.shape
+        kxq_flat = _clamp_to_knots(kxq.ravel(), axes["kx"])
+        vq_flat = _clamp_to_knots(vq.ravel(), axes["v"])
 
         def dist_save_func(t, y, args):
             """Return the distribution spectrum interpolated on configured kx-v points."""

--- a/docs/source/solvers/vlasov1d/config.md
+++ b/docs/source/solvers/vlasov1d/config.md
@@ -323,6 +323,28 @@ Each named save contains a `t` sub-key with:
 | `tmax` | float | End time for saving |
 | `nt` | int | Number of save points |
 
+### Save axis conventions
+
+A save with an `x`/`v` block is **interpolated** off the solver grid (bilinear); a save
+with only `t` is dumped at full resolution and is not interpolated at all.
+
+The two axes do not use the same convention. The save `x` axis is cell-centered like the
+solver's, but the save `v` axis is *endpoint-inclusive* — it includes `vmin` and `vmax`
+exactly. Because the solver's own v axis is cell-centered (spanning `vmin + dv/2` to
+`vmax - dv/2`), a save configured over the solver's full velocity range asks for points
+half a solver cell beyond the outermost cell centre at each end. That overhang is half a
+*solver* cell wide regardless of either resolution, so it does not shrink as the grid is
+refined.
+
+Query points outside the solver grid are clamped to it, so those edge cells take the
+nearest solver-cell value rather than becoming NaN. The saved coordinate still reports
+the configured `vmin`/`vmax`. The same clamping applies in `x`, which matters when a
+save's `nx` exceeds the solver's `grid.nx`.
+
+If you would rather the edge cells carry interpolated values than clamped ones, give the
+save a slightly narrower range than the solver grid (e.g. `vmax: 15.8` against a solver
+`vmax: 16.0`), which keeps every sample point strictly inside.
+
 ## mlflow
 
 Experiment tracking configuration.

--- a/tests/test_vlasov1d/test_multi_dist_save.py
+++ b/tests/test_vlasov1d/test_multi_dist_save.py
@@ -20,8 +20,10 @@ from copy import deepcopy
 import numpy as np
 import pytest
 import yaml
+from jax import numpy as jnp
 
 from adept import ergoExo
+from adept._vlasov1d.storage import _add_dim_axes, get_dist_save_func
 
 
 @pytest.fixture
@@ -50,6 +52,11 @@ def test_single_label_basic(base_config):
     f_result = datasets["dists"]
     assert "electron.main" in f_result
     assert "electron.main" in f_result["electron.main"].data_vars
+
+    # resonance.yaml saves v over the solver's full [-vmax, vmax], which is exactly
+    # the case that used to leave the first and last v column NaN.
+    saved = f_result["electron.main"]["electron.main"].values
+    assert np.all(np.isfinite(saved)), f"{int((~np.isfinite(saved)).sum())} non-finite cells in the save"
 
 
 def test_two_labels_same_species(base_config):
@@ -120,6 +127,105 @@ def test_dist_save_files_and_datasets(base_config):
     # Velocity coordinate named after the species, not the label
     assert "v_electron" in f_result["electron.full"]["electron.full"].dims
     assert "v_electron" in f_result["electron.monitor"]["electron.monitor"].dims
+
+
+def _solver_axis(lo: float, hi: float, n: int) -> jnp.ndarray:
+    """Cell-centred axis, matching how the solver builds its own x and v grids."""
+    d = (hi - lo) / n
+    return jnp.array(np.linspace(lo + d / 2.0, hi - d / 2.0, n))
+
+
+def _edge_save_setup(grid_nv: int, save_nv: int = 384):
+    """An x-v save spanning the solver's full domain, plus the solver axes it samples."""
+    vmax, xmax, grid_nx, save_nx = 6.4, 20.94, 32, 24
+
+    axes = {
+        "x": _solver_axis(0.0, xmax, grid_nx),
+        "v": _solver_axis(-vmax, vmax, grid_nv),
+        "kx": jnp.fft.rfftfreq(grid_nx, d=xmax / grid_nx) * 2.0 * np.pi,
+    }
+    save_cfg = {
+        "t": {"tmin": 0.0, "tmax": 1.0, "nt": 2},
+        "x": {"xmin": 0.0, "xmax": xmax, "nx": save_nx},
+        "v": {"vmin": -vmax, "vmax": vmax, "nv": save_nv},
+    }
+    _add_dim_axes(save_cfg)
+    return axes, save_cfg, (save_nx, save_nv), vmax
+
+
+@pytest.mark.parametrize("grid_nv", [384, 512, 2048])
+def test_full_domain_v_save_has_no_nan_edges(grid_nv):
+    """A save spanning [-vmax, vmax] stays finite regardless of solver resolution.
+
+    The save v axis is endpoint-inclusive while the solver's is cell-centred, so
+    the save always queries half a solver cell beyond the outermost cell centre.
+    That overhang does not shrink with resolution, so neither does the bug it used
+    to cause -- hence the sweep over grid_nv both below and above the save's nv.
+    """
+    axes, save_cfg, out_shape, _ = _edge_save_setup(grid_nv)
+
+    # Precondition: the save really is asking for points outside the solver axis.
+    assert save_cfg["v"]["ax"][0] < float(axes["v"][0])
+    assert save_cfg["v"]["ax"][-1] > float(axes["v"][-1])
+
+    func = get_dist_save_func(axes=axes, dist_save_config=save_cfg, dist_key="electron")
+    f = jnp.exp(-(axes["v"][None, :] ** 2) / 2.0) * jnp.ones((len(axes["x"]), 1))
+    out = np.asarray(func(0.0, {"electron": f}, None))
+
+    assert out.shape == out_shape
+    assert np.all(np.isfinite(out)), f"{int((~np.isfinite(out)).sum())} non-finite cells"
+
+
+def test_edge_v_columns_take_nearest_solver_value():
+    """Edge cells are clamped to the outermost solver cell, not extrapolated.
+
+    The reported v coordinate stays exactly vmin/vmax, so consumers that assume
+    the save axis spans the configured range are unaffected.
+    """
+    grid_nv = 512
+    axes, save_cfg, _, vmax = _edge_save_setup(grid_nv)
+
+    # A separable f, linear in x so that linear interpolation in x is exact.
+    g = 1.0 + 0.5 * axes["x"] / float(axes["x"][-1])
+    h = jnp.exp(-(axes["v"] ** 2) / 2.0)
+    f = g[:, None] * h[None, :]
+
+    func = get_dist_save_func(axes=axes, dist_save_config=save_cfg, dist_key="electron")
+    out = np.asarray(func(0.0, {"electron": f}, None))
+
+    g_at_save_x = np.interp(save_cfg["x"]["ax"], np.asarray(axes["x"]), np.asarray(g))
+    np.testing.assert_allclose(out[:, 0], g_at_save_x * float(h[0]), rtol=1e-6)
+    np.testing.assert_allclose(out[:, -1], g_at_save_x * float(h[-1]), rtol=1e-6)
+
+    # The coordinate the file will carry is untouched by the clamp.
+    np.testing.assert_allclose([save_cfg["v"]["ax"][0], save_cfg["v"]["ax"][-1]], [-vmax, vmax])
+
+
+def test_save_x_finer_than_solver_grid_has_no_nan_edges():
+    """A save x axis finer than the solver's also overhangs, and must stay finite."""
+    xmax, grid_nx, save_nx, vmax, grid_nv = 500.0, 64, 256, 15.0, 2048
+
+    axes = {
+        "x": _solver_axis(0.0, xmax, grid_nx),
+        "v": _solver_axis(-vmax, vmax, grid_nv),
+        "kx": jnp.fft.rfftfreq(grid_nx, d=xmax / grid_nx) * 2.0 * np.pi,
+    }
+    save_cfg = {
+        "t": {"tmin": 0.0, "tmax": 1.0, "nt": 2},
+        "x": {"xmin": 0.0, "xmax": xmax, "nx": save_nx},
+        "v": {"vmin": -vmax, "vmax": vmax, "nv": 512},
+    }
+    _add_dim_axes(save_cfg)
+
+    # Precondition: a 256-point save on a 64-point solver grid pokes out in x too.
+    assert save_cfg["x"]["ax"][0] < float(axes["x"][0])
+    assert save_cfg["x"]["ax"][-1] > float(axes["x"][-1])
+
+    func = get_dist_save_func(axes=axes, dist_save_config=save_cfg, dist_key="electron")
+    f = jnp.exp(-(axes["v"][None, :] ** 2) / 2.0) * jnp.ones((grid_nx, 1))
+    out = np.asarray(func(0.0, {"electron": f}, None))
+
+    assert np.all(np.isfinite(out)), f"{int((~np.isfinite(out)).sum())} non-finite cells"
 
 
 def test_full_resolution_save(base_config):


### PR DESCRIPTION
## The bug

Any distribution save with an `x`/`v` block writes NaN into its **first and last v column**, for every `t` and every `x`.

The two axes are built with different conventions:

- **Solver** v axis (`_vlasov1d/helpers.py`): `linspace(vmin + dv/2, vmax - dv/2, nv)` — cell-centred.
- **Save** v axis (`_add_dim_axes`): the half-cell offset is computed only for `dim_key == "x"`; every other dim gets `dx = 0.0`, giving `linspace(vmin, vmax, nv)` — endpoint-inclusive.

So a save spanning the solver's full velocity range queries exactly `±vmax`, half a solver cell beyond the outermost cell centre. `interp2d` is called without `extrap`, and interpax defaults to `extrap=False` → NaN.

**This does not shrink with resolution.** The overhang is half a *solver* cell wide, so it is present at any `nv`:

```
grid nv=512   solver v hi 14.970703   save hi 15   -> 2 NaN columns
grid nv=2048  solver v hi 14.992676   save hi 15   -> 2 NaN columns
grid nv=16384 solver v hi 14.999084   save hi 15   -> 2 NaN columns
```

The same thing happens in `x` when a save's `nx` exceeds the solver's `grid.nx`.

## Why it went unnoticed

The run succeeds, and a NaN edge column reads as a blank margin in a phase-space plot. But it poisons anything reducing over v — a sum over the v axis for a Casimir or energy diagnostic returns NaN at every time, which surfaces downstream as NaN gradients that look like a diverging optimizer rather than a corrupt input file.

`tests/test_vlasov1d/configs/resonance.yaml` has `grid.vmax: 6.4` and a save over `v ∈ [-6.4, 6.4]`, so **this repo's own test suite was producing two NaN columns**, uncaught.

## The fix

Clamp interpolation query points into the knot range. Edge cells take the nearest solver-cell value instead of becoming NaN, and the saved coordinate still reports the configured `vmin`/`vmax` — so consumers that assume the save spans its configured range are unaffected, and no archival file changes shape or coordinates.

Considered and rejected: cell-centring the save axis for all dims (cleaner conceptually, but shifts the reported v coordinates by half a save cell, so new files stop being coordinate-comparable with old ones, and when save `nv` == solver `nv` the endpoints coincide exactly — a float-equality edge not worth relying on); and dropping the edge cells (changes the artifact shape, breaking consumers that expect the configured `nv`).

## Tests

New tests in `test_multi_dist_save.py`: finiteness parametrised over grid `nv` = 384/512/2048 (deliberately spanning below and above the save's `nv`, since the bug is resolution-independent), clamping semantics including that the coordinate is untouched, and the `x`-overhang case. All 5 fail without the clamp and pass with it. A finiteness assertion is also added to the existing end-to-end `test_single_label_basic`, which covers the real pipeline via `resonance.yaml`.

`tests/test_vlasov1d` passes in full (112 passed, 1 xpassed) — the same selection CI runs. `test_config_regression.py` also passes, confirming the logged save axes are unchanged.

## Note for downstream consumers

The fix is forward-only. Artifacts already written keep their NaN edge columns, so anything reading an existing interpolated save should drop those two v columns or re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)