### PR TITLE
perf(vlasov1d): halve reverse-mode residuals in the spectral velocity push

### DIFF
--- a/adept/_vlasov1d/solvers/pushers/vlasov.py
+++ b/adept/_vlasov1d/solvers/pushers/vlasov.py
@@ -7,10 +7,62 @@ import equinox as eqx
 import jax
 import numpy as np
 from interpax import interp1d, interp2d
+from jax import Array, shard_map, vmap
 from jax import numpy as jnp
-from jax import shard_map, vmap
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
+
+
+def _shift_spectrum_impl(spectrum: Array, k: Array, dt: float, shift: Array) -> Array:
+    """Multiply a half-spectrum by the translation factor exp(-i·k·dt·shift)."""
+    return jnp.exp(-1j * k[None, :] * dt * shift[:, None]) * spectrum
+
+
+@jax.custom_vjp
+def _shift_spectrum(spectrum: Array, k: Array, dt: float, shift: Array) -> Array:
+    """Translate `spectrum` by `dt * shift`, recomputing the phase factor when reversed.
+
+    Mathematically this is just ``exp(-1j * k * dt * shift) * spectrum``. The custom VJP
+    exists purely to trade a stored array for a cheap recomputation in the backward pass.
+
+    Reverse-mode over the plain expression has to keep *two* residuals alive per call: the
+    spectrum, because the phase gradient needs it, and the phase factor itself, because the
+    spectrum gradient needs it. Both are ``(nx, nv // 2 + 1)`` complex128, so a single
+    velocity push stores twice the distribution function it advects — and the sixth-order
+    integrator issues six of them per timestep. Saving only ``(spectrum, k, dt, shift)`` and
+    rebuilding the phase factor from those small generators halves that, at the cost of one
+    elementwise ``exp`` on the reverse pass. On bandwidth-bound hardware that exp is cheaper
+    than the round trip to memory it replaces.
+
+    The backward rule differentiates the recomputed primal with :func:`jax.vjp` rather than
+    hand-deriving the complex-multiply adjoint, so the gradients are exact by construction
+    rather than by argument.
+
+    Note this deliberately wraps only the phase multiply, not the surrounding transforms:
+    ``rfft``/``irfft`` are linear, so autodiff already stores nothing for them, and leaving
+    them alone keeps the FFT conventions (including the Nyquist bin's treatment) untouched.
+
+    :param spectrum: half-spectrum to translate, shape ``(nx, nk)``
+    :param k: wavenumbers along the transformed axis, shape ``(nk,)``
+    :param dt: timestep the shift is applied over
+    :param shift: per-row shift rate, shape ``(nx,)``
+    """
+    return _shift_spectrum_impl(spectrum, k, dt, shift)
+
+
+def _shift_spectrum_fwd(spectrum: Array, k: Array, dt: float, shift: Array):
+    """Return the translated spectrum, saving only the small phase generators."""
+    return _shift_spectrum_impl(spectrum, k, dt, shift), (spectrum, k, dt, shift)
+
+
+def _shift_spectrum_bwd(res, cotangent: Array):
+    """Rebuild the phase factor and take the exact VJP of the recomputed primal."""
+    spectrum, k, dt, shift = res
+    _, vjp = jax.vjp(_shift_spectrum_impl, spectrum, k, dt, shift)
+    return vjp(cotangent)
+
+
+_shift_spectrum.defvjp(_shift_spectrum_fwd, _shift_spectrum_bwd)
 
 
 class VlasovExternalE(eqx.Module):
@@ -84,7 +136,7 @@ class VelocityExponential:
             accel = force / m
             result[species_name] = jnp.real(
                 jnp.fft.irfft(
-                    jnp.exp(-1j * kv_real[None, :] * dt * accel[:, None]) * jnp.fft.rfft(f, axis=1),
+                    _shift_spectrum(jnp.fft.rfft(f, axis=1), kv_real, dt, accel),
                     axis=1,
                 )
             )

--- a/tests/test_vlasov1d/test_pusher_spectral_vjp.py
+++ b/tests/test_vlasov1d/test_pusher_spectral_vjp.py
@@ -1,0 +1,159 @@
+"""Tests for the custom VJP on the spectral velocity push.
+
+``_shift_spectrum`` replaces a plain ``exp(...) * spectrum`` with an identical primal that
+rebuilds the phase factor on the backward pass instead of storing it. These tests pin the
+two properties that make that substitution safe — the primal and its gradients must be
+*unchanged* — and the property that makes it worth doing, namely that the reverse pass
+stops carrying the phase factor as a residual.
+"""
+
+import subprocess
+import sys
+
+import jax
+import numpy as np
+import pytest
+from jax import numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from adept._vlasov1d.solvers.pushers.vlasov import VelocityExponential, _shift_spectrum
+
+NX, NV, DT = 32, 256, 0.1
+
+
+def _grids():
+    """Return the wavenumber grid and a reproducible (f, accel) pair."""
+    kv = jnp.fft.rfftfreq(NV, d=12.8 / NV) * 2 * jnp.pi
+    rng = np.random.default_rng(0)
+    f = jnp.asarray(rng.normal(size=(NX, NV)))
+    accel = jnp.asarray(rng.normal(size=NX)) * 0.1
+    return kv, f, accel
+
+
+def _push_naive(f, kv, accel):
+    """The expression `_shift_spectrum` replaced, written out inline."""
+    return jnp.real(jnp.fft.irfft(jnp.exp(-1j * kv[None, :] * DT * accel[:, None]) * jnp.fft.rfft(f, axis=1), axis=1))
+
+
+def _push_custom(f, kv, accel):
+    """The same push routed through the custom-VJP helper."""
+    return jnp.real(jnp.fft.irfft(_shift_spectrum(jnp.fft.rfft(f, axis=1), kv, DT, accel), axis=1))
+
+
+def _loss(push):
+    """A scalar loss whose gradient exercises both the `f` and `accel` paths."""
+
+    def loss(f, kv, accel):
+        return jnp.sum(push(f, kv, accel) ** 2 * jnp.cos(jnp.arange(NV)[None, :] / NV))
+
+    return loss
+
+
+def _residual_bytes(fn, *args):
+    """Bytes autodiff keeps alive between the forward and backward passes of `fn`.
+
+    The residuals of a linearized function are exactly the constants closed over by its
+    linear part, so this reads them straight off the jaxpr. That makes the measurement a
+    property of JAX's partial evaluation rather than of any particular XLA backend.
+    """
+    _, linear = jax.linearize(fn, *args)
+    jaxpr = jax.make_jaxpr(linear)(*jax.tree.map(jnp.zeros_like, args))
+    return sum(jnp.asarray(c).size * jnp.asarray(c).dtype.itemsize for c in jaxpr.consts)
+
+
+def test_forward_is_bit_identical_to_naive():
+    """The custom VJP must not perturb the primal, not even in the last bit."""
+    kv, f, accel = _grids()
+    assert jnp.array_equal(_push_naive(f, kv, accel), _push_custom(f, kv, accel))
+
+
+@pytest.mark.parametrize("argnum, name", [(0, "f"), (2, "accel")])
+def test_gradients_are_bit_identical_to_naive(argnum, name):
+    """Gradients must match the inline expression exactly, through both input paths.
+
+    Bit-identity rather than a tolerance: the backward rule differentiates a recomputation
+    of the *same* primal expression, so any discrepancy at all would mean the recomputation
+    has drifted from what the forward pass actually did.
+    """
+    kv, f, accel = _grids()
+    expected = jax.grad(_loss(_push_naive), argnums=argnum)(f, kv, accel)
+    actual = jax.grad(_loss(_push_custom), argnums=argnum)(f, kv, accel)
+    assert jnp.array_equal(expected, actual), f"gradient wrt {name} changed"
+
+
+def test_phase_factor_is_not_kept_as_a_residual():
+    """The reverse pass should carry the spectrum but no longer the phase factor.
+
+    Both are ``(nx, nv // 2 + 1)`` complex128, so dropping one of the two is a ~2x cut. The
+    assertion is a band rather than an equality so that unrelated small residuals elsewhere
+    in the expression do not make it brittle.
+    """
+    kv, f, accel = _grids()
+    naive = _residual_bytes(lambda a, b: _push_naive(a, kv, b), f, accel)
+    custom = _residual_bytes(lambda a, b: _push_custom(a, kv, b), f, accel)
+
+    phase_bytes = NX * (NV // 2 + 1) * jnp.complex128.dtype.itemsize
+    assert custom <= naive - phase_bytes, f"phase factor still resident: {naive} -> {custom} bytes"
+    assert custom < 0.6 * naive
+
+
+def test_velocity_exponential_gradients_match_naive_end_to_end():
+    """Drive the real pusher class and compare against the inline expression."""
+    kv, f, accel = _grids()
+    species_grids = {"electron": {"kvr": kv}}
+    species_params = {"electron": {"charge": -1.0, "mass": 1.0}}
+    pusher = VelocityExponential(species_grids, species_params)
+
+    # `push` takes the field, not the acceleration: with q = -1 and m = 1, accel = -e.
+    def via_class(e_field):
+        return jnp.sum(pusher.push({"electron": f}, e=e_field, pond=jnp.zeros(NX), dt=DT)["electron"] ** 2)
+
+    def via_naive(e_field):
+        return jnp.sum(_push_naive(f, kv, -e_field) ** 2)
+
+    e = -accel
+    assert jnp.allclose(jax.grad(via_class)(e), jax.grad(via_naive)(e), rtol=0, atol=0)
+
+
+def test_custom_vjp_composes_with_shard_map():
+    """The sharded push must still trace and differentiate under `shard_map`.
+
+    `parallel: [x]` (used by the large IAW configs) wraps `VelocityExponential.push` in a
+    `shard_map`, so the custom VJP has to survive that composition. Runs in a subprocess
+    because faking multiple devices requires XLA flags set before JAX initializes.
+    """
+    script = """
+import os
+os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+import jax
+jax.config.update("jax_enable_x64", True)
+import numpy as np
+from jax import numpy as jnp
+from adept._vlasov1d.solvers.pushers.vlasov import VelocityExponential
+
+nx, nv, dt = 32, 256, 0.1
+kv = jnp.fft.rfftfreq(nv, d=12.8 / nv) * 2 * jnp.pi
+rng = np.random.default_rng(0)
+f = jnp.asarray(rng.normal(size=(nx, nv)))
+e = jnp.asarray(rng.normal(size=nx)) * 0.1
+pond = jnp.zeros(nx)
+
+grids = {"electron": {"kvr": kv}}
+params = {"electron": {"charge": -1.0, "mass": 1.0}}
+serial = VelocityExponential(grids, params, parallel=False)
+sharded = VelocityExponential(grids, params, parallel=True)
+
+def loss(pusher):
+    return lambda ef: jnp.sum(pusher({"electron": f}, e=ef, pond=pond, dt=dt)["electron"] ** 2)
+
+assert len(jax.devices()) == 4, jax.devices()
+np.testing.assert_allclose(loss(serial)(e), loss(sharded)(e), rtol=1e-12)
+np.testing.assert_allclose(
+    jax.grad(loss(serial))(e), jax.grad(loss(sharded))(e), rtol=1e-10, atol=1e-12
+)
+print("ok")
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "ok" in result.stdout


### PR DESCRIPTION
## What

The spectral velocity push is

```python
irfft(exp(-1j * kv * dt * accel) * rfft(f))
```

`accel` comes from the field solve, so it is traced, and reverse-mode has to keep **two** `(nx, nv//2+1)` complex128 arrays alive per call: the spectrum (needed by the phase gradient) and the phase factor (needed by the spectrum gradient). That is two residual arrays for every one distribution function advected, and `SixthOrderHamIntegrator` issues six pushes per timestep.

This routes the phase multiply through a `custom_vjp` that saves only the spectrum and the small generators (`kv`, `dt`, `accel`), and rebuilds the phase factor on the backward pass.

## Measured

Residual bytes read straight off the linearized jaxpr, so the numbers are a property of JAX's partial evaluation rather than of any one backend. At `nx=64, nv=4096` (the `bump-on-tail.yaml` velocity resolution):

| | residual / push |
|---|---|
| before | 4.229 MB |
| after | 2.115 MB |

Exactly the phase factor dropped — 50.0%. Under the sixth-order integrator that is ~25 MB/step of `edfdv` residual against a 2.1 MB state, so the per-step figure goes to ~12.7 MB.

## Correctness

The primal and both gradients come out **bit-identical** to the expression they replace. The tests assert equality, not a tolerance — a silent gradient change in an optimization codebase is the failure mode worth guarding against, and bit-identity means no downstream behaviour can shift.

Two choices make that guarantee cheap to hold:

- The wrapper covers **only the phase multiply**, not the surrounding transforms. `rfft`/`irfft` are linear, so autodiff already stores nothing for them; leaving them untouched keeps the FFT conventions (including the Nyquist bin, which a spectral shift does *not* treat as a pure rotation) exactly as they were.
- The backward rule differentiates a recomputation of the same primal with `jax.vjp` rather than hand-deriving the complex-multiply adjoint. Exact by construction rather than by argument.

## Scope

`SpaceExponential` and `HouLiFilter` are deliberately left alone. Their factors are built from constants — the `v`-grid times `dt`, and the fixed filter kernel — so XLA hoists them out of the step and there is no per-step residual to save. Only `VelocityExponential` has a traced phase. (If `dt` ever becomes traced, e.g. adaptive stepping, `SpaceExponential` would become a candidate too.)

## Tests

New `tests/test_vlasov1d/test_pusher_spectral_vjp.py` — 6 tests:

- forward is bit-identical to the inline expression
- gradients are bit-identical through both the `f` and `accel` paths
- the phase factor is provably no longer a residual (asserted in bytes, not inferred)
- end-to-end through the real `VelocityExponential` class
- composes with `shard_map` — `parallel: [x]` (used by the large IAW configs) wraps `push`, so the custom VJP has to survive that. Runs in a subprocess since faking devices needs XLA flags set before JAX initializes; there was no prior sharding coverage here.

Full suite: `113 passed, 7 deselected, 1 xpassed`. The xpass is the pre-existing self-marked flaky `test_landau_damping` ("Fails mysteriously with float64"), unrelated.

CI needs no change — the existing paths filter already covers `adept/_vlasov1d/**` and `tests/test_vlasov1d/**`.

## Tradeoff worth knowing

This buys memory with compute: one extra elementwise `exp` on the reverse pass. On CPU that measures ~7% slower backward for the 50% memory. On GPU these kernels are bandwidth-bound, so recomputing an `exp` should beat the 2 MB round trip it replaces — but that wants confirming on real hardware before anyone leans on it. A GPU A/B benchmark script (peak memory + backward time, monkeypatching the helper back to the plain expression) is available separately; it was kept out of the tree since there is no `benchmarks/` dir. If it comes back negative for production grid sizes, the change is one line to revert at the call site.

The payoff is not the 2 MB by itself — it is that halving per-step residuals lets `RecursiveCheckpointAdjoint` afford more checkpoints at the same memory ceiling, which is the dominant backward cost on the long IAW runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjo7qNpJAiCWtEMmhEiStA)_