### PR TITLE
feat(hermite-legendre): add conserving collision models

### DIFF
--- a/adept/_hermite_legendre_1d/modules.py
+++ b/adept/_hermite_legendre_1d/modules.py
@@ -12,7 +12,8 @@ Normalization (paper sec 2.1): t*wpe, x/lambda_D, v/vthe.
 Config keys in cfg["physics"]:
   Lx (float), alpha (float, Hermite scale), u (float, Hermite shift, default 0),
   v_a, v_b (float, Legendre velocity window), gamma (penalty, default 0.5),
-  nu_H, nu_L (artificial collision rates, default 0), enforce_conservation (bool, default True)
+  nu_H, nu_L (artificial collision rates, default 0), enforce_conservation (bool, default True),
+  collisions ({model: bgk|dougherty, nu: float, ...}, optional conservative physical collisions)
 
 Config keys in cfg["grid"]:
   Nx (int), Nh (int, Hermite modes), Nl (int, Legendre modes), tmax (float), dt (float, default 0.01)
@@ -36,7 +37,9 @@ from adept._hermite_legendre_1d.storage import (
 )
 from adept._hermite_legendre_1d.vector_field import (
     CombinedLinearExp1D,
+    ConservingBGKCollision1D,
     DiagonalCollisionExp1D,
+    DoughertyCollision1D,
     ExternalExDriver,
     HermiteLegendre1DVectorField,
     PoissonSolver1D,
@@ -46,6 +49,7 @@ from adept._hermite_legendre_1d.vector_field import (
     hermite_streaming_matrix,
     legendre_constants,
     legendre_force_operator,
+    mixed_moment_matrix,
     safe_col,
 )
 
@@ -393,6 +397,35 @@ class BaseHermiteLegendre1D(ADEPTModule):
         legendre_coll = DiagonalCollisionExp1D(nu_L, col_l)
         combined_exp = CombinedLinearExp1D(hermite_stream, legendre_stream, hermite_coll, legendre_coll)
 
+        # Optional physical collisions.  nu_H/nu_L above remain independent
+        # truncation-edge absorbers. BGK is the linear-time baseline; Dougherty
+        # keeps the Fokker--Planck velocity-space structure at quadratic modal cost.
+        physical_collision = None
+        collision_cfg = physics.get("collisions", {})
+        collision_model = str(collision_cfg.get("model", "none")).casefold().replace("_", "-")
+        if collision_model not in {"none", "off", "bgk", "dougherty"}:
+            raise ValueError(
+                f"Unknown physics.collisions.model {collision_model!r}; "
+                "supported models are 'none', 'bgk', and 'dougherty'"
+            )
+        collision_nu = float(collision_cfg.get("nu", 0.0))
+        if collision_nu < 0.0:
+            raise ValueError("physics.collisions.nu must be non-negative")
+        if collision_model in {"bgk", "dougherty"} and collision_nu > 0.0:
+            moment_matrix = mixed_moment_matrix(alpha, u, jnp.asarray(leg["T_L"]), width)
+            common = {
+                "nu": collision_nu,
+                "Nh": Nh,
+                "alpha": alpha,
+                "basis_u": u,
+                "moment_matrix": moment_matrix,
+                "min_temperature": float(collision_cfg.get("min_temperature", 1.0e-8)),
+            }
+            if collision_model == "bgk":
+                physical_collision = ConservingBGKCollision1D(**common)
+            else:
+                physical_collision = DoughertyCollision1D(T_L=leg["T_L"], deriv=leg["deriv"], **common)
+
         poisson = PoissonSolver1D(one_over_kx=one_over_kx, kx_sq=kx_sq, alpha=alpha, width=width)
 
         # External longitudinal (Ex) driver, e.g. a resonant EPW kick for Landau damping
@@ -449,6 +482,7 @@ class BaseHermiteLegendre1D(ADEPTModule):
             G_B=G_B,
             T_H=jnp.asarray(T_H) if split else None,
             T_L=jnp.asarray(np.asarray(leg["T_L"])) if split else None,
+            physical_collision=physical_collision,
         )
 
         self.cfg = get_save_quantities(self.cfg)

--- a/adept/_hermite_legendre_1d/vector_field.py
+++ b/adept/_hermite_legendre_1d/vector_field.py
@@ -20,6 +20,8 @@ IMEX. Uses the Stepper (discrete-map) convention from adept._base_, mirroring
 adept._hermite_poisson_1d.vector_field.
 """
 
+import math
+
 import jax
 import jax.numpy as jnp
 import jax.scipy.linalg as jsla
@@ -160,6 +162,40 @@ def legendre_constants(Nl: int, v_a: float, v_b: float) -> dict:
     }
 
 
+def mixed_moment_matrix(alpha: float, u: float, T_L: Array, width: float) -> Array:
+    """Map ``(C_0..2, B_0..2)`` to density, momentum, and kinetic energy.
+
+    The last row is ``1/2 * integral(v**2 f dv)``.  Keeping this map in one
+    place is important: the Vlasov conservation correction and the physical
+    collision step must agree exactly about the three collision invariants.
+    """
+    sigma_bar = T_L[0, 0]
+    sigma1 = T_L[0, 1]
+    sigma2 = T_L[1, 2]
+    return jnp.asarray(
+        [
+            [alpha, 0.0, 0.0, width, 0.0, 0.0],
+            [
+                u * alpha,
+                alpha**2 / jnp.sqrt(2.0),
+                0.0,
+                width * sigma_bar,
+                width * sigma1,
+                0.0,
+            ],
+            [
+                0.5 * alpha * (alpha**2 / 2.0 + u**2),
+                alpha**2 * u / jnp.sqrt(2.0),
+                alpha**3 / (2.0 * jnp.sqrt(2.0)),
+                0.5 * width * (sigma1**2 + sigma_bar**2),
+                width * sigma1 * sigma_bar,
+                0.5 * width * sigma2 * sigma1,
+            ],
+        ],
+        dtype=jnp.float64,
+    )
+
+
 def _hermite_function_values(Nh_plus_1: int, v: np.ndarray, u: float, alpha: float) -> np.ndarray:
     """psi_n(v; u, alpha) for n = 0..Nh, shape (Nh+1, len(v)). Used for J integrals.
 
@@ -262,6 +298,229 @@ class DiagonalCollisionExp1D:
         if self.nu == 0.0:
             return Ck
         return Ck * jnp.exp(-self.nu * self.col[:, None] * s)
+
+
+class ConservingBGKCollision1D:
+    r"""Linear-time conservative BGK collisions for ``f = f0 + df``.
+
+    The collision map is the exact solution of
+
+    .. math:: C[f] = \nu\left(M[n,u,T] - f\right)
+
+    over one frozen-moment substep.  Density, flow, and temperature come from
+    the combined low Hermite and Legendre coefficients.  The same-moment
+    Maxwellian is represented entirely in the AW-Hermite basis, while the
+    Legendre correction decays by ``exp(-nu*s)``.  Consequently
+
+    ``C_new = r*C + (1-r)*C_M`` and ``B_new = r*B``,
+
+    which is O((Nh+Nl) Nx), involves no velocity-grid transform or modal solve,
+    and fixes the otherwise arbitrary mixed-basis collision equilibrium in the
+    natural way: the thermalized population belongs to the Hermite bulk.
+
+    ``C_M`` is generated in one pass.  If ``p = sqrt(2)*(u-u_H)/alpha`` and
+    ``q = T/alpha**2 - 1/2``, its normalized coefficients obey
+
+    ``h_0=1, h_1=p, h_n=p*h_(n-1)/sqrt(n) + 2*q*sqrt((n-1)/n)*h_(n-2)``,
+
+    with ``C_M,n=(density/alpha)*h_n``.  The first three coefficients reproduce
+    the requested density, momentum, and energy exactly; a final local correction
+    removes floating-point roundoff in those invariants.
+    """
+
+    def __init__(
+        self,
+        nu: float,
+        Nh: int,
+        alpha: float,
+        basis_u: float,
+        moment_matrix: Array,
+        min_temperature: float = 1.0e-8,
+    ):
+        if Nh < 3 or moment_matrix.shape[1] < 6:
+            raise ValueError("BGK collisions require Nh >= 3 and Nl >= 3")
+
+        self.nu = float(nu)
+        self.Nh = int(Nh)
+        self.alpha = float(alpha)
+        self.basis_u = float(basis_u)
+        self.min_temperature = float(min_temperature)
+        self.moment_matrix = jnp.asarray(moment_matrix)
+        self.hermite_moment_matrix = self.moment_matrix[:, :3]
+
+    def _moments(self, C: Array, B: Array) -> Array:
+        low = jnp.stack([C[0], C[1], C[2], B[0], B[1], B[2]], axis=0)
+        return self.moment_matrix @ low
+
+    def _maxwellian_coefficients(self, density: Array, mean_v: Array, temperature: Array) -> Array:
+        p = jnp.sqrt(2.0) * (mean_v - self.basis_u) / self.alpha
+        q = temperature / self.alpha**2 - 0.5
+        h = [jnp.ones_like(density)]
+        if self.Nh > 1:
+            h.append(p)
+        for n in range(2, self.Nh):
+            h.append((p / jnp.sqrt(float(n))) * h[n - 1] + 2.0 * q * jnp.sqrt(float(n - 1) / float(n)) * h[n - 2])
+        return (density / self.alpha)[None, :] * jnp.stack(h, axis=0)
+
+    def apply(self, state: dict, s: float) -> dict:
+        if self.nu == 0.0 or s == 0.0:
+            return state
+
+        Ck = state["Ck"].view(jnp.complex128)
+        Bk = state["Bk"].view(jnp.complex128)
+        C = jnp.fft.ifft(Ck, axis=-1, norm="forward").real
+        B = jnp.fft.ifft(Bk, axis=-1, norm="forward").real
+        target = self._moments(C, B)
+
+        density = jnp.maximum(target[0], 1.0e-14)
+        mean_v = target[1] / density
+        temperature = jnp.maximum(2.0 * target[2] / density - mean_v**2, self.min_temperature)
+
+        C_maxwellian = self._maxwellian_coefficients(density, mean_v, temperature)
+        decay = jnp.exp(-self.nu * s)
+        C_new = decay * C + (1.0 - decay) * C_maxwellian
+        B_new = decay * B
+
+        # Exact local field-particle restoration.  Density restoration also
+        # guarantees that this collision-only map leaves Poisson's E unchanged.
+        defect = target - self._moments(C_new, B_new)
+        low_correction = jnp.linalg.solve(self.hermite_moment_matrix, defect)
+        C_new = C_new.at[:3].add(low_correction)
+
+        out = dict(state)
+        out["Ck"] = jnp.fft.fft(C_new, axis=-1, norm="forward").astype(jnp.complex128).view(jnp.float64)
+        out["Bk"] = jnp.fft.fft(B_new, axis=-1, norm="forward").astype(jnp.complex128).view(jnp.float64)
+        return out
+
+
+class DoughertyCollision1D:
+    r"""Basis-native conserving Dougherty collisions for ``f = f0 + df``.
+
+    The nonlinear moments ``U[f]`` and ``T[f]`` are computed from the combined
+    low Hermite and Legendre coefficients. With those moments frozen, the
+    Dougherty operator is linear, so it can be applied independently in the two
+    bases without changing representations:
+
+    .. math:: C_{U,T}[f_0] + C_{U,T}[\delta f] = C_{U,T}[f_0+\delta f].
+
+    The AW-Hermite Ornstein--Uhlenbeck semigroup is evaluated exactly from its
+    generating function. The Legendre weak form is
+
+    ``L_B = -D @ ((V - U I) + T D.T)``.
+
+    Its symmetric diffusion block is prediagonalized once and applied exactly;
+    its lower-triangular drift block uses an implicit-midpoint solve. A symmetric
+    diffusion/drift/diffusion composition is second order. The runtime is
+    O((Nh^2+Nl^2) Nx), with no auxiliary velocity grid or mixed-basis projection.
+
+    The bounded Legendre weak form uses zero collisional flux at the velocity-
+    window boundaries. A local field-particle correction restores the exact
+    combined density, momentum, and kinetic energy after each substep.
+    """
+
+    def __init__(
+        self,
+        nu: float,
+        Nh: int,
+        alpha: float,
+        basis_u: float,
+        T_L: Array,
+        deriv: Array,
+        moment_matrix: Array,
+        min_temperature: float = 1.0e-8,
+    ):
+        if Nh < 3 or T_L.shape[0] < 3:
+            raise ValueError("Dougherty collisions require Nh >= 3 and Nl >= 3")
+
+        self.nu = float(nu)
+        self.Nh = int(Nh)
+        self.alpha = float(alpha)
+        self.basis_u = float(basis_u)
+        self.min_temperature = float(min_temperature)
+        self.moment_matrix = jnp.asarray(moment_matrix)
+        self.hermite_moment_matrix = self.moment_matrix[:, :3]
+
+        n = np.arange(Nh, dtype=np.float64)
+        sqrt_factorial = np.exp(np.asarray([0.5 * math.lgamma(float(i) + 1.0) for i in n]))
+        if not np.all(np.isfinite(sqrt_factorial)):
+            raise ValueError("Nh is too large for the basis-native Dougherty Hermite recurrence")
+        self.sqrt_factorial = jnp.asarray(sqrt_factorial)
+        self.hermite_mode = jnp.asarray(n)
+
+        D = np.asarray(deriv, dtype=np.float64)
+        V = np.asarray(T_L, dtype=np.float64)
+        diffusion = -(D @ D.T)
+        diffusion_eigenvalues, diffusion_eigenvectors = np.linalg.eigh(diffusion)
+        self.legendre_deriv = jnp.asarray(D)
+        self.legendre_drift_0 = jnp.asarray(np.tril(-(D @ V)))
+        self.diffusion_eigenvalues = jnp.asarray(np.minimum(diffusion_eigenvalues, 0.0))
+        self.diffusion_eigenvectors = jnp.asarray(diffusion_eigenvectors)
+
+    def _moments(self, C: Array, B: Array) -> Array:
+        low = jnp.stack([C[0], C[1], C[2], B[0], B[1], B[2]], axis=0)
+        return self.moment_matrix @ low
+
+    def _hermite_exact(self, C: Array, mean_v: Array, temperature: Array, s: float) -> Array:
+        tau = self.nu * s
+        r = jnp.exp(-tau)
+        A = jnp.sqrt(2.0) * (self.basis_u - mean_v) / self.alpha
+        B = 1.0 - 2.0 * temperature / self.alpha**2
+        p = -A * (1.0 - r)
+        q = -0.5 * B * (1.0 - r**2)
+
+        exp_coeff = [jnp.ones_like(mean_v)]
+        if self.Nh > 1:
+            exp_coeff.append(p)
+        for k in range(2, self.Nh):
+            exp_coeff.append((p * exp_coeff[k - 1] + 2.0 * q * exp_coeff[k - 2]) / k)
+
+        scaled = C / self.sqrt_factorial[:, None]
+        damped = scaled * r ** self.hermite_mode[:, None]
+        result = []
+        for n in range(self.Nh):
+            result.append(self.sqrt_factorial[n] * sum(damped[j] * exp_coeff[n - j] for j in range(n + 1)))
+        return jnp.stack(result, axis=0)
+
+    def _legendre_diffusion(self, B: Array, temperature: Array, s: float) -> Array:
+        modal = self.diffusion_eigenvectors.T @ B
+        factor = jnp.exp(self.nu * s * self.diffusion_eigenvalues[:, None] * temperature[None, :])
+        return self.diffusion_eigenvectors @ (factor * modal)
+
+    def _legendre_drift(self, B: Array, mean_v: Array, s: float) -> Array:
+        drift_B = self.legendre_drift_0 @ B + (self.legendre_deriv @ B) * mean_v[None, :]
+        rhs = B + 0.5 * self.nu * s * drift_B
+
+        drift = self.legendre_drift_0[None, :, :] + mean_v[:, None, None] * self.legendre_deriv[None, :, :]
+        lhs = jnp.eye(B.shape[0], dtype=B.dtype)[None, :, :] - 0.5 * self.nu * s * drift
+        return jsla.solve_triangular(lhs, rhs.T[..., None], lower=True)[..., 0].T
+
+    def apply(self, state: dict, s: float) -> dict:
+        if self.nu == 0.0 or s == 0.0:
+            return state
+
+        Ck = state["Ck"].view(jnp.complex128)
+        Bk = state["Bk"].view(jnp.complex128)
+        C = jnp.fft.ifft(Ck, axis=-1, norm="forward").real
+        B = jnp.fft.ifft(Bk, axis=-1, norm="forward").real
+        target = self._moments(C, B)
+
+        density = jnp.maximum(target[0], 1.0e-14)
+        mean_v = target[1] / density
+        temperature = jnp.maximum(2.0 * target[2] / density - mean_v**2, self.min_temperature)
+
+        C_new = self._hermite_exact(C, mean_v, temperature, s)
+        B_new = self._legendre_diffusion(B, temperature, 0.5 * s)
+        B_new = self._legendre_drift(B_new, mean_v, s)
+        B_new = self._legendre_diffusion(B_new, temperature, 0.5 * s)
+
+        defect = target - self._moments(C_new, B_new)
+        low_correction = jnp.linalg.solve(self.hermite_moment_matrix, defect)
+        C_new = C_new.at[:3].add(low_correction)
+
+        out = dict(state)
+        out["Ck"] = jnp.fft.fft(C_new, axis=-1, norm="forward").astype(jnp.complex128).view(jnp.float64)
+        out["Bk"] = jnp.fft.fft(B_new, axis=-1, norm="forward").astype(jnp.complex128).view(jnp.float64)
+        return out
 
 
 class CombinedLinearExp1D:
@@ -594,6 +853,7 @@ class HermiteLegendre1DVectorField:
         G_B: Array | None = None,
         T_H: Array | None = None,
         T_L: Array | None = None,
+        physical_collision: "ConservingBGKCollision1D | DoughertyCollision1D | None" = None,
     ):
         self.combined_exp = combined_exp
         self.poisson = poisson
@@ -626,36 +886,11 @@ class HermiteLegendre1DVectorField:
         self.G_B = None if G_B is None else jnp.asarray(G_B, dtype=jnp.complex128)
         self.T_H = None if T_H is None else jnp.asarray(T_H)
         self.T_L = None if T_L is None else jnp.asarray(T_L)
+        self.physical_collision = physical_collision
         if self.split:
-            sigma_bar = self.T_L[0, 0]
-            sigma1 = self.T_L[0, 1]
-            sigma2 = self.T_L[1, 2]
-            alpha = self.alpha
-            width = self.width
             # T_H's diagonal is u/alpha, so recover the Hermite velocity shift here.
-            u = alpha * self.T_H[0, 0]
-            self._moment_matrix = jnp.asarray(
-                [
-                    [alpha, 0.0, 0.0, width, 0.0, 0.0],
-                    [
-                        u * alpha,
-                        alpha**2 / jnp.sqrt(2.0),
-                        0.0,
-                        width * sigma_bar,
-                        width * sigma1,
-                        0.0,
-                    ],
-                    [
-                        0.5 * alpha * (alpha**2 / 2.0 + u**2),
-                        alpha**2 * u / jnp.sqrt(2.0),
-                        alpha**3 / (2.0 * jnp.sqrt(2.0)),
-                        0.5 * width * (sigma1**2 + sigma_bar**2),
-                        width * sigma1 * sigma_bar,
-                        0.5 * width * sigma2 * sigma1,
-                    ],
-                ],
-                dtype=jnp.float64,
-            )
+            u = self.alpha * self.T_H[0, 0]
+            self._moment_matrix = mixed_moment_matrix(self.alpha, u, self.T_L, self.width)
             gram = self._moment_matrix @ self._moment_matrix.T
             self._moment_projector = self._moment_matrix.T @ jnp.linalg.inv(gram)
 
@@ -892,6 +1127,9 @@ class HermiteLegendre1DVectorField:
         return out
 
     def __call__(self, t: float, y: dict, args: dict) -> dict:
+        if self.physical_collision is not None:
+            y = self.physical_collision.apply(y, 0.5 * self.dt)
+
         step_residual = jnp.asarray(0.0)
         correction_norm = jnp.asarray(0.0)
         if self.split:
@@ -908,6 +1146,9 @@ class HermiteLegendre1DVectorField:
                 if self.ex_driver is not None:
                     E_frozen = E_frozen + self.ex_driver(t + self.dt, args)
                 y_new = self._implicit_E_substep(y_new, E_frozen, self.dt)
+
+        if self.physical_collision is not None:
+            y_new = self.physical_collision.apply(y_new, 0.5 * self.dt)
 
         Ck = y_new["Ck"].view(jnp.complex128)
         Bk = y_new["Bk"].view(jnp.complex128)

--- a/docs/source/solvers/hermite_legendre_1d/config.md
+++ b/docs/source/solvers/hermite_legendre_1d/config.md
@@ -56,14 +56,71 @@ save: ...
 | `v_a`, `v_b` | float | — | Legendre velocity-window bounds (`df` is resolved on `[v_a, v_b]`) |
 | `gamma` | float | `0.5` | Penalty coefficient `γ` for the weak Legendre Dirichlet BC (`df(v_a)=df(v_b)=0`). |
 | `penalty_all_modes` | bool | integrator-dependent | Apply `gamma` to modes 0–2 as well as the high modes. Defaults to `true` for `split` (making the `gamma=0.5` force operator skew-symmetric) and when `enforce_conservation: false`; otherwise defaults to `false`. |
-| `nu_H` | float | `0.0` | Artificial (Lenard-Bernstein) Hermite collision rate `ν_H`. Keep small/zero so `f0` can feed `df` through the last Hermite moment. |
-| `nu_L` | float | `0.0` | Artificial Legendre collision rate `ν_L`. Controls filamentation/recurrence in `df`. |
+| `nu_H` | float | `0.0` | Artificial cubic hypercollision rate `ν_H` for Hermite modes. Keep small/zero so `f0` can feed `df` through the last Hermite moment. |
+| `nu_L` | float | `0.0` | Artificial cubic hypercollision rate `ν_L` for Legendre modes. Controls filamentation/recurrence in `df`. |
+| `collisions` | mapping | `{model: none}` | Optional conservative collision model: `bgk` (linear cost) or `dougherty` (Fokker--Planck, quadratic modal cost). |
 | `enforce_conservation` | bool | `true` | Zero the coupling integrals `J_{Nh,0}=J_{Nh,1}=J_{Nh,2}=0`. With `split`, also apply the minimum-L2 correction to the six low `k=0` Hermite/Legendre coefficients after each step, restoring total mass, momentum, and energy. With other integrators this also defaults the penalty on modes 0–2 to zero. |
 | `field` | bool | `true` | Self-consistent Poisson field. Set `false` for the pure linear-advection test (`φ = 0`); the linear Hermite→Legendre closure flux still acts. |
 
 The artificial collision operator (paper sec 2.5) uses the cubic spectrum
 `col[n] = n(n-1)(n-2) / ((N-1)(N-2)(N-3))`, which is identically zero for
 `n = 0, 1, 2` — so collisions never touch the mass/momentum/energy moments.
+
+### Physical collisions: `physics.collisions`
+
+The cubic `nu_H`/`nu_L` terms are spectral recurrence absorbers, not a physical
+collision model. Physical collisions are configured separately:
+
+```yaml
+physics:
+  collisions:
+    model: dougherty  # or: bgk
+    nu: 0.01
+    # Optional positivity guard for the moment closure:
+    # min_temperature: 1.0e-8
+```
+
+Both models compute density, flow, and temperature from the **total**
+`f = f0 + df` and restore the exact combined density, momentum, and kinetic
+energy at every `x`. Neither uses an auxiliary velocity grid or projects between
+the Hermite and Legendre representations. The collision map is Strang-split
+around the selected Vlasov update.
+
+`bgk` advances
+
+$$
+C_{BGK}[f] = \nu\left(M[n,U,T]-f\right).
+$$
+
+The same-moment Maxwellian is generated directly in the AW-Hermite basis with
+a one-pass recurrence, while the Legendre correction decays by
+`exp(-nu*dt)`. This fixes the thermalized population in the Hermite bulk and
+costs `O(Nx*(Nh+Nl))`. It is the inexpensive physical-ish dissipation and
+regularization option, but it has only one relaxation rate.
+
+`dougherty` advances the nonlinear 1D Fokker--Planck operator
+
+$$
+C_D[f] = \nu\,\partial_v\left[(v-U[f])f + T[f]\,\partial_v f\right]
+$$
+
+With `U[f]` and `T[f]` frozen it uses an exact Ornstein--Uhlenbeck update for
+Hermite plus prediagonalized diffusion and a triangular drift solve for
+Legendre. It costs `O(Nx*(Nh^2+Nl^2))`, but is still inexpensive at the intended
+mode counts: the measured Legendre block at `Nx=32, Nl=171` was `0.45 ms` per
+half-step on the development machine, versus `0.054 ms` for a raw nodal
+tridiagonal solve and `0.15 ms` for the existing Legendre force Cayley update.
+The tridiagonal number excludes the Legendre/nodal transforms it would require.
+
+The Legendre collision flux is zero at `v_a` and `v_b`. This is a controlled
+approximation only while `df` and its physical collisional flux are negligible
+at both boundaries, so `boundary_df_max` remains an important validity gate in
+collisional runs as well as collisionless ones.
+
+This is a physical **1D model operator**, not the full Coulomb/Landau operator.
+Pitch-angle scattering and perpendicular energy diffusion require a 2V/3V
+velocity geometry; use `vlasov-1d2v` with `cylindrical_landau` when those effects
+are required.
 
 **Choosing `Nh` (important).** Keep the Hermite basis *bulk-only* — structure inside
 the Legendre window belongs to `df`. At large `Nh` (≳64) and saturation-scale fields,

--- a/docs/source/solvers/hermite_legendre_1d/overview.md
+++ b/docs/source/solvers/hermite_legendre_1d/overview.md
@@ -68,6 +68,14 @@ Artificial collision rates `nu_H` and `nu_L` damp the highest modes of each basi
 filamentation, in the same spirit as the hypercollisions in
 [Spectrax-1D](../spectrax1d/overview.md).
 
+For collisional physics, `physics.collisions` offers two total-distribution models:
+`bgk` is a linear-cost relaxation to the same-moment Maxwellian, while `dougherty`
+is the higher-fidelity Fokker--Planck option with quadratic modal cost. Both use
+native Hermite/Legendre updates with no conversion or least-squares projection and
+restore density, momentum, and kinetic energy exactly. These remain 1D model
+operators; full Coulomb pitch-angle and perpendicular-energy scattering require the
+`vlasov-1d2v` solver's cylindrical Landau operator.
+
 ## Initialization
 
 The `initialization.type` key selects the initial condition:
@@ -99,6 +107,7 @@ operators are integrated exactly.
 | `initialization.type` | The dominant "forcing" here is the initial condition: `linear-advection`, `two-stream`, `bump-on-tail`, or `custom`, each with its own parameters. |
 | `drivers.ex` | A prescribed longitudinal field $E_\text{drive}(x,t) = \sum \text{env}(x,t)(\omega_0 + \delta\omega_0) a_0 \sin(k_0 x - (\omega_0+\delta\omega_0)t)$. It enters **only** the $E \cdot \partial_v f$ force term and never the Poisson solve, so the self-consistent field-energy diagnostic excludes the driver — which is what makes a clean Landau-damping measurement possible. |
 | `physics.nu_H`, `nu_L` | Artificial collision rates damping the highest modes of each basis, to control filamentation. |
+| `physics.collisions` | Optional conservative `bgk` or `dougherty` total-distribution collision model. |
 
 ## What Gets Saved
 

--- a/tests/test_hermite_legendre_1d/test_collisions.py
+++ b/tests/test_hermite_legendre_1d/test_collisions.py
@@ -1,0 +1,214 @@
+"""Physical-collision gates for the mixed Hermite--Legendre solver."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from adept._hermite_legendre_1d.modules import BaseHermiteLegendre1D, _project_legendre
+from adept._hermite_legendre_1d.vector_field import (
+    ConservingBGKCollision1D,
+    DoughertyCollision1D,
+    _hermite_function_values,
+    _legendre_basis_values,
+    legendre_constants,
+    mixed_moment_matrix,
+)
+
+
+def _collision_setup(nx: int = 3, model: str = "bgk"):
+    Nh, Nl = 8, 16
+    alpha, u = np.sqrt(2.0), 0.0
+    v_a, v_b = 2.0, 10.0
+    leg = legendre_constants(Nl, v_a, v_b)
+    moments = mixed_moment_matrix(alpha, u, leg["T_L"], v_b - v_a)
+    common = dict(
+        nu=1.0,
+        Nh=Nh,
+        alpha=alpha,
+        basis_u=u,
+        moment_matrix=moments,
+    )
+    if model == "bgk":
+        collision = ConservingBGKCollision1D(**common)
+    elif model == "dougherty":
+        collision = DoughertyCollision1D(T_L=leg["T_L"], deriv=leg["deriv"], **common)
+    else:
+        raise ValueError(model)
+    return collision, moments, Nh, Nl, nx, alpha, v_a, v_b
+
+
+def _state(C: np.ndarray, B: np.ndarray) -> dict:
+    Ck = jnp.fft.fft(jnp.asarray(C), axis=-1, norm="forward").astype(jnp.complex128)
+    Bk = jnp.fft.fft(jnp.asarray(B), axis=-1, norm="forward").astype(jnp.complex128)
+    return {"Ck": Ck.view(jnp.float64), "Bk": Bk.view(jnp.float64)}
+
+
+def _real_coefficients(state: dict) -> tuple[np.ndarray, np.ndarray]:
+    Ck = state["Ck"].view(jnp.complex128)
+    Bk = state["Bk"].view(jnp.complex128)
+    C = jnp.fft.ifft(Ck, axis=-1, norm="forward").real
+    B = jnp.fft.ifft(Bk, axis=-1, norm="forward").real
+    return np.asarray(C), np.asarray(B)
+
+
+def _moments(moment_matrix, C: np.ndarray, B: np.ndarray) -> np.ndarray:
+    low = np.stack([C[0], C[1], C[2], B[0], B[1], B[2]], axis=0)
+    return np.asarray(moment_matrix) @ low
+
+
+def test_bgk_preserves_a_sampled_maxwellian():
+    collision, _, Nh, Nl, nx, alpha, _, _ = _collision_setup()
+    C = np.zeros((Nh, nx))
+    C[0] = np.array([0.8, 1.0, 1.2]) / alpha
+    B = np.zeros((Nl, nx))
+
+    C_new, B_new = _real_coefficients(collision.apply(_state(C, B), 0.5))
+
+    np.testing.assert_allclose(C_new, C, rtol=0.0, atol=1.0e-13)
+    np.testing.assert_allclose(B_new, B, rtol=0.0, atol=1.0e-13)
+
+
+def test_dougherty_preserves_a_sampled_maxwellian():
+    collision, _, Nh, Nl, nx, alpha, _, _ = _collision_setup(model="dougherty")
+    C = np.zeros((Nh, nx))
+    C[0] = np.array([0.8, 1.0, 1.2]) / alpha
+    B = np.zeros((Nl, nx))
+
+    C_new, B_new = _real_coefficients(collision.apply(_state(C, B), 0.5))
+
+    np.testing.assert_allclose(C_new, C, rtol=0.0, atol=1.0e-13)
+    np.testing.assert_allclose(B_new, B, rtol=0.0, atol=1.0e-13)
+
+
+def test_bgk_maxwellian_recurrence_has_requested_moments():
+    collision, moment_matrix, _, Nl, _, _, _, _ = _collision_setup()
+    density = jnp.asarray([0.8, 1.0, 1.3])
+    mean_v = jnp.asarray([-0.3, 0.1, 0.7])
+    temperature = jnp.asarray([0.6, 1.0, 1.8])
+
+    C_maxwellian = np.asarray(collision._maxwellian_coefficients(density, mean_v, temperature))
+    B = np.zeros((Nl, density.size))
+    actual = _moments(moment_matrix, C_maxwellian, B)
+    expected = np.stack([density, density * mean_v, 0.5 * density * (temperature + mean_v**2)])
+
+    np.testing.assert_allclose(actual, expected, rtol=2.0e-14, atol=2.0e-15)
+
+
+def test_bgk_does_not_project_between_bases():
+    collision, _, Nh, Nl, nx, alpha, _, _ = _collision_setup()
+    C = np.zeros((Nh, nx))
+    C[0] = 1.0 / alpha
+    C[3] = np.array([1.0e-3, -2.0e-3, 3.0e-3])
+    B = np.zeros((Nl, nx))
+    step = 0.2
+
+    C_new, B_new = _real_coefficients(collision.apply(_state(C, B), step))
+
+    np.testing.assert_allclose(B_new, 0.0, rtol=0.0, atol=1.0e-15)
+    np.testing.assert_allclose(C_new[3], np.exp(-step) * C[3], rtol=2.0e-13, atol=1.0e-15)
+
+
+def test_bgk_conserves_local_moments_and_relaxes_a_beam():
+    collision, moment_matrix, Nh, Nl, nx, alpha, v_a, v_b = _collision_setup()
+    C = np.zeros((Nh, nx))
+    C[0] = 0.99 / alpha
+
+    beam_density = 0.01
+    beam = _project_legendre(
+        lambda v: beam_density / np.sqrt(2.0 * np.pi) * np.exp(-0.5 * (v - 6.0) ** 2),
+        Nl,
+        v_a,
+        v_b,
+    )
+    B = np.repeat(beam[:, None], nx, axis=1)
+    C[3, 1] = 1.0e-3  # make the three spatial points genuinely independent
+
+    before = _moments(moment_matrix, C, B)
+    state_new = collision.apply(_state(C, B), 0.2)
+    C_new, B_new = _real_coefficients(state_new)
+    after = _moments(moment_matrix, C_new, B_new)
+
+    np.testing.assert_allclose(after, before, rtol=0.0, atol=2.0e-13)
+
+    v = np.linspace(-8.0, 12.0, 512)
+    psi = _hermite_function_values(Nh, v, 0.0, alpha)
+    xi = _legendre_basis_values(Nl, v, v_a, v_b)
+    xi[:, (v < v_a) | (v > v_b)] = 0.0
+    f = C.T @ psi + B.T @ xi
+    f_new = C_new.T @ psi + B_new.T @ xi
+
+    density = before[0]
+    mean_v = before[1] / density
+    temperature = 2.0 * before[2] / density - mean_v**2
+    maxwellian = (
+        density[:, None]
+        / np.sqrt(2.0 * np.pi * temperature[:, None])
+        * np.exp(-((v[None, :] - mean_v[:, None]) ** 2) / (2.0 * temperature[:, None]))
+    )
+
+    assert np.linalg.norm(f_new - maxwellian) < np.linalg.norm(f - maxwellian)
+    assert np.linalg.norm(C_new - C) > 0.0  # field-particle back reaction reaches the Hermite bulk
+    assert np.linalg.norm(B_new - B) > 0.0
+
+
+def test_dougherty_conserves_local_moments_and_relaxes_a_beam():
+    collision, moment_matrix, Nh, Nl, nx, alpha, v_a, v_b = _collision_setup(model="dougherty")
+    C = np.zeros((Nh, nx))
+    C[0] = 0.99 / alpha
+    beam_density = 0.01
+    beam = _project_legendre(
+        lambda v: beam_density / np.sqrt(2.0 * np.pi) * np.exp(-0.5 * (v - 6.0) ** 2),
+        Nl,
+        v_a,
+        v_b,
+    )
+    B = np.repeat(beam[:, None], nx, axis=1)
+
+    before = _moments(moment_matrix, C, B)
+    C_new, B_new = _real_coefficients(collision.apply(_state(C, B), 0.2))
+    after = _moments(moment_matrix, C_new, B_new)
+
+    np.testing.assert_allclose(after, before, rtol=0.0, atol=2.0e-13)
+    assert np.linalg.norm(C_new - C) > 0.0
+    assert np.linalg.norm(B_new - B) > 0.0
+
+
+@pytest.mark.parametrize("model", ["bgk", "dougherty"])
+def test_physical_collision_is_wired_through_solver_config(model):
+    cfg = {
+        "solver": "hermite-legendre-1d",
+        "physics": {
+            "Lx": 2.0 * np.pi,
+            "alpha": np.sqrt(2.0),
+            "u": 0.0,
+            "v_a": 2.0,
+            "v_b": 10.0,
+            "gamma": 0.5,
+            "nu_H": 0.0,
+            "nu_L": 0.0,
+            "collisions": {"model": model, "nu": 0.2},
+            "enforce_conservation": True,
+            "field": False,
+        },
+        "grid": {"Nx": 4, "Nh": 8, "Nl": 16, "tmax": 0.05, "dt": 0.05, "integrator": "split"},
+        "initialization": {
+            "type": "bump-on-tail",
+            "eps": 0.0,
+            "n_beam": 0.01,
+            "v_drift": 6.0,
+            "v_th": 1.0,
+        },
+        "save": {"default": {"t": {"nt": 2}}},
+        "units": {},
+    }
+    module = BaseHermiteLegendre1D(cfg)
+    module.write_units()
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    module.init_diffeqsolve()
+    data = module(trainable_modules={})["solver result"].ys["default"]
+
+    for name in ("mass", "momentum", "energy"):
+        values = np.asarray(data[name])
+        np.testing.assert_allclose(values, values[0], rtol=0.0, atol=2.0e-12)


### PR DESCRIPTION
## Summary
- add an O(Nh + Nl) conserving BGK operator for inexpensive physical dissipation and regularization
- add a basis-native conserving Dougherty Fokker-Planck operator with exact Hermite relaxation and prediagonalized Legendre diffusion
- expose both through physics.collisions while retaining the existing hypercollisional absorbers
- document conservation, representation, and cost tradeoffs, including comparison with a batched tridiagonal solve

## Validation
- Ruff format and lint checks
- 8 focused collision tests covering conservation, damping, equilibrium, and end-to-end model selection
- Hermite-Legendre streaming, split, and linear-advection regressions
- 25 affected tests passed