### PR TITLE
perf(vlasov1d): specialize cubic interpolation

### DIFF
--- a/adept/_vlasov1d/solvers/pushers/vlasov.py
+++ b/adept/_vlasov1d/solvers/pushers/vlasov.py
@@ -6,9 +6,9 @@ from functools import partial
 import equinox as eqx
 import jax
 import numpy as np
-from interpax import interp1d, interp2d
+from interpax import interp2d
 from jax import numpy as jnp
-from jax import shard_map, vmap
+from jax import shard_map
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
 
@@ -103,6 +103,51 @@ class VelocityExponential:
             return self.push(f_dict, e, pond, dt)
 
 
+def _uniform_cubic_interp(f: jnp.ndarray, shift: jnp.ndarray, dv: float) -> jnp.ndarray:
+    """Shift each row of ``f`` on a uniform grid with local cubic splines.
+
+    This is the uniform-grid specialization of ``interpax.interp1d(method="cubic")``
+    used by the velocity pusher. Each row has one constant velocity shift, so its
+    cell offset and fractional displacement are shared by every velocity point.
+    The direct four-point stencil avoids constructing query grids, binary searches,
+    and a full array of spline derivatives.
+    """
+    _, nv = f.shape
+    if nv < 2:
+        raise ValueError("cubic interpolation requires at least two velocity cells")
+
+    scaled_shift = shift / jnp.asarray(dv, dtype=f.dtype)
+    velocity_index = jnp.arange(nv, dtype=jnp.int32)[None, :]
+
+    # For query index u = j - shift/dv, floor(u) separates into the velocity
+    # index j and one row-wise offset. Clipping selects the endpoint segment;
+    # t is then bounded to that segment so exterior queries cannot overflow.
+    row_offset = jnp.floor(-scaled_shift).astype(jnp.int32)[:, None]
+    left = jnp.clip(velocity_index + row_offset, 0, nv - 2)
+    query_index = velocity_index - scaled_shift[:, None]
+    t = jnp.clip(query_index - left, 0.0, 1.0)
+
+    fm1 = jnp.take_along_axis(f, jnp.clip(left - 1, 0, nv - 1), axis=1)
+    f0 = jnp.take_along_axis(f, left, axis=1)
+    f1 = jnp.take_along_axis(f, left + 1, axis=1)
+    f2 = jnp.take_along_axis(f, jnp.clip(left + 2, 0, nv - 1), axis=1)
+
+    # interpax's local cubic method uses one-sided endpoint slopes and the
+    # average of adjacent secant slopes in the interior. Multiplication by dv
+    # is folded into m0/m1, leaving differences of f values directly.
+    m0 = jnp.where(left == 0, f1 - f0, 0.5 * (f1 - fm1))
+    m1 = jnp.where(left == nv - 2, f1 - f0, 0.5 * (f2 - f0))
+
+    t2 = t * t
+    t3 = t2 * t
+    interpolated = (
+        (2.0 * t3 - 3.0 * t2 + 1.0) * f0 + (t3 - 2.0 * t2 + t) * m0 + (-2.0 * t3 + 3.0 * t2) * f1 + (t3 - t2) * m1
+    )
+
+    outside = (query_index < 0.0) | (query_index > nv - 1)
+    return jnp.where(outside, jnp.asarray(1.0e-30, dtype=f.dtype), interpolated)
+
+
 class VelocityCubicSpline:
     """Cubic-spline velocity-space advection under electric and ponderomotive forces."""
 
@@ -110,7 +155,6 @@ class VelocityCubicSpline:
         """Store per-species velocity grids, interpolation kernel, and sharding metadata."""
         self.species_grids = species_grids
         self.species_params = species_params
-        self.interp = vmap(partial(interp1d, extrap=1.0e-30), in_axes=0)
         self.parallel = parallel
         if self.parallel:
             self.mesh = Mesh(np.array(jax.devices()), ("device",))
@@ -119,15 +163,12 @@ class VelocityCubicSpline:
         """Apply the unsharded cubic-spline velocity push to each species."""
         result = {}
         for species_name, f in f_dict.items():
-            v = self.species_grids[species_name]["v"]
+            dv = self.species_grids[species_name]["dv"]
             q = self.species_params[species_name]["charge"]
             m = self.species_params[species_name]["mass"]
-            nx = f.shape[0]
-            v_repeated = jnp.repeat(v[None, :], repeats=nx, axis=0)
             force = q * e + (q**2 / m) * pond
             accel = force / m
-            vq = v_repeated - accel[:, None] * dt
-            result[species_name] = self.interp(xq=vq, x=v_repeated, f=f)
+            result[species_name] = _uniform_cubic_interp(f, accel * dt, dv)
         return result
 
     def __call__(self, f_dict, e, pond, dt):

--- a/tests/test_vlasov1d/test_velocity_cubic_spline.py
+++ b/tests/test_vlasov1d/test_velocity_cubic_spline.py
@@ -1,0 +1,122 @@
+"""Tests for the uniform-grid cubic-spline velocity pusher."""
+
+from functools import partial
+
+import jax
+import numpy as np
+import pytest
+from interpax import interp1d
+from jax import numpy as jnp
+
+from adept._vlasov1d.solvers.pushers.vlasov import VelocityCubicSpline, _uniform_cubic_interp
+
+
+def _reference_interp(f: jnp.ndarray, shift: jnp.ndarray, v: jnp.ndarray) -> jnp.ndarray:
+    interp_rows = jax.vmap(partial(interp1d, extrap=1.0e-30), in_axes=0)
+    v_repeated = jnp.broadcast_to(v, f.shape)
+    return interp_rows(xq=v_repeated - shift[:, None], x=v_repeated, f=f)
+
+
+@pytest.mark.parametrize("vmin, vmax", [(-6.4, 6.4), (-4.0, 8.0)])
+def test_uniform_cubic_interp_matches_interpax(vmin: float, vmax: float):
+    """The optimized stencil reproduces interpax on symmetric and asymmetric grids."""
+    nx, nv = 8, 64
+    dv = (vmax - vmin) / nv
+    v = jnp.linspace(vmin + dv / 2.0, vmax - dv / 2.0, nv)
+    f = jax.random.normal(jax.random.key(42), (nx, nv), dtype=jnp.float64)
+    shift = dv * jnp.array([-70.0, -2.17, -0.37, 0.0, 0.25, 1.13, 3.4, 70.0])
+
+    expected = _reference_interp(f, shift, v)
+    actual = _uniform_cubic_interp(f, shift, dv)
+
+    np.testing.assert_allclose(actual, expected, rtol=2.0e-12, atol=2.0e-12)
+
+
+def test_uniform_cubic_interp_handles_exact_cell_shifts_at_boundaries():
+    """Exact integer-cell shifts retain endpoint knots without roundoff leakage."""
+    nx, nv = 3, 16
+    dv = 0.25
+    f = jnp.arange(nx * nv, dtype=jnp.float64).reshape(nx, nv)
+    actual = _uniform_cubic_interp(f, dv * jnp.array([1.0, -1.0, 0.0]), dv)
+
+    expected = np.empty((nx, nv))
+    expected[0] = np.concatenate(([1.0e-30], np.asarray(f[0, :-1])))
+    expected[1] = np.concatenate((np.asarray(f[1, 1:]), [1.0e-30]))
+    expected[2] = np.asarray(f[2])
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_uniform_cubic_interp_matches_interpax_gradients():
+    """The optimized stencil preserves gradients with respect to f and the shift."""
+    nx, nv = 5, 48
+    vmin, vmax = -3.0, 7.0
+    dv = (vmax - vmin) / nv
+    v = jnp.linspace(vmin + dv / 2.0, vmax - dv / 2.0, nv)
+    f = jax.random.normal(jax.random.key(1), (nx, nv), dtype=jnp.float64)
+    weights = jax.random.normal(jax.random.key(2), (nx, nv), dtype=jnp.float64)
+    shift = dv * jnp.array([-1.37, -0.22, 0.19, 0.83, 2.41])
+
+    def reference_objective(values, offsets):
+        return jnp.sum(_reference_interp(values, offsets, v) * weights)
+
+    def optimized_objective(values, offsets):
+        return jnp.sum(_uniform_cubic_interp(values, offsets, dv) * weights)
+
+    expected_value, expected_grad = jax.value_and_grad(reference_objective, argnums=(0, 1))(f, shift)
+    actual_value, actual_grad = jax.value_and_grad(optimized_objective, argnums=(0, 1))(f, shift)
+
+    np.testing.assert_allclose(actual_value, expected_value, rtol=2.0e-11, atol=2.0e-11)
+    np.testing.assert_allclose(actual_grad[0], expected_grad[0], rtol=2.0e-11, atol=2.0e-11)
+    np.testing.assert_allclose(actual_grad[1], expected_grad[1], rtol=2.0e-11, atol=2.0e-11)
+
+
+def test_velocity_cubic_spline_uses_each_species_grid_and_force():
+    """Each species uses its own dv and q/m acceleration, including ponderomotive force."""
+    nx = 4
+    species_grids = {}
+    species_params = {
+        "electron": {"charge": -1.0, "mass": 1.0},
+        "ion": {"charge": 1.0, "mass": 4.0},
+    }
+    f_dict = {}
+
+    for seed, name, vmin, vmax, nv in [
+        (3, "electron", -4.0, 8.0, 64),
+        (4, "ion", -0.5, 1.0, 40),
+    ]:
+        dv = (vmax - vmin) / nv
+        species_grids[name] = {
+            "v": jnp.linspace(vmin + dv / 2.0, vmax - dv / 2.0, nv),
+            "dv": dv,
+        }
+        f_dict[name] = jax.random.normal(jax.random.key(seed), (nx, nv), dtype=jnp.float64)
+
+    e = jnp.array([-0.2, 0.1, 0.3, -0.4])
+    pond = jnp.array([0.05, -0.03, 0.02, 0.01])
+    dt = 0.17
+    actual = VelocityCubicSpline(species_grids, species_params)(f_dict, e, pond, dt)
+
+    for name, f in f_dict.items():
+        q = species_params[name]["charge"]
+        m = species_params[name]["mass"]
+        shift = ((q * e + (q**2 / m) * pond) / m) * dt
+        expected = _reference_interp(f, shift, species_grids[name]["v"])
+        np.testing.assert_allclose(actual[name], expected, rtol=2.0e-12, atol=2.0e-12)
+
+
+def test_velocity_cubic_spline_parallel_matches_unsharded():
+    """The optimized stencil remains compatible with x-axis shard_map execution."""
+    nx = 4 * jax.device_count()
+    nv = 32
+    dv = 0.2
+    v = jnp.linspace(-3.2 + dv / 2.0, 3.2 - dv / 2.0, nv)
+    species_grids = {"electron": {"v": v, "dv": dv}}
+    species_params = {"electron": {"charge": -1.0, "mass": 1.0}}
+    f_dict = {"electron": jax.random.normal(jax.random.key(5), (nx, nv), dtype=jnp.float64)}
+    e = jnp.linspace(-0.3, 0.4, nx)
+    pond = jnp.linspace(0.02, -0.01, nx)
+
+    expected = VelocityCubicSpline(species_grids, species_params)(f_dict, e, pond, 0.1)
+    actual = VelocityCubicSpline(species_grids, species_params, parallel=True)(f_dict, e, pond, 0.1)
+
+    np.testing.assert_allclose(actual["electron"], expected["electron"], rtol=2.0e-12, atol=2.0e-12)


### PR DESCRIPTION
## What changed

- Replace the vmapped general-purpose `interpax.interp1d` velocity push with a uniform-grid cubic-Hermite stencil.
- Compute one integer cell offset and fractional displacement per x row.
- Preserve interpax's local C1 slopes, endpoint treatment, exterior value, multi-species behavior, autodiff, and x-axis sharding.
- Add focused tests against interpax for values and gradients, exact boundary shifts, asymmetric/multi-species grids, and `shard_map`.

## Why

Vlasov-1D velocity grids are uniform and each x row receives one constant velocity shift. The previous implementation still constructed full coordinate arrays, performed an elementwise binary search, and built generic spline derivatives and coefficients. That work is unnecessary for this pusher and creates substantial temporary memory traffic at production grid sizes.

## Impact

Local float64 CPU microbenchmarks of the isolated JIT-compiled kernel:

| shape | interpax | uniform stencil | speedup |
| --- | ---: | ---: | ---: |
| 32 x 256 | 0.170 ms | 0.040 ms | 4.2x |
| 256 x 1024 | 2.754 ms | 0.137 ms | 20.1x |
| 1024 x 2048 | 20.214 ms | 0.662 ms | 30.5x |

Maximum observed forward difference was `1.2e-15`. At `256 x 1024`, reverse-mode runtime dropped from 3.96 ms to 1.03 ms with value/gradient differences below `6e-13`.

For the `4096 x 6144` production shape, the local compiler's isolated-kernel temporary-memory estimate dropped from 2.25 GiB to effectively zero. These are local CPU/compiler measurements; A100 timings on NERSC remain the acceptance benchmark.

## Validation

- `14 passed`: focused cubic-spline, asymmetric-grid, and multi-species pusher tests.
- Ruff lint and formatting checks pass.
- `git diff --check` passes.
- The complete Vlasov-1D suite was attempted, but an integration test requires external MLflow access unavailable in the local sandbox; CI should exercise that configured environment.
