### PR TITLE
feat(vfp2d): couple ion hydro and kinetic-electron pressure

### DIFF
--- a/.github/workflows/cpu-tests.yaml
+++ b/.github/workflows/cpu-tests.yaml
@@ -30,6 +30,7 @@ jobs:
       lpse2d: ${{ steps.filter.outputs.lpse2d }}
       vlasov1d: ${{ steps.filter.outputs.vlasov1d }}
       vfp1d: ${{ steps.filter.outputs.vfp1d }}
+      vfp2d: ${{ steps.filter.outputs.vfp2d }}
       spectrax1d: ${{ steps.filter.outputs.spectrax1d }}
       pic1d: ${{ steps.filter.outputs.pic1d }}
       osiris: ${{ steps.filter.outputs.osiris }}
@@ -82,6 +83,11 @@ jobs:
             - 'adept/vfp1d/**'
             - 'tests/test_vfp1d/**'
             - 'tests/fp_relaxation/**'
+          vfp2d:
+            - *shared
+            - 'adept/vfp2d/**'
+            - 'configs/vfp-2d/**'
+            - 'tests/test_vfp2d/**'
           spectrax1d:
             - *shared
             - 'adept/_spectrax1d/**'
@@ -144,6 +150,18 @@ jobs:
         python-version: '3.11'
     - name: Test with pytest
       run: uv run --locked pytest tests/test_vfp1d
+
+  test-vfp2d:
+    needs: changes
+    if: needs.changes.outputs.run_all == 'true' || needs.changes.outputs.vfp2d == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: ./.github/actions/setup_repo
+      with:
+        python-version: '3.11'
+    - name: Test with pytest
+      run: uv run --locked pytest tests/test_vfp2d
 
   test-spectrax1d:
     needs: changes

--- a/adept/vfp2d/__init__.py
+++ b/adept/vfp2d/__init__.py
@@ -18,6 +18,13 @@ from adept.vfp2d.harmonics import (
     tensor_velocity_moment,
     vector_velocity_moment,
 )
+from adept.vfp2d.hydro import (
+    IonEuler2D,
+    conserved_to_primitive,
+    euler_flux,
+    hllc_flux,
+    primitive_to_conserved,
+)
 from adept.vfp2d.ohm import KineticOhm2D, project_current_moment
 from adept.vfp2d.vector_field import (
     KineticOhmStep,
@@ -34,6 +41,7 @@ __all__ = [
     "Grid",
     "HarmonicLayout",
     "HouLiFilter2D",
+    "IonEuler2D",
     "KineticOhm2D",
     "KineticOhmStep",
     "Maxwell2D",
@@ -44,9 +52,13 @@ __all__ = [
     "cartesian_l2",
     "complex_to_real",
     "conservative_f00_positivity",
+    "conserved_to_primitive",
     "current",
     "density",
+    "euler_flux",
+    "hllc_flux",
     "nernst_velocity",
+    "primitive_to_conserved",
     "project_current_moment",
     "real_to_complex",
     "scalar_velocity_moment",

--- a/adept/vfp2d/__init__.py
+++ b/adept/vfp2d/__init__.py
@@ -38,6 +38,7 @@ from adept.vfp2d.pressure import ElectronPressureCoupling, electron_pressure_ten
 from adept.vfp2d.vector_field import (
     KineticOhmStep,
     Maxwell2D,
+    OSHUNImplicitStep,
     SpectralPoisson2D,
     SplitStepVFP2D,
     VlasovMaxwell,
@@ -58,6 +59,7 @@ __all__ = [
     "KineticOhm2D",
     "KineticOhmStep",
     "Maxwell2D",
+    "OSHUNImplicitStep",
     "SpectralPoisson2D",
     "SplitStepVFP2D",
     "TzoufrasVlasov",

--- a/adept/vfp2d/__init__.py
+++ b/adept/vfp2d/__init__.py
@@ -2,6 +2,11 @@
 
 from adept.vfp2d.base import BaseVFP2D
 from adept.vfp2d.collisions import AnisotropicCollisions, CollisionStep
+from adept.vfp2d.exchange import (
+    ElectronIonExchange,
+    electron_kinetic_energy_density,
+    electron_momentum_density,
+)
 from adept.vfp2d.grid import Grid
 from adept.vfp2d.harmonics import (
     HarmonicLayout,
@@ -25,6 +30,7 @@ from adept.vfp2d.hydro import (
     hllc_flux,
     primitive_to_conserved,
 )
+from adept.vfp2d.moving_frame import IonFrameVlasov
 from adept.vfp2d.ohm import KineticOhm2D, project_current_moment
 from adept.vfp2d.vector_field import (
     KineticOhmStep,
@@ -38,10 +44,12 @@ __all__ = [
     "AnisotropicCollisions",
     "BaseVFP2D",
     "CollisionStep",
+    "ElectronIonExchange",
     "Grid",
     "HarmonicLayout",
     "HouLiFilter2D",
     "IonEuler2D",
+    "IonFrameVlasov",
     "KineticOhm2D",
     "KineticOhmStep",
     "Maxwell2D",
@@ -55,6 +63,8 @@ __all__ = [
     "conserved_to_primitive",
     "current",
     "density",
+    "electron_kinetic_energy_density",
+    "electron_momentum_density",
     "euler_flux",
     "hllc_flux",
     "nernst_velocity",

--- a/adept/vfp2d/__init__.py
+++ b/adept/vfp2d/__init__.py
@@ -2,6 +2,7 @@
 
 from adept.vfp2d.base import BaseVFP2D
 from adept.vfp2d.collisions import AnisotropicCollisions, CollisionStep
+from adept.vfp2d.coupling import CoupledIonKineticStep, coupled_invariants
 from adept.vfp2d.exchange import (
     ElectronIonExchange,
     electron_kinetic_energy_density,
@@ -44,6 +45,7 @@ __all__ = [
     "AnisotropicCollisions",
     "BaseVFP2D",
     "CollisionStep",
+    "CoupledIonKineticStep",
     "ElectronIonExchange",
     "Grid",
     "HarmonicLayout",
@@ -61,6 +63,7 @@ __all__ = [
     "complex_to_real",
     "conservative_f00_positivity",
     "conserved_to_primitive",
+    "coupled_invariants",
     "current",
     "density",
     "electron_kinetic_energy_density",

--- a/adept/vfp2d/__init__.py
+++ b/adept/vfp2d/__init__.py
@@ -5,6 +5,7 @@ from adept.vfp2d.collisions import AnisotropicCollisions, CollisionStep
 from adept.vfp2d.coupling import CoupledIonKineticStep, coupled_invariants
 from adept.vfp2d.exchange import (
     ElectronIonExchange,
+    VelocityFrameRemap,
     electron_kinetic_energy_density,
     electron_momentum_density,
 )
@@ -33,6 +34,7 @@ from adept.vfp2d.hydro import (
 )
 from adept.vfp2d.moving_frame import IonFrameVlasov
 from adept.vfp2d.ohm import KineticOhm2D, project_current_moment
+from adept.vfp2d.pressure import ElectronPressureCoupling, electron_pressure_tensor
 from adept.vfp2d.vector_field import (
     KineticOhmStep,
     Maxwell2D,
@@ -47,6 +49,7 @@ __all__ = [
     "CollisionStep",
     "CoupledIonKineticStep",
     "ElectronIonExchange",
+    "ElectronPressureCoupling",
     "Grid",
     "HarmonicLayout",
     "HouLiFilter2D",
@@ -58,6 +61,7 @@ __all__ = [
     "SpectralPoisson2D",
     "SplitStepVFP2D",
     "TzoufrasVlasov",
+    "VelocityFrameRemap",
     "VlasovMaxwell",
     "cartesian_l2",
     "complex_to_real",
@@ -68,6 +72,7 @@ __all__ = [
     "density",
     "electron_kinetic_energy_density",
     "electron_momentum_density",
+    "electron_pressure_tensor",
     "euler_flux",
     "hllc_flux",
     "nernst_velocity",

--- a/adept/vfp2d/base.py
+++ b/adept/vfp2d/base.py
@@ -44,6 +44,7 @@ from adept.vfp2d.hydro import IonEuler2D, conserved_to_primitive, primitive_to_c
 from adept.vfp2d.moving_frame import IonFrameVlasov
 from adept.vfp2d.ohm import KineticOhm2D
 from adept.vfp2d.plotting import add_reconnection_diagnostics, reconnection_metrics, save_artifacts
+from adept.vfp2d.pressure import ElectronPressureCoupling
 from adept.vfp2d.vector_field import (
     KineticOhmStep,
     Maxwell2D,
@@ -152,11 +153,6 @@ class BaseVFP2D(ADEPTModule):
             raise ValueError("terms.ion_fluid.mass_ratio must be positive")
         if self.ion_fluid_active and not cfg.get("density", {}).get("quasineutrality", True):
             raise ValueError("moving ion-fluid coupling requires density.quasineutrality=true")
-        if self.ion_fluid_active and float(self.ion_cfg.get("momentum_relaxation_rate", 0.0)) != 0.0:
-            raise NotImplementedError(
-                "Gate 2a production coupling requires momentum_relaxation_rate=0 "
-                "until the finite-mass frame remap lands"
-            )
         self.spatial_sharding = create_spatial_sharding(g.get("sharding"), self.grid.nx)
 
     def write_units(self) -> dict:
@@ -503,7 +499,7 @@ class BaseVFP2D(ADEPTModule):
             if self.ion_fluid_active:
                 boundaries = tuple(self.ion_cfg.get("boundaries", ["periodic", "periodic"]))
                 if boundaries != ("periodic", "periodic"):
-                    raise ValueError("Gate 2a moving-ion coupling currently requires periodic x/y boundaries")
+                    raise ValueError("moving-ion coupling currently requires periodic x/y boundaries")
                 hydro = IonEuler2D(
                     self.grid.dx,
                     self.grid.dy,
@@ -527,11 +523,17 @@ class BaseVFP2D(ADEPTModule):
                     ion_mass=self.ion_mass,
                     ion_gamma=self.ion_gamma,
                 )
+                pressure = (
+                    ElectronPressureCoupling(ion_frame)
+                    if bool(self.ion_cfg.get("electron_pressure_feedback", True))
+                    else None
+                )
                 step = CoupledIonKineticStep(
                     kinetic_step,
                     hydro,
                     self.grid.dt,
                     exchange=exchange,
+                    pressure=pressure,
                     evolve_ions=not bool(self.ion_cfg.get("frozen", False)),
                 )
                 self._coupled_step = step

--- a/adept/vfp2d/base.py
+++ b/adept/vfp2d/base.py
@@ -48,6 +48,7 @@ from adept.vfp2d.pressure import ElectronPressureCoupling
 from adept.vfp2d.vector_field import (
     KineticOhmStep,
     Maxwell2D,
+    OSHUNImplicitStep,
     SpectralPoisson2D,
     SplitStepVFP2D,
     VlasovMaxwell,
@@ -139,10 +140,14 @@ class BaseVFP2D(ADEPTModule):
         self.tmax = self.tmin + self.nt * self.grid.dt
         self.max_steps = self.nt + 4
         self._density = None
-        field_cfg = cfg.get("terms", {}).get("field_solver", {})
-        self.field_mode = field_cfg if isinstance(field_cfg, str) else field_cfg.get("mode", "maxwell")
+        field_cfg = cfg.get("terms", {}).get("field_solver", {}) or {}
+        if not isinstance(field_cfg, (str, dict)):
+            raise TypeError("terms.field_solver must be a mode string or mapping")
+        self.field_cfg = {"mode": field_cfg} if isinstance(field_cfg, str) else dict(field_cfg)
+        self.field_mode = self.field_cfg.get("mode", "maxwell")
         self._kinetic_ohm = None
         self._kinetic_step = None
+        self._implicit_current_step = None
         self._coupled_step = None
         self._maxwell = None
         self.ion_cfg = cfg.get("terms", {}).get("ion_fluid", {})
@@ -409,6 +414,8 @@ class BaseVFP2D(ADEPTModule):
                 raise ValueError("moving ion-fluid coupling is not yet compatible with spatial sharding")
             if self.cfg["grid"].get("relativistic", False):
                 raise ValueError("moving ion-fluid coupling currently requires grid.relativistic=false")
+        if self.field_mode == "oshun-implicit" and self.spatial_sharding is not None:
+            raise ValueError("the OSHUN implicit-current solver is not yet compatible with spatial sharding")
         if self.spatial_sharding is not None:
             self.state = jtu.tree_map(self.spatial_sharding.put, self.state)
             self.args = jtu.tree_map(self.spatial_sharding.put, self.args)
@@ -427,17 +434,21 @@ class BaseVFP2D(ADEPTModule):
             dy=partitioned_dy,
             mesh=None if self.spatial_sharding is None else self.spatial_sharding.mesh,
         )
+        if self.field_mode == "ampere" and "relative_permittivity" not in self.field_cfg:
+            raise ValueError("terms.field_solver.relative_permittivity is required for mode='ampere'")
+        relative_permittivity = float(self.field_cfg["relative_permittivity"]) if self.field_mode == "ampere" else 1.0
         maxwell = Maxwell2D(
             self.grid.kx,
             self.grid.ky,
             c=self.plasma_norm.speed_of_light_norm(),
+            relative_permittivity=relative_permittivity,
             dx=partitioned_dx,
             dy=partitioned_dy,
             mesh=None if self.spatial_sharding is None else self.spatial_sharding.mesh,
         )
         self._maxwell = maxwell
         collisions = self._collision_step()
-        if self.field_mode == "maxwell":
+        if self.field_mode in ("maxwell", "ampere"):
             rhs = VlasovMaxwell(
                 vlasov,
                 maxwell,
@@ -448,6 +459,38 @@ class BaseVFP2D(ADEPTModule):
                 streaming_speed=streaming_speed,
             )
             step = SplitStepVFP2D(rhs, self.grid.dt, collisions=collisions)
+        elif self.field_mode == "oshun-implicit":
+            filter_cfg = self.cfg.get("terms", {}).get("hou_li_filter", {})
+            spatial_filter = None
+            if filter_cfg.get("is_on", False):
+                dimensions = set(filter_cfg.get("dimensions", ["x", "y"]))
+                if not dimensions or not dimensions <= {"x", "y"}:
+                    raise ValueError("VFP-2D Hou-Li filtering dimensions must be a nonempty subset of [x, y]")
+                spatial_filter = HouLiFilter2D(
+                    self.grid.nx,
+                    self.grid.ny,
+                    alpha=float(filter_cfg.get("alpha", 36.0)),
+                    order=int(filter_cfg.get("order", 36)),
+                    dimensions=tuple(sorted(dimensions)),
+                )
+            step = OSHUNImplicitStep(
+                vlasov,
+                maxwell,
+                self.layout,
+                self.grid.v,
+                self.grid.dv,
+                self.grid.dt,
+                collisions=collisions,
+                real_storage=True,
+                streaming_speed=streaming_speed,
+                enforce_f00_positivity=(
+                    self.cfg.get("terms", {}).get("fokker_planck", {}).get("f00", {}).get("positivity", "none")
+                    == "conservative"
+                ),
+                spatial_filter=spatial_filter,
+                response_regularization=float(self.field_cfg.get("response_regularization", 0.0)),
+            )
+            self._implicit_current_step = step
         elif self.field_mode == "kinetic-ohm":
             zref = float(self.cfg["units"]["Z"])
             resistivity_coefficient = (
@@ -555,7 +598,8 @@ class BaseVFP2D(ADEPTModule):
             self.state = {**self.state, "e": initial_e}
         else:
             raise ValueError(
-                f"Unsupported VFP-2D field solver mode {self.field_mode!r}; expected 'maxwell' or 'kinetic-ohm'"
+                f"Unsupported VFP-2D field solver mode {self.field_mode!r}; expected "
+                "'maxwell', 'ampere', 'oshun-implicit', or 'kinetic-ohm'"
             )
         save_cfg = self.cfg.get("save", {}).get("t", {})
         save_tmin = normalize(save_cfg.get("tmin", self.tmin), self.plasma_norm, dim="t")
@@ -632,6 +676,59 @@ class BaseVFP2D(ADEPTModule):
                 np.asarray(pressure_anisotropy),
             ),
         }
+        ampere_target_frames = []
+        for frame in result.ys["b"]:
+            ax, ay, az = frame[..., 0], frame[..., 1], frame[..., 2]
+            ampere_target_frames.append(
+                self._maxwell.c2
+                * np.stack(
+                    (
+                        np.asarray(self._maxwell.ddy(az)),
+                        -np.asarray(self._maxwell.ddx(az)),
+                        np.asarray(self._maxwell.ddx(ay)) - np.asarray(self._maxwell.ddy(ax)),
+                    ),
+                    axis=-1,
+                )
+            )
+        ampere_target = np.stack(ampere_target_frames)
+        ampere_residual = np.asarray(plasma_current) - ampere_target
+        magnetic_field_energy = (
+            0.5 * self._maxwell.c2 * self.grid.dx * self.grid.dy * jnp.sum(result.ys["b"] ** 2, axis=(1, 2, 3))
+        )
+        data_vars.update(
+            {
+                "ampere_target_current": (
+                    ("t", "x", "y", "component"),
+                    ampere_target,
+                ),
+                "ampere_residual": (
+                    ("t", "x", "y", "component"),
+                    ampere_residual,
+                ),
+                "ampere_residual_linf": (
+                    ("t",),
+                    np.max(np.abs(ampere_residual), axis=(1, 2, 3)),
+                ),
+                "magnetic_field_energy": (("t",), np.asarray(magnetic_field_energy)),
+            }
+        )
+        if self.field_mode in ("maxwell", "ampere"):
+            electric_field_energy = (
+                0.5
+                * self._maxwell.relative_permittivity
+                * self.grid.dx
+                * self.grid.dy
+                * jnp.sum(result.ys["e"] ** 2, axis=(1, 2, 3))
+            )
+            data_vars.update(
+                {
+                    "electric_field_energy": (("t",), np.asarray(electric_field_energy)),
+                    "electromagnetic_field_energy": (
+                        ("t",),
+                        np.asarray(electric_field_energy + magnetic_field_energy),
+                    ),
+                }
+            )
         if self.ion_fluid_active:
             ions_jax = result.ys["ions"]
             ions = np.asarray(ions_jax)
@@ -744,6 +841,9 @@ class BaseVFP2D(ADEPTModule):
                 "harmonic_convention": "Tzoufras JCP 230 (2011)",
                 "length_unit_um": float(self.plasma_norm.L0.to("um").magnitude),
                 "time_unit_ps": float(self.plasma_norm.tau.to("ps").magnitude),
+                "field_solver_mode": self.field_mode,
+                "relative_permittivity": self._maxwell.relative_permittivity,
+                "ampere_constraint": "current = c^2 curl(magnetic_field); residual is current minus target",
                 "ion_fluid_coupling": "gate2a" if self.ion_fluid_active else "stationary",
                 "coupled_energy_convention": (
                     "electron lab kinetic + ion total + magnetic; algebraic kinetic-Ohm E has no field energy"

--- a/adept/vfp2d/base.py
+++ b/adept/vfp2d/base.py
@@ -291,6 +291,7 @@ class BaseVFP2D(ADEPTModule):
                 axis=-1,
             )
             self.state["ions"] = primitive_to_conserved(ion_primitive, self.ion_gamma)
+            self.state["current_projection_energy"] = jnp.zeros_like(ion_density)
             self.args["ei_momentum_relaxation_rate"] = float(self.ion_cfg.get("momentum_relaxation_rate", 0.0))
             self.args["ei_temperature_relaxation_rate"] = float(self.ion_cfg.get("temperature_relaxation_rate", 0.0))
         drivers = self.cfg.get("drivers", {})
@@ -653,6 +654,7 @@ class BaseVFP2D(ADEPTModule):
                 ion_mass=self.ion_mass,
                 ion_charge=float(self.cfg["units"]["Z"]),
                 light_speed=self.plasma_norm.speed_of_light_norm(),
+                current_projection_energy=result.ys["current_projection_energy"],
             )
             f00 = jnp.real(flm_jax[..., self.layout.index(0, 0), :])
             negative_f00_mass = (
@@ -691,6 +693,11 @@ class BaseVFP2D(ADEPTModule):
                     "ion_energy": (("t",), np.asarray(invariants["ion_energy"])),
                     "magnetic_energy": (("t",), np.asarray(invariants["magnetic_energy"])),
                     "total_energy": (("t",), np.asarray(invariants["total_energy"])),
+                    "current_projection_energy": (
+                        ("t",),
+                        np.asarray(invariants["current_projection_energy"]),
+                    ),
+                    "accounted_total_energy": (("t",), np.asarray(invariants["accounted_total_energy"])),
                     "div_b_linf": (("t",), np.asarray(div_b_linf)),
                     "negative_f00_mass": (("t",), np.asarray(negative_f00_mass)),
                     "harmonic_free_energy": (("t", "harmonic"), np.asarray(harmonic_free_energy)),

--- a/adept/vfp2d/base.py
+++ b/adept/vfp2d/base.py
@@ -24,7 +24,9 @@ from adept.vfp1d.fokker_planck import (
 from adept.vfp1d.grid import Grid as CollisionGrid
 from adept.vfp1d.helpers import _initialize_distribution_, calc_logLambda, load_profile_on_grid
 from adept.vfp2d.collisions import AnisotropicCollisions, CollisionStep
+from adept.vfp2d.coupling import CoupledIonKineticStep, coupled_invariants
 from adept.vfp2d.distributed import create_spatial_sharding
+from adept.vfp2d.exchange import ElectronIonExchange
 from adept.vfp2d.grid import Grid
 from adept.vfp2d.harmonics import (
     HarmonicLayout,
@@ -38,6 +40,8 @@ from adept.vfp2d.harmonics import (
     scalar_velocity_moment,
     tensor_velocity_moment,
 )
+from adept.vfp2d.hydro import IonEuler2D, conserved_to_primitive, primitive_to_conserved
+from adept.vfp2d.moving_frame import IonFrameVlasov
 from adept.vfp2d.ohm import KineticOhm2D
 from adept.vfp2d.plotting import add_reconnection_diagnostics, reconnection_metrics, save_artifacts
 from adept.vfp2d.vector_field import (
@@ -137,7 +141,22 @@ class BaseVFP2D(ADEPTModule):
         field_cfg = cfg.get("terms", {}).get("field_solver", {})
         self.field_mode = field_cfg if isinstance(field_cfg, str) else field_cfg.get("mode", "maxwell")
         self._kinetic_ohm = None
+        self._kinetic_step = None
+        self._coupled_step = None
         self._maxwell = None
+        self.ion_cfg = cfg.get("terms", {}).get("ion_fluid", {})
+        self.ion_fluid_active = bool(self.ion_cfg.get("active", False))
+        self.ion_mass = float(self.ion_cfg.get("mass_ratio", 1836.0))
+        self.ion_gamma = float(self.ion_cfg.get("gamma", 5.0 / 3.0))
+        if self.ion_fluid_active and self.ion_mass <= 0.0:
+            raise ValueError("terms.ion_fluid.mass_ratio must be positive")
+        if self.ion_fluid_active and not cfg.get("density", {}).get("quasineutrality", True):
+            raise ValueError("moving ion-fluid coupling requires density.quasineutrality=true")
+        if self.ion_fluid_active and float(self.ion_cfg.get("momentum_relaxation_rate", 0.0)) != 0.0:
+            raise NotImplementedError(
+                "Gate 2a production coupling requires momentum_relaxation_rate=0 "
+                "until the finite-mass frame remap lands"
+            )
         self.spatial_sharding = create_spatial_sharding(g.get("sharding"), self.grid.nx)
 
     def write_units(self) -> dict:
@@ -248,6 +267,36 @@ class BaseVFP2D(ADEPTModule):
         self.state = {"flm": complex_to_real(flm), "e": e, "b": jnp.zeros_like(e)}
         self._density = n_total
         self.args = {"Z": jnp.ones_like(n_total), "ni": n_total / zref}
+        if self.ion_fluid_active:
+            # Tie the ion state to the discretely integrated electron density,
+            # not the analytic profile, so quasineutrality is exact on the
+            # finite radial grid at initialization.
+            ion_density = density(flm, self.layout, self.grid.v, self.grid.dv) / zref
+            self.args["ni"] = ion_density
+            ion_velocity = jnp.broadcast_to(
+                jnp.asarray(self.ion_cfg.get("initial_velocity", [0.0, 0.0, 0.0])),
+                (self.grid.nx, self.grid.ny, 3),
+            )
+            ion_temperature = float(
+                (
+                    UREG.Quantity(self.cfg["units"]["reference ion temperature"])
+                    / UREG.Quantity(self.cfg["units"]["reference electron temperature"])
+                )
+                .to("")
+                .magnitude
+            )
+            ion_temperature *= 0.5 * self.plasma_norm.vth_norm() ** 2
+            ion_primitive = jnp.concatenate(
+                (
+                    (self.ion_mass * ion_density)[..., None],
+                    ion_velocity,
+                    (ion_density * ion_temperature)[..., None],
+                ),
+                axis=-1,
+            )
+            self.state["ions"] = primitive_to_conserved(ion_primitive, self.ion_gamma)
+            self.args["ei_momentum_relaxation_rate"] = float(self.ion_cfg.get("momentum_relaxation_rate", 0.0))
+            self.args["ei_temperature_relaxation_rate"] = float(self.ion_cfg.get("temperature_relaxation_rate", 0.0))
         drivers = self.cfg.get("drivers", {})
         maxwellian = drivers.get("maxwellian_heating", {})
         if "D0" in maxwellian:
@@ -356,6 +405,13 @@ class BaseVFP2D(ADEPTModule):
         )
 
     def init_diffeqsolve(self):
+        if self.ion_fluid_active:
+            if self.field_mode != "kinetic-ohm":
+                raise ValueError("moving ion-fluid coupling currently requires terms.field_solver.mode='kinetic-ohm'")
+            if self.spatial_sharding is not None:
+                raise ValueError("moving ion-fluid coupling is not yet compatible with spatial sharding")
+            if self.cfg["grid"].get("relativistic", False):
+                raise ValueError("moving ion-fluid coupling currently requires grid.relativistic=false")
         if self.spatial_sharding is not None:
             self.state = jtu.tree_map(self.spatial_sharding.put, self.state)
             self.args = jtu.tree_map(self.spatial_sharding.put, self.args)
@@ -425,7 +481,8 @@ class BaseVFP2D(ADEPTModule):
                     dimensions=tuple(sorted(dimensions)),
                     mesh=None if self.spatial_sharding is None else self.spatial_sharding.mesh,
                 )
-            step = KineticOhmStep(
+            ion_frame = IonFrameVlasov(vlasov) if self.ion_fluid_active else None
+            kinetic_step = KineticOhmStep(
                 vlasov,
                 maxwell,
                 self._kinetic_ohm,
@@ -440,14 +497,56 @@ class BaseVFP2D(ADEPTModule):
                     == "conservative"
                 ),
                 spatial_filter=spatial_filter,
+                ion_frame=ion_frame,
             )
+            self._kinetic_step = kinetic_step
+            if self.ion_fluid_active:
+                boundaries = tuple(self.ion_cfg.get("boundaries", ["periodic", "periodic"]))
+                if boundaries != ("periodic", "periodic"):
+                    raise ValueError("Gate 2a moving-ion coupling currently requires periodic x/y boundaries")
+                hydro = IonEuler2D(
+                    self.grid.dx,
+                    self.grid.dy,
+                    gamma=self.ion_gamma,
+                    boundaries=boundaries,
+                    limiter_theta=float(self.ion_cfg.get("limiter_theta", 1.5)),
+                    density_floor=float(self.ion_cfg.get("density_floor", 1.0e-12)),
+                    pressure_floor=float(self.ion_cfg.get("pressure_floor", 1.0e-12)),
+                )
+                ion_cfl = float(self.ion_cfg.get("cfl", 0.4))
+                initial_cfl_timestep = float(hydro.cfl_timestep(self.state["ions"], cfl=ion_cfl))
+                if 0.5 * self.grid.dt > initial_cfl_timestep:
+                    raise ValueError(
+                        "the VFP timestep violates the initial ion half-step CFL limit; "
+                        "reduce grid.dt or terms.ion_fluid.cfl"
+                    )
+                exchange = ElectronIonExchange(
+                    self.layout,
+                    self.grid.v,
+                    self.grid.dv,
+                    ion_mass=self.ion_mass,
+                    ion_gamma=self.ion_gamma,
+                )
+                step = CoupledIonKineticStep(
+                    kinetic_step,
+                    hydro,
+                    self.grid.dt,
+                    exchange=exchange,
+                    evolve_ions=not bool(self.ion_cfg.get("frozen", False)),
+                )
+                self._coupled_step = step
+            else:
+                step = kinetic_step
             initial_flm = real_to_complex(self.state["flm"])
-            initial_current = maxwell.c2 * maxwell.curl(self.state["b"])
             initial_hidden_dndz = KineticOhmStep._hidden_dndz(self.tmin, self.args, self.state["b"][..., 0])
-            initial_e, _terms = self._kinetic_ohm(
+            if self.ion_fluid_active:
+                initial_args = {**self.args, **step.ion_kinematics(self.state["ions"])}
+            else:
+                initial_args = self.args
+            initial_e, _terms = kinetic_step.electric_field(
                 initial_flm,
                 self.state["b"],
-                plasma_current=initial_current,
+                initial_args,
                 hidden_dndz=initial_hidden_dndz,
             )
             self.state = {**self.state, "e": initial_e}
@@ -530,20 +629,94 @@ class BaseVFP2D(ADEPTModule):
                 np.asarray(pressure_anisotropy),
             ),
         }
+        if self.ion_fluid_active:
+            ions_jax = result.ys["ions"]
+            ions = np.asarray(ions_jax)
+            ion_primitive = conserved_to_primitive(ions_jax, self.ion_gamma)
+            ion_number_density = ions_jax[..., 0] / self.ion_mass
+            ion_temperature_scale = 0.5 * self.plasma_norm.vth_norm() ** 2
+            ion_temperature = ion_primitive[..., 4] / jnp.maximum(
+                ion_number_density * ion_temperature_scale,
+                jnp.finfo(ion_number_density.dtype).tiny,
+            )
+            invariants = coupled_invariants(
+                flm_jax,
+                ions_jax,
+                result.ys["b"],
+                self.layout,
+                self.grid.v,
+                self.grid.dv,
+                dx=self.grid.dx,
+                dy=self.grid.dy,
+                ion_mass=self.ion_mass,
+                ion_charge=float(self.cfg["units"]["Z"]),
+                light_speed=self.plasma_norm.speed_of_light_norm(),
+            )
+            f00 = jnp.real(flm_jax[..., self.layout.index(0, 0), :])
+            negative_f00_mass = (
+                4.0
+                * jnp.pi
+                * self.grid.dx
+                * self.grid.dy
+                * jnp.sum(jnp.maximum(-f00, 0.0) * self.grid.v**2, axis=(1, 2, 3))
+                * self.grid.dv
+            )
+            harmonic_free_energy = (
+                self.grid.dx
+                * self.grid.dy
+                * jnp.sum(jnp.abs(flm_jax) ** 2 * self.grid.v**2, axis=(1, 2, 4))
+                * self.grid.dv
+            )
+            div_b_linf = jnp.stack(
+                [
+                    jnp.max(jnp.abs(self._maxwell.ddx(frame[..., 0]) + self._maxwell.ddy(frame[..., 1])))
+                    for frame in result.ys["b"]
+                ]
+            )
+            coords["ion_conserved"] = ["rho", "rho_ux", "rho_uy", "rho_uz", "energy"]
+            data_vars.update(
+                {
+                    "ions": (("t", "x", "y", "ion_conserved"), ions),
+                    "ni": (("t", "x", "y"), np.asarray(ion_number_density)),
+                    "ion_velocity": (("t", "x", "y", "component"), np.asarray(ion_primitive[..., 1:4])),
+                    "ion_pressure": (("t", "x", "y"), np.asarray(ion_primitive[..., 4])),
+                    "ion_temperature": (("t", "x", "y"), np.asarray(ion_temperature)),
+                    "electron_number": (("t",), np.asarray(invariants["electron_number"])),
+                    "ion_number": (("t",), np.asarray(invariants["ion_number"])),
+                    "quasineutrality_linf": (("t",), np.asarray(invariants["quasineutrality_linf"])),
+                    "total_momentum": (("t", "component"), np.asarray(invariants["total_momentum"])),
+                    "electron_energy": (("t",), np.asarray(invariants["electron_energy"])),
+                    "ion_energy": (("t",), np.asarray(invariants["ion_energy"])),
+                    "magnetic_energy": (("t",), np.asarray(invariants["magnetic_energy"])),
+                    "total_energy": (("t",), np.asarray(invariants["total_energy"])),
+                    "div_b_linf": (("t",), np.asarray(div_b_linf)),
+                    "negative_f00_mass": (("t",), np.asarray(negative_f00_mass)),
+                    "harmonic_free_energy": (("t", "harmonic"), np.asarray(harmonic_free_energy)),
+                }
+            )
         if self._kinetic_ohm is not None and self._maxwell is not None:
-            ohm_history = {key: [] for key in ("resistive", "hall", "nernst", "scalar_pressure", "tensor_pressure")}
+            ohm_keys = ["resistive", "hall", "nernst", "scalar_pressure", "tensor_pressure"]
+            if self.ion_fluid_active:
+                ohm_keys.insert(0, "bulk")
+            ohm_history = {key: [] for key in ohm_keys}
             for index, time in enumerate(np.asarray(result.ts)):
                 frame_flm = flm_jax[index]
                 frame_b = result.ys["b"][index]
                 if self.spatial_sharding is not None:
                     frame_flm = self.spatial_sharding.put(frame_flm)
                     frame_b = self.spatial_sharding.put(frame_b)
-                target_current = self._maxwell.c2 * self._maxwell.curl(frame_b)
                 hidden_dndz = KineticOhmStep._hidden_dndz(float(time), self.args, frame_b[..., 0])
-                _electric, terms = self._kinetic_ohm(
+                if self.ion_fluid_active:
+                    frame_args = {
+                        **self.args,
+                        **self._coupled_step.ion_kinematics(result.ys["ions"][index]),
+                    }
+                else:
+                    frame_args = self.args
+                _electric, terms = self._kinetic_step.electric_field(
                     frame_flm,
                     frame_b,
-                    plasma_current=target_current,
+                    frame_args,
                     hidden_dndz=hidden_dndz,
                 )
                 for key, value in terms.items():
@@ -562,6 +735,12 @@ class BaseVFP2D(ADEPTModule):
                 "harmonic_convention": "Tzoufras JCP 230 (2011)",
                 "length_unit_um": float(self.plasma_norm.L0.to("um").magnitude),
                 "time_unit_ps": float(self.plasma_norm.tau.to("ps").magnitude),
+                "ion_fluid_coupling": "gate2a" if self.ion_fluid_active else "stationary",
+                "coupled_energy_convention": (
+                    "electron lab kinetic + ion total + magnetic; algebraic kinetic-Ohm E has no field energy"
+                    if self.ion_fluid_active
+                    else "not applicable"
+                ),
             },
         )
         ds = add_reconnection_diagnostics(ds)

--- a/adept/vfp2d/coupling.py
+++ b/adept/vfp2d/coupling.py
@@ -1,0 +1,203 @@
+"""Time-centered kinetic-electron / ion-fluid coupling for VFP-2D.
+
+Gate 2a composes the verified ion-frame electron, ideal-ion Euler, and local
+electron--ion exchange operators.  The split is deliberately explicit and
+auditable: hydro half-step, full kinetic step at midpoint ion kinematics,
+midpoint collisional exchange, then the second hydro half-step.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+
+from adept.vfp2d.exchange import (
+    ElectronIonExchange,
+    electron_kinetic_energy_density,
+    electron_momentum_density,
+)
+from adept.vfp2d.harmonics import HarmonicLayout, complex_to_real, density, real_to_complex
+from adept.vfp2d.hydro import IonEuler2D, conserved_to_primitive
+from adept.vfp2d.vector_field import KineticOhmStep
+
+
+class CoupledIonKineticStep:
+    """Strang-style map step for kinetic electrons and ideal-fluid ions.
+
+    The electron step must be a ``KineticOhmStep`` configured with an ion-frame
+    operator. Ion kinematics are held at the hydro midpoint during its RK stages.
+    This first production coupling slice includes ideal-ion transport and local
+    thermal exchange; electron-pressure feedback belongs to Gate 2b. A nonzero
+    momentum-exchange rate is retained for isolated reference tests only and must
+    not be used in a production step until the finite-mass frame remap lands.
+    """
+
+    def __init__(
+        self,
+        electron_step: KineticOhmStep,
+        hydro: IonEuler2D,
+        dt: float,
+        *,
+        exchange: ElectronIonExchange | None = None,
+        evolve_ions: bool = True,
+    ):
+        if electron_step.ion_frame is None:
+            raise ValueError("coupled kinetic-ion stepping requires an ion-frame electron operator")
+        if dt <= 0.0:
+            raise ValueError("dt must be positive")
+        self.electron_step = electron_step
+        self.hydro = hydro
+        self.dt = float(dt)
+        self.exchange = exchange
+        self.evolve_ions = bool(evolve_ions)
+
+    def _hydro_half_step(self, ions: Array) -> Array:
+        return self.hydro.step(ions, 0.5 * self.dt) if self.evolve_ions else ions
+
+    def ion_kinematics(self, ions: Array) -> dict[str, Array]:
+        """Return midpoint velocity, gradient, and material acceleration."""
+
+        primitive = conserved_to_primitive(
+            ions,
+            self.hydro.gamma,
+            density_floor=self.hydro.density_floor,
+            pressure_floor=self.hydro.pressure_floor,
+        )
+        velocity = primitive[..., 1:4]
+        gradient = self.electron_step.ion_frame.velocity_gradient(velocity)
+        if self.evolve_ions:
+            hydro_rate = self.hydro.rhs(ions)
+            rho = ions[..., 0]
+            safe_rho = jnp.maximum(rho, self.hydro.density_floor)
+            velocity_rate = (hydro_rate[..., 1:4] - velocity * hydro_rate[..., :1]) / safe_rho[..., None]
+            advective_rate = jnp.einsum("...j,...ij->...i", velocity, gradient)
+            material_acceleration = velocity_rate + advective_rate
+        else:
+            material_acceleration = jnp.zeros_like(velocity)
+        return {
+            "ion_velocity": velocity,
+            "ion_velocity_gradient": gradient,
+            "ion_material_acceleration": material_acceleration,
+        }
+
+    @staticmethod
+    def _rate(args: dict | None, key: str, t: float, template: Array) -> Array:
+        if not args or key not in args:
+            return jnp.zeros_like(template)
+        value = args[key]
+        value = value(t) if callable(value) else value
+        return jnp.broadcast_to(jnp.asarray(value), template.shape)
+
+    def _exchange(self, t: float, flm: Array, ions: Array, args: dict | None) -> tuple[Array, Array]:
+        if self.exchange is None:
+            return flm, ions
+        template = ions[..., 0]
+        momentum_rate = self._rate(args, "ei_momentum_relaxation_rate", t, template)
+        temperature_rate = self._rate(args, "ei_temperature_relaxation_rate", t, template)
+        df1, di1, _diagnostics = self.exchange(
+            flm,
+            ions,
+            momentum_relaxation_rate=momentum_rate,
+            temperature_relaxation_rate=temperature_rate,
+        )
+        midpoint_f = flm + 0.5 * self.dt * df1
+        midpoint_i = ions + 0.5 * self.dt * di1
+        df2, di2, _diagnostics = self.exchange(
+            midpoint_f,
+            midpoint_i,
+            momentum_relaxation_rate=momentum_rate,
+            temperature_relaxation_rate=temperature_rate,
+        )
+        return flm + self.dt * df2, ions + self.dt * di2
+
+    def __call__(self, t: float, state: dict[str, Array], args: dict | None = None) -> dict[str, Array]:
+        if "ions" not in state:
+            raise ValueError("coupled state must contain the ion conserved array under 'ions'")
+        midpoint_ions = self._hydro_half_step(state["ions"])
+        electron_args = {**({} if args is None else args), **self.ion_kinematics(midpoint_ions)}
+        electron_state = {key: state[key] for key in ("flm", "e", "b")}
+        advanced_electrons = self.electron_step(t, electron_state, electron_args)
+
+        flm = (
+            real_to_complex(advanced_electrons["flm"]) if self.electron_step.real_storage else advanced_electrons["flm"]
+        )
+        flm, midpoint_ions = self._exchange(t + 0.5 * self.dt, flm, midpoint_ions, args)
+        final_ions = self._hydro_half_step(midpoint_ions)
+        final_args = {**({} if args is None else args), **self.ion_kinematics(final_ions)}
+        hidden_dndz = self.electron_step._hidden_dndz(
+            t + self.dt,
+            final_args,
+            advanced_electrons["b"][..., 0],
+        )
+        advanced_electrons["e"], _terms = self.electron_step.electric_field(
+            flm,
+            advanced_electrons["b"],
+            final_args,
+            hidden_dndz=hidden_dndz,
+        )
+        advanced_electrons["flm"] = complex_to_real(flm) if self.electron_step.real_storage else flm
+        return {**advanced_electrons, "ions": final_ions}
+
+
+def coupled_invariants(
+    flm: Array,
+    ions: Array,
+    magnetic_field: Array,
+    layout: HarmonicLayout,
+    v: Array,
+    dv: float,
+    *,
+    dx: float,
+    dy: float,
+    ion_mass: float,
+    ion_charge: float,
+    light_speed: float,
+    electron_mass: float = 1.0,
+) -> dict[str, Array]:
+    """Return global number, momentum, and energy histories.
+
+    ``flm`` is expressed in peculiar velocity. Electron lab-frame momentum and
+    kinetic energy therefore include the ion-frame translation terms.
+    Leading batch dimensions (normally time) are preserved.
+    """
+
+    electron_density = density(flm, layout, v, dv)
+    ion_density = ions[..., 0] / float(ion_mass)
+    ion_velocity = ions[..., 1:4] / ions[..., :1]
+    relative_momentum = electron_momentum_density(flm, layout, v, dv, electron_mass)
+    electron_momentum = relative_momentum + float(electron_mass) * electron_density[..., None] * ion_velocity
+    electron_energy = electron_kinetic_energy_density(flm, layout, v, dv, electron_mass)
+    electron_energy += jnp.sum(ion_velocity * relative_momentum, axis=-1)
+    electron_energy += 0.5 * float(electron_mass) * electron_density * jnp.sum(ion_velocity**2, axis=-1)
+
+    cell_area = float(dx) * float(dy)
+    scalar_axes = (-2, -1)
+    vector_axes = (-3, -2)
+    electron_number = cell_area * jnp.sum(electron_density, axis=scalar_axes)
+    ion_number = cell_area * jnp.sum(ion_density, axis=scalar_axes)
+    total_momentum = cell_area * jnp.sum(electron_momentum + ions[..., 1:4], axis=vector_axes)
+    electron_energy = cell_area * jnp.sum(electron_energy, axis=scalar_axes)
+    ion_energy = cell_area * jnp.sum(ions[..., 4], axis=scalar_axes)
+    magnetic_energy = (
+        0.5
+        * float(light_speed) ** 2
+        * cell_area
+        * jnp.sum(
+            magnetic_field**2,
+            axis=(-3, -2, -1),
+        )
+    )
+    quasineutrality_linf = jnp.max(
+        jnp.abs(electron_density - float(ion_charge) * ion_density),
+        axis=scalar_axes,
+    )
+    return {
+        "electron_number": electron_number,
+        "ion_number": ion_number,
+        "quasineutrality_linf": quasineutrality_linf,
+        "total_momentum": total_momentum,
+        "electron_energy": electron_energy,
+        "ion_energy": ion_energy,
+        "magnetic_energy": magnetic_energy,
+        "total_energy": electron_energy + ion_energy + magnetic_energy,
+    }

--- a/adept/vfp2d/coupling.py
+++ b/adept/vfp2d/coupling.py
@@ -2,8 +2,8 @@
 
 The split composes ion-frame electrons, ideal-ion Euler transport, kinetic
 electron-pressure feedback, and finite-mass electron--ion exchange. It remains
-explicit and auditable: hydro half-step, full kinetic midpoint step, midpoint
-coupled sources, then the second hydro half-step.
+explicit and auditable: hydro half-step, coupled-source half-step, full kinetic
+step, the second coupled-source half-step, then the second hydro half-step.
 """
 
 from __future__ import annotations
@@ -29,8 +29,7 @@ class CoupledIonKineticStep:
     The electron step must be a ``KineticOhmStep`` configured with an ion-frame
     operator. Ion kinematics are held at the hydro midpoint during its RK stages.
     This production coupling includes ideal-ion transport and local finite-mass
-    thermal and momentum exchange. Electron-pressure feedback belongs to the
-    next Gate 2b slice.
+    thermal and momentum exchange together with electron-pressure feedback.
     """
 
     def __init__(
@@ -99,9 +98,17 @@ class CoupledIonKineticStep:
         value = value(t) if callable(value) else value
         return jnp.broadcast_to(jnp.asarray(value), template.shape)
 
-    def _exchange(self, t: float, flm: Array, ions: Array, args: dict | None) -> tuple[Array, Array]:
+    def _exchange(
+        self,
+        t: float,
+        flm: Array,
+        ions: Array,
+        args: dict | None,
+        source_dt: float | None = None,
+    ) -> tuple[Array, Array]:
         if self.exchange is None and self.pressure is None:
             return flm, ions
+        source_dt = self.dt if source_dt is None else float(source_dt)
         template = ions[..., 0]
         momentum_rate = self._rate(args, "ei_momentum_relaxation_rate", t, template)
         temperature_rate = self._rate(args, "ei_temperature_relaxation_rate", t, template)
@@ -120,11 +127,11 @@ class CoupledIonKineticStep:
             pressure_df1, pressure_di1, _diagnostics = self.pressure(flm, ions)
             df1 += pressure_df1
             di1 += pressure_di1
-        midpoint_i = ions + 0.5 * self.dt * di1
+        midpoint_i = ions + 0.5 * source_dt * di1
         initial_velocity = ions[..., 1:4] / ions[..., :1]
         midpoint_velocity = midpoint_i[..., 1:4] / midpoint_i[..., :1]
         half_frame_change = midpoint_velocity - initial_velocity
-        midpoint_f = self.frame_remap(flm + 0.5 * self.dt * df1, half_frame_change)
+        midpoint_f = self.frame_remap(flm + 0.5 * source_dt * df1, half_frame_change)
         df2 = jnp.zeros_like(flm)
         di2 = jnp.zeros_like(ions)
         if self.exchange is not None:
@@ -140,25 +147,33 @@ class CoupledIonKineticStep:
             pressure_df2, pressure_di2, _diagnostics = self.pressure(midpoint_f, midpoint_i)
             df2 += pressure_df2
             di2 += pressure_di2
-        final_i = ions + self.dt * di2
+        final_i = ions + source_dt * di2
         final_velocity = final_i[..., 1:4] / final_i[..., :1]
         base_in_midpoint_frame = self.frame_remap(flm, half_frame_change)
-        final_f_in_midpoint_frame = base_in_midpoint_frame + self.dt * df2
+        final_f_in_midpoint_frame = base_in_midpoint_frame + source_dt * df2
         final_f = self.frame_remap(final_f_in_midpoint_frame, final_velocity - midpoint_velocity)
         return final_f, final_i
 
     def __call__(self, t: float, state: dict[str, Array], args: dict | None = None) -> dict[str, Array]:
         if "ions" not in state:
             raise ValueError("coupled state must contain the ion conserved array under 'ions'")
+        flm = real_to_complex(state["flm"]) if self.electron_step.real_storage else state["flm"]
         midpoint_ions = self._hydro_half_step(state["ions"])
+        flm, midpoint_ions = self._exchange(t + 0.25 * self.dt, flm, midpoint_ions, args, 0.5 * self.dt)
         electron_args = {**({} if args is None else args), **self.ion_kinematics(midpoint_ions)}
-        electron_state = {key: state[key] for key in ("flm", "e", "b")}
+        electron_state = {
+            "flm": complex_to_real(flm) if self.electron_step.real_storage else flm,
+            "e": state["e"],
+            "b": state["b"],
+        }
+        if "current_projection_energy" in state:
+            electron_state["current_projection_energy"] = state["current_projection_energy"]
         advanced_electrons = self.electron_step(t, electron_state, electron_args)
 
         flm = (
             real_to_complex(advanced_electrons["flm"]) if self.electron_step.real_storage else advanced_electrons["flm"]
         )
-        flm, midpoint_ions = self._exchange(t + 0.5 * self.dt, flm, midpoint_ions, args)
+        flm, midpoint_ions = self._exchange(t + 0.75 * self.dt, flm, midpoint_ions, args, 0.5 * self.dt)
         final_ions = self._hydro_half_step(midpoint_ions)
         final_args = {**({} if args is None else args), **self.ion_kinematics(final_ions)}
         hidden_dndz = self.electron_step._hidden_dndz(
@@ -190,11 +205,15 @@ def coupled_invariants(
     ion_charge: float,
     light_speed: float,
     electron_mass: float = 1.0,
+    current_projection_energy: Array | None = None,
 ) -> dict[str, Array]:
     """Return global number, momentum, and energy histories.
 
     ``flm`` is expressed in peculiar velocity. Electron lab-frame momentum and
     kinetic energy therefore include the ion-frame translation terms.
+    ``current_projection_energy`` records work introduced by enforcing the
+    quasistatic Ampere moment; subtracting it exposes the conservative energy
+    defect of the coupled evolution itself.
     Leading batch dimensions (normally time) are preserved.
     """
 
@@ -228,6 +247,11 @@ def coupled_invariants(
         jnp.abs(electron_density - float(ion_charge) * ion_density),
         axis=scalar_axes,
     )
+    total_energy = electron_energy + ion_energy + magnetic_energy
+    if current_projection_energy is None:
+        projection_energy = jnp.zeros_like(total_energy)
+    else:
+        projection_energy = cell_area * jnp.sum(current_projection_energy, axis=scalar_axes)
     return {
         "electron_number": electron_number,
         "ion_number": ion_number,
@@ -236,5 +260,7 @@ def coupled_invariants(
         "electron_energy": electron_energy,
         "ion_energy": ion_energy,
         "magnetic_energy": magnetic_energy,
-        "total_energy": electron_energy + ion_energy + magnetic_energy,
+        "total_energy": total_energy,
+        "current_projection_energy": projection_energy,
+        "accounted_total_energy": total_energy - projection_energy,
     }

--- a/adept/vfp2d/coupling.py
+++ b/adept/vfp2d/coupling.py
@@ -1,9 +1,9 @@
 """Time-centered kinetic-electron / ion-fluid coupling for VFP-2D.
 
-Gate 2a composes the verified ion-frame electron, ideal-ion Euler, and local
-electron--ion exchange operators.  The split is deliberately explicit and
-auditable: hydro half-step, full kinetic step at midpoint ion kinematics,
-midpoint collisional exchange, then the second hydro half-step.
+The split composes ion-frame electrons, ideal-ion Euler transport, kinetic
+electron-pressure feedback, and finite-mass electron--ion exchange. It remains
+explicit and auditable: hydro half-step, full kinetic midpoint step, midpoint
+coupled sources, then the second hydro half-step.
 """
 
 from __future__ import annotations
@@ -13,11 +13,13 @@ from jax import Array
 
 from adept.vfp2d.exchange import (
     ElectronIonExchange,
+    VelocityFrameRemap,
     electron_kinetic_energy_density,
     electron_momentum_density,
 )
 from adept.vfp2d.harmonics import HarmonicLayout, complex_to_real, density, real_to_complex
 from adept.vfp2d.hydro import IonEuler2D, conserved_to_primitive
+from adept.vfp2d.pressure import ElectronPressureCoupling
 from adept.vfp2d.vector_field import KineticOhmStep
 
 
@@ -26,10 +28,9 @@ class CoupledIonKineticStep:
 
     The electron step must be a ``KineticOhmStep`` configured with an ion-frame
     operator. Ion kinematics are held at the hydro midpoint during its RK stages.
-    This first production coupling slice includes ideal-ion transport and local
-    thermal exchange; electron-pressure feedback belongs to Gate 2b. A nonzero
-    momentum-exchange rate is retained for isolated reference tests only and must
-    not be used in a production step until the finite-mass frame remap lands.
+    This production coupling includes ideal-ion transport and local finite-mass
+    thermal and momentum exchange. Electron-pressure feedback belongs to the
+    next Gate 2b slice.
     """
 
     def __init__(
@@ -39,6 +40,7 @@ class CoupledIonKineticStep:
         dt: float,
         *,
         exchange: ElectronIonExchange | None = None,
+        pressure: ElectronPressureCoupling | None = None,
         evolve_ions: bool = True,
     ):
         if electron_step.ion_frame is None:
@@ -49,6 +51,15 @@ class CoupledIonKineticStep:
         self.hydro = hydro
         self.dt = float(dt)
         self.exchange = exchange
+        self.pressure = pressure
+        electron_mass = 1.0
+        if exchange is not None:
+            electron_mass = exchange.electron_mass
+        if pressure is not None:
+            if exchange is not None and pressure.electron_mass != electron_mass:
+                raise ValueError("pressure and exchange electron masses must match")
+            electron_mass = pressure.electron_mass
+        self.frame_remap = VelocityFrameRemap(electron_step.ion_frame, electron_mass=electron_mass)
         self.evolve_ions = bool(evolve_ions)
 
     def _hydro_half_step(self, ions: Array) -> Array:
@@ -89,26 +100,52 @@ class CoupledIonKineticStep:
         return jnp.broadcast_to(jnp.asarray(value), template.shape)
 
     def _exchange(self, t: float, flm: Array, ions: Array, args: dict | None) -> tuple[Array, Array]:
-        if self.exchange is None:
+        if self.exchange is None and self.pressure is None:
             return flm, ions
         template = ions[..., 0]
         momentum_rate = self._rate(args, "ei_momentum_relaxation_rate", t, template)
         temperature_rate = self._rate(args, "ei_temperature_relaxation_rate", t, template)
-        df1, di1, _diagnostics = self.exchange(
-            flm,
-            ions,
-            momentum_relaxation_rate=momentum_rate,
-            temperature_relaxation_rate=temperature_rate,
-        )
-        midpoint_f = flm + 0.5 * self.dt * df1
+        df1 = jnp.zeros_like(flm)
+        di1 = jnp.zeros_like(ions)
+        if self.exchange is not None:
+            exchange_df1, exchange_di1, _diagnostics = self.exchange(
+                flm,
+                ions,
+                momentum_relaxation_rate=momentum_rate,
+                temperature_relaxation_rate=temperature_rate,
+            )
+            df1 += exchange_df1
+            di1 += exchange_di1
+        if self.pressure is not None:
+            pressure_df1, pressure_di1, _diagnostics = self.pressure(flm, ions)
+            df1 += pressure_df1
+            di1 += pressure_di1
         midpoint_i = ions + 0.5 * self.dt * di1
-        df2, di2, _diagnostics = self.exchange(
-            midpoint_f,
-            midpoint_i,
-            momentum_relaxation_rate=momentum_rate,
-            temperature_relaxation_rate=temperature_rate,
-        )
-        return flm + self.dt * df2, ions + self.dt * di2
+        initial_velocity = ions[..., 1:4] / ions[..., :1]
+        midpoint_velocity = midpoint_i[..., 1:4] / midpoint_i[..., :1]
+        half_frame_change = midpoint_velocity - initial_velocity
+        midpoint_f = self.frame_remap(flm + 0.5 * self.dt * df1, half_frame_change)
+        df2 = jnp.zeros_like(flm)
+        di2 = jnp.zeros_like(ions)
+        if self.exchange is not None:
+            exchange_df2, exchange_di2, _diagnostics = self.exchange(
+                midpoint_f,
+                midpoint_i,
+                momentum_relaxation_rate=momentum_rate,
+                temperature_relaxation_rate=temperature_rate,
+            )
+            df2 += exchange_df2
+            di2 += exchange_di2
+        if self.pressure is not None:
+            pressure_df2, pressure_di2, _diagnostics = self.pressure(midpoint_f, midpoint_i)
+            df2 += pressure_df2
+            di2 += pressure_di2
+        final_i = ions + self.dt * di2
+        final_velocity = final_i[..., 1:4] / final_i[..., :1]
+        base_in_midpoint_frame = self.frame_remap(flm, half_frame_change)
+        final_f_in_midpoint_frame = base_in_midpoint_frame + self.dt * df2
+        final_f = self.frame_remap(final_f_in_midpoint_frame, final_velocity - midpoint_velocity)
+        return final_f, final_i
 
     def __call__(self, t: float, state: dict[str, Array], args: dict | None = None) -> dict[str, Array]:
         if "ions" not in state:

--- a/adept/vfp2d/exchange.py
+++ b/adept/vfp2d/exchange.py
@@ -1,0 +1,150 @@
+"""Conservative finite-mass electron--ion moment exchange for VFP-2D.
+
+This module supplies a differential, weak-anisotropy relaxation reference.  It
+changes only the electron ``f0`` energy moment and ``f1`` bulk-momentum moment,
+then applies their measured discrete opposites to the ion conserved state.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+
+from adept.vfp2d.harmonics import HarmonicLayout, current, density, scalar_velocity_moment
+from adept.vfp2d.ohm import project_current_moment
+
+
+def electron_momentum_density(
+    f: Array,
+    layout: HarmonicLayout,
+    v: Array,
+    dv: float,
+    electron_mass: float = 1.0,
+) -> Array:
+    """Return ``m_e integral(c f d^3c)`` in the local ion frame."""
+
+    return float(electron_mass) * current(f, layout, v, dv, charge=1.0)
+
+
+def electron_kinetic_energy_density(
+    f: Array,
+    layout: HarmonicLayout,
+    v: Array,
+    dv: float,
+    electron_mass: float = 1.0,
+) -> Array:
+    """Return ``m_e/2 integral(c^2 f d^3c)``."""
+
+    i00 = layout.index(0, 0)
+    f00 = jnp.real(f[..., i00, :])
+    return 2.0 * jnp.pi * float(electron_mass) * jnp.sum(f00 * jnp.asarray(v) ** 4, axis=-1) * float(dv)
+
+
+class ElectronIonExchange:
+    """Discrete equal-and-opposite electron--ion relaxation rates.
+
+    ``momentum_relaxation_rate`` defines ``dP_e/dt = -nu_m P_e`` in the ion
+    frame. ``temperature_relaxation_rate`` defines
+    ``dT_e/dt = -nu_T (T_e - T_i)`` for the isotropic weak-drift temperature.
+    The returned ion source has exactly opposite measured momentum and energy.
+    """
+
+    def __init__(
+        self,
+        layout: HarmonicLayout,
+        v: Array,
+        dv: float,
+        *,
+        electron_mass: float = 1.0,
+        ion_mass: float = 1836.0,
+        ion_gamma: float = 5.0 / 3.0,
+    ):
+        if layout.l_max < 1:
+            raise ValueError("electron-ion momentum exchange requires l_max >= 1")
+        if electron_mass <= 0.0 or ion_mass <= 0.0:
+            raise ValueError("electron and ion masses must be positive")
+        if ion_gamma <= 1.0:
+            raise ValueError("ion_gamma must be greater than one")
+        self.layout = layout
+        self.v = jnp.asarray(v)
+        self.dv = float(dv)
+        self.electron_mass = float(electron_mass)
+        self.ion_mass = float(ion_mass)
+        self.ion_gamma = float(ion_gamma)
+
+    def _temperatures(self, f: Array, ion_conserved: Array) -> tuple[Array, Array, Array]:
+        electron_density = density(f, self.layout, self.v, self.dv)
+        mean_square_speed = scalar_velocity_moment(f, self.layout, self.v, self.dv, power=2)
+        electron_temperature = self.electron_mass * mean_square_speed / 3.0
+
+        ion_density = ion_conserved[..., 0] / self.ion_mass
+        ion_velocity = ion_conserved[..., 1:4] / ion_conserved[..., :1]
+        ion_internal_energy = ion_conserved[..., 4] - 0.5 * ion_conserved[..., 0] * jnp.sum(ion_velocity**2, axis=-1)
+        ion_pressure = (self.ion_gamma - 1.0) * ion_internal_energy
+        ion_temperature = ion_pressure / jnp.maximum(ion_density, jnp.finfo(ion_density.dtype).tiny)
+        return electron_density, electron_temperature, ion_temperature
+
+    def _momentum_rate(self, f: Array, rate: Array) -> Array:
+        measured_current = current(f, self.layout, self.v, self.dv)
+        target_current = (1.0 - rate[..., None]) * measured_current
+        return project_current_moment(f, self.layout, self.v, self.dv, target_current) - f
+
+    def _thermal_rate(self, f: Array, energy_rate: Array) -> Array:
+        i00 = self.layout.index(0, 0)
+        f00 = jnp.real(f[..., i00, :])
+        mean_square_speed = scalar_velocity_moment(f, self.layout, self.v, self.dv, power=2)
+        density_neutral_basis = (self.v**2 - mean_square_speed[..., None]) * f00
+        energy_response = (
+            2.0 * jnp.pi * self.electron_mass * jnp.sum(density_neutral_basis * self.v**4, axis=-1) * self.dv
+        )
+        tiny = jnp.finfo(energy_response.dtype).tiny
+        safe_response = jnp.where(jnp.abs(energy_response) > tiny, energy_response, 1.0)
+        amplitude = jnp.where(jnp.abs(energy_response) > tiny, energy_rate / safe_response, 0.0)
+        return jnp.zeros_like(f).at[..., i00, :].set(amplitude[..., None] * density_neutral_basis)
+
+    def __call__(
+        self,
+        f: Array,
+        ion_conserved: Array,
+        *,
+        momentum_relaxation_rate: float | Array,
+        temperature_relaxation_rate: float | Array,
+    ) -> tuple[Array, Array, dict[str, Array]]:
+        if ion_conserved.shape != (*f.shape[:-2], 5):
+            raise ValueError("ion_conserved must match the spatial VFP shape and have five conserved variables")
+        spatial_shape = f.shape[:-2]
+        momentum_rate = jnp.broadcast_to(jnp.asarray(momentum_relaxation_rate), spatial_shape)
+        temperature_rate = jnp.broadcast_to(jnp.asarray(temperature_relaxation_rate), spatial_shape)
+        electron_density, electron_temperature, ion_temperature = self._temperatures(f, ion_conserved)
+
+        requested_energy_rate = -1.5 * electron_density * temperature_rate * (electron_temperature - ion_temperature)
+        dfdt = self._momentum_rate(f, momentum_rate) + self._thermal_rate(f, requested_energy_rate)
+        measured_momentum_rate = electron_momentum_density(
+            dfdt,
+            self.layout,
+            self.v,
+            self.dv,
+            self.electron_mass,
+        )
+        measured_energy_rate = electron_kinetic_energy_density(
+            dfdt,
+            self.layout,
+            self.v,
+            self.dv,
+            self.electron_mass,
+        )
+
+        ion_rate = jnp.zeros_like(ion_conserved)
+        ion_rate = ion_rate.at[..., 1:4].set(-measured_momentum_rate)
+        ion_rate = ion_rate.at[..., 4].set(-measured_energy_rate)
+        diagnostics = {
+            "electron_temperature": electron_temperature,
+            "ion_temperature": ion_temperature,
+            "electron_momentum_rate": measured_momentum_rate,
+            "ion_momentum_rate": ion_rate[..., 1:4],
+            "electron_energy_rate": measured_energy_rate,
+            "ion_energy_rate": ion_rate[..., 4],
+            "momentum_residual": measured_momentum_rate + ion_rate[..., 1:4],
+            "energy_residual": measured_energy_rate + ion_rate[..., 4],
+        }
+        return dfdt, ion_rate, diagnostics

--- a/adept/vfp2d/exchange.py
+++ b/adept/vfp2d/exchange.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 from jax import Array
 
 from adept.vfp2d.harmonics import HarmonicLayout, current, density, scalar_velocity_moment
+from adept.vfp2d.moving_frame import IonFrameVlasov
 from adept.vfp2d.ohm import project_current_moment
 
 
@@ -38,6 +39,96 @@ def electron_kinetic_energy_density(
     i00 = layout.index(0, 0)
     f00 = jnp.real(f[..., i00, :])
     return 2.0 * jnp.pi * float(electron_mass) * jnp.sum(f00 * jnp.asarray(v) ** 4, axis=-1) * float(dv)
+
+
+def electron_energy_moment_correction(
+    f: Array,
+    layout: HarmonicLayout,
+    v: Array,
+    dv: float,
+    energy_correction: Array,
+    electron_mass: float,
+) -> Array:
+    """Return a density-neutral ``f00`` correction with a prescribed energy."""
+
+    i00 = layout.index(0, 0)
+    f00 = jnp.real(f[..., i00, :])
+    mean_square_speed = scalar_velocity_moment(f, layout, v, dv, power=2)
+    density_neutral_basis = (v**2 - mean_square_speed[..., None]) * f00
+    response = 2.0 * jnp.pi * electron_mass * jnp.sum(density_neutral_basis * v**4, axis=-1) * dv
+    tiny = jnp.finfo(response.dtype).tiny
+    safe_response = jnp.where(jnp.abs(response) > tiny, response, 1.0)
+    amplitude = jnp.where(jnp.abs(response) > tiny, energy_correction / safe_response, 0.0)
+    return jnp.zeros_like(f).at[..., i00, :].set(amplitude[..., None] * density_neutral_basis)
+
+
+class VelocityFrameRemap:
+    """Translate ``f(c)`` between finite-mass ion velocity frames.
+
+    A second-order velocity-space translation retains the resolved distribution
+    shape. Discrete projections then enforce the exact Galilean density,
+    momentum, and kinetic-energy transforms, including radial-grid boundary
+    defects from the differential translation operator.
+    """
+
+    def __init__(self, ion_frame: IonFrameVlasov, *, electron_mass: float = 1.0):
+        if electron_mass <= 0.0:
+            raise ValueError("electron_mass must be positive")
+        self.ion_frame = ion_frame
+        self.layout = ion_frame.layout
+        self.v = ion_frame.vlasov.v
+        self.dv = ion_frame.vlasov.dv
+        self.electron_mass = float(electron_mass)
+
+    def __call__(self, f: Array, frame_velocity_change: Array) -> Array:
+        expected_shape = (*f.shape[:-2], 3)
+        if frame_velocity_change.shape != expected_shape:
+            raise ValueError(f"frame_velocity_change must have shape {expected_shape}")
+
+        electron_density = density(f, self.layout, self.v, self.dv)
+        old_momentum = electron_momentum_density(f, self.layout, self.v, self.dv, self.electron_mass)
+        old_energy = electron_kinetic_energy_density(f, self.layout, self.v, self.dv, self.electron_mass)
+
+        first = self.ion_frame.frame_acceleration(f, frame_velocity_change)
+        midpoint = f + 0.5 * first
+        translated = f + self.ion_frame.frame_acceleration(midpoint, frame_velocity_change)
+
+        # The differential operator is conservative in the continuum. Restore
+        # exact discrete density before correcting its first two moments.
+        i00 = self.layout.index(0, 0)
+        translated_density = density(translated, self.layout, self.v, self.dv)
+        tiny = jnp.finfo(translated_density.dtype).tiny
+        density_scale = jnp.where(jnp.abs(translated_density) > tiny, electron_density / translated_density, 1.0)
+        translated = translated.at[..., i00, :].set(density_scale[..., None] * jnp.real(translated[..., i00, :]))
+
+        target_momentum = old_momentum - self.electron_mass * electron_density[..., None] * frame_velocity_change
+        target_current = -target_momentum / self.electron_mass
+        translated = project_current_moment(
+            translated,
+            self.layout,
+            self.v,
+            self.dv,
+            target_current,
+        )
+
+        target_energy = old_energy - jnp.sum(frame_velocity_change * old_momentum, axis=-1)
+        target_energy += 0.5 * self.electron_mass * electron_density * jnp.sum(frame_velocity_change**2, axis=-1)
+        measured_energy = electron_kinetic_energy_density(
+            translated,
+            self.layout,
+            self.v,
+            self.dv,
+            self.electron_mass,
+        )
+        translated += electron_energy_moment_correction(
+            translated,
+            self.layout,
+            self.v,
+            self.dv,
+            target_energy - measured_energy,
+            self.electron_mass,
+        )
+        return translated
 
 
 class ElectronIonExchange:
@@ -90,17 +181,14 @@ class ElectronIonExchange:
         return project_current_moment(f, self.layout, self.v, self.dv, target_current) - f
 
     def _thermal_rate(self, f: Array, energy_rate: Array) -> Array:
-        i00 = self.layout.index(0, 0)
-        f00 = jnp.real(f[..., i00, :])
-        mean_square_speed = scalar_velocity_moment(f, self.layout, self.v, self.dv, power=2)
-        density_neutral_basis = (self.v**2 - mean_square_speed[..., None]) * f00
-        energy_response = (
-            2.0 * jnp.pi * self.electron_mass * jnp.sum(density_neutral_basis * self.v**4, axis=-1) * self.dv
+        return electron_energy_moment_correction(
+            f,
+            self.layout,
+            self.v,
+            self.dv,
+            energy_rate,
+            self.electron_mass,
         )
-        tiny = jnp.finfo(energy_response.dtype).tiny
-        safe_response = jnp.where(jnp.abs(energy_response) > tiny, energy_response, 1.0)
-        amplitude = jnp.where(jnp.abs(energy_response) > tiny, energy_rate / safe_response, 0.0)
-        return jnp.zeros_like(f).at[..., i00, :].set(amplitude[..., None] * density_neutral_basis)
 
     def __call__(
         self,
@@ -136,15 +224,21 @@ class ElectronIonExchange:
 
         ion_rate = jnp.zeros_like(ion_conserved)
         ion_rate = ion_rate.at[..., 1:4].set(-measured_momentum_rate)
-        ion_rate = ion_rate.at[..., 4].set(-measured_energy_rate)
+        ion_velocity = ion_conserved[..., 1:4] / ion_conserved[..., :1]
+        measured_lab_energy_rate = measured_energy_rate + jnp.sum(
+            ion_velocity * measured_momentum_rate,
+            axis=-1,
+        )
+        ion_rate = ion_rate.at[..., 4].set(-measured_lab_energy_rate)
         diagnostics = {
             "electron_temperature": electron_temperature,
             "ion_temperature": ion_temperature,
             "electron_momentum_rate": measured_momentum_rate,
             "ion_momentum_rate": ion_rate[..., 1:4],
             "electron_energy_rate": measured_energy_rate,
+            "electron_lab_energy_rate": measured_lab_energy_rate,
             "ion_energy_rate": ion_rate[..., 4],
             "momentum_residual": measured_momentum_rate + ion_rate[..., 1:4],
-            "energy_residual": measured_energy_rate + ion_rate[..., 4],
+            "energy_residual": measured_lab_energy_rate + ion_rate[..., 4],
         }
         return dfdt, ion_rate, diagnostics

--- a/adept/vfp2d/harmonics.py
+++ b/adept/vfp2d/harmonics.py
@@ -180,6 +180,23 @@ class TzoufrasVlasov:
         padded = jnp.concatenate((left, f, right), axis=-1)
         return (padded[..., 2:] - padded[..., :-2]) / (2.0 * self.dv)
 
+    def spatial_derivative(self, f: Array, axis: int) -> Array:
+        """Differentiate a VFP-grid field along ``x`` (0) or ``y`` (1)."""
+
+        if axis == 0:
+            return (
+                _spectral_derivative(f, self.kx, axis=0)
+                if self.dx is None
+                else periodic_central_derivative(f, self.dx, axis=0, mesh=self.mesh)
+            )
+        if axis == 1:
+            return (
+                _spectral_derivative(f, self.ky, axis=1)
+                if self.dy is None
+                else periodic_central_derivative(f, self.dy, axis=1)
+            )
+        raise ValueError("VFP-2D spatial derivative axis must be 0 (x) or 1 (y)")
+
     def gh(self, f: Array) -> tuple[Array, Array]:
         """Return the radial operators ``G_l`` and ``H_l`` from Eqs. (20)--(22)."""
 
@@ -200,16 +217,8 @@ class TzoufrasVlasov:
         for an integrable 2.5D density gradient without allocating a z grid.
         """
 
-        dfdx = (
-            _spectral_derivative(f, self.kx, axis=0)
-            if self.dx is None
-            else periodic_central_derivative(f, self.dx, axis=0, mesh=self.mesh)
-        )
-        dfdy = (
-            _spectral_derivative(f, self.ky, axis=1)
-            if self.dy is None
-            else periodic_central_derivative(f, self.dy, axis=1)
-        )
+        dfdx = self.spatial_derivative(f, axis=0)
+        dfdy = self.spatial_derivative(f, axis=1)
         if dfdz is None:
             dfdz = jnp.zeros_like(f)
         transverse_minus = dfdy - 1j * dfdz

--- a/adept/vfp2d/hydro.py
+++ b/adept/vfp2d/hydro.py
@@ -1,0 +1,344 @@
+"""Conservative ion-fluid building blocks for kinetic-electron coupling.
+
+The ion state uses cell averages of ``(rho, rho*u_x, rho*u_y, rho*u_z, E)``.
+Only the two configuration-space directions carry fluxes, but all three momentum
+components are retained for the eventual 2D3P VFP coupling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import jax.numpy as jnp
+from jax import Array
+
+Boundary = Literal["periodic", "outflow"]
+
+N_HYDRO_VARS = 5
+DENSITY = 0
+ENERGY = 4
+
+
+def _check_state_shape(state: Array) -> None:
+    if state.ndim < 1 or state.shape[-1] != N_HYDRO_VARS:
+        raise ValueError("hydro states must have a final axis of length 5")
+
+
+def _check_gamma(gamma: float) -> None:
+    if gamma <= 1.0:
+        raise ValueError("gamma must be greater than one")
+
+
+def primitive_to_conserved(primitive: Array, gamma: float = 5.0 / 3.0) -> Array:
+    """Convert ``(rho, u_x, u_y, u_z, p)`` to conservative variables."""
+
+    primitive = jnp.asarray(primitive)
+    _check_state_shape(primitive)
+    _check_gamma(gamma)
+    rho = primitive[..., DENSITY]
+    velocity = primitive[..., 1:4]
+    pressure = primitive[..., ENERGY]
+    momentum = rho[..., None] * velocity
+    total_energy = pressure / (gamma - 1.0) + 0.5 * rho * jnp.sum(velocity**2, axis=-1)
+    return jnp.concatenate((rho[..., None], momentum, total_energy[..., None]), axis=-1)
+
+
+def conserved_to_primitive(
+    conserved: Array,
+    gamma: float = 5.0 / 3.0,
+    *,
+    density_floor: float = 1.0e-12,
+    pressure_floor: float = 1.0e-12,
+) -> Array:
+    """Convert conservative variables to ``(rho, u_x, u_y, u_z, p)``.
+
+    Floors keep wave-speed and reconstruction calculations finite if an
+    intermediate explicit stage approaches vacuum. Valid states are unchanged.
+    """
+
+    conserved = jnp.asarray(conserved)
+    _check_state_shape(conserved)
+    _check_gamma(gamma)
+    if density_floor <= 0.0 or pressure_floor <= 0.0:
+        raise ValueError("density_floor and pressure_floor must be positive")
+
+    rho = jnp.maximum(conserved[..., DENSITY], density_floor)
+    momentum = conserved[..., 1:4]
+    velocity = momentum / rho[..., None]
+    kinetic_energy = 0.5 * jnp.sum(momentum**2, axis=-1) / rho
+    pressure = jnp.maximum((gamma - 1.0) * (conserved[..., ENERGY] - kinetic_energy), pressure_floor)
+    return jnp.concatenate((rho[..., None], velocity, pressure[..., None]), axis=-1)
+
+
+def euler_flux(primitive: Array, normal_axis: int, gamma: float = 5.0 / 3.0) -> Array:
+    """Return the physical Euler flux normal to ``x`` (0) or ``y`` (1)."""
+
+    primitive = jnp.asarray(primitive)
+    _check_state_shape(primitive)
+    _check_gamma(gamma)
+    if normal_axis not in (0, 1):
+        raise ValueError("normal_axis must be 0 (x) or 1 (y)")
+
+    conserved = primitive_to_conserved(primitive, gamma)
+    pressure = primitive[..., ENERGY]
+    normal_velocity = primitive[..., 1 + normal_axis]
+    flux = conserved * normal_velocity[..., None]
+    flux = flux.at[..., 1 + normal_axis].add(pressure)
+    return flux.at[..., ENERGY].set((conserved[..., ENERGY] + pressure) * normal_velocity)
+
+
+def _nonzero(value: Array) -> Array:
+    eps = jnp.finfo(value.dtype).eps
+    sign = jnp.where(value < 0.0, -1.0, 1.0)
+    return jnp.where(jnp.abs(value) < eps, sign * eps, value)
+
+
+def _hllc_star_state(
+    primitive: Array,
+    wave_speed: Array,
+    contact_speed: Array,
+    normal_axis: int,
+    gamma: float,
+) -> Array:
+    rho = primitive[..., DENSITY]
+    pressure = primitive[..., ENERGY]
+    velocity = primitive[..., 1:4]
+    normal_velocity = velocity[..., normal_axis]
+    conserved = primitive_to_conserved(primitive, gamma)
+    denominator = _nonzero(wave_speed - contact_speed)
+    star_density = rho * (wave_speed - normal_velocity) / denominator
+    star_velocity = velocity.at[..., normal_axis].set(contact_speed)
+    star_pressure = pressure + rho * (wave_speed - normal_velocity) * (contact_speed - normal_velocity)
+    star_energy = (
+        (wave_speed - normal_velocity) * conserved[..., ENERGY]
+        - pressure * normal_velocity
+        + star_pressure * contact_speed
+    ) / denominator
+    return jnp.concatenate(
+        (
+            star_density[..., None],
+            star_density[..., None] * star_velocity,
+            star_energy[..., None],
+        ),
+        axis=-1,
+    )
+
+
+def hllc_flux(left: Array, right: Array, normal_axis: int, gamma: float = 5.0 / 3.0) -> Array:
+    """Compute the HLLC flux for left/right primitive states.
+
+    The same implementation is used in both spatial directions. The third
+    velocity component is transported as tangential momentum.
+    """
+
+    left = jnp.asarray(left)
+    right = jnp.asarray(right)
+    _check_state_shape(left)
+    _check_state_shape(right)
+    _check_gamma(gamma)
+    if left.shape != right.shape:
+        raise ValueError("left and right states must have matching shapes")
+    if normal_axis not in (0, 1):
+        raise ValueError("normal_axis must be 0 (x) or 1 (y)")
+
+    rho_left, rho_right = left[..., DENSITY], right[..., DENSITY]
+    pressure_left, pressure_right = left[..., ENERGY], right[..., ENERGY]
+    velocity_left = left[..., 1 + normal_axis]
+    velocity_right = right[..., 1 + normal_axis]
+    sound_left = jnp.sqrt(gamma * pressure_left / rho_left)
+    sound_right = jnp.sqrt(gamma * pressure_right / rho_right)
+    wave_left = jnp.minimum(velocity_left - sound_left, velocity_right - sound_right)
+    wave_right = jnp.maximum(velocity_left + sound_left, velocity_right + sound_right)
+    contact_numerator = (
+        pressure_right
+        - pressure_left
+        + rho_left * velocity_left * (wave_left - velocity_left)
+        - rho_right * velocity_right * (wave_right - velocity_right)
+    )
+    contact_denominator = _nonzero(rho_left * (wave_left - velocity_left) - rho_right * (wave_right - velocity_right))
+    contact = contact_numerator / contact_denominator
+
+    conserved_left = primitive_to_conserved(left, gamma)
+    conserved_right = primitive_to_conserved(right, gamma)
+    flux_left = euler_flux(left, normal_axis, gamma)
+    flux_right = euler_flux(right, normal_axis, gamma)
+    star_left = _hllc_star_state(left, wave_left, contact, normal_axis, gamma)
+    star_right = _hllc_star_state(right, wave_right, contact, normal_axis, gamma)
+    left_star_flux = flux_left + wave_left[..., None] * (star_left - conserved_left)
+    right_star_flux = flux_right + wave_right[..., None] * (star_right - conserved_right)
+
+    return jnp.where(
+        (wave_left >= 0.0)[..., None],
+        flux_left,
+        jnp.where(
+            (contact >= 0.0)[..., None],
+            left_star_flux,
+            jnp.where((wave_right > 0.0)[..., None], right_star_flux, flux_right),
+        ),
+    )
+
+
+def _minmod3(first: Array, second: Array, third: Array) -> Array:
+    all_positive = (first > 0.0) & (second > 0.0) & (third > 0.0)
+    all_negative = (first < 0.0) & (second < 0.0) & (third < 0.0)
+    magnitude = jnp.minimum(jnp.abs(first), jnp.minimum(jnp.abs(second), jnp.abs(third)))
+    return jnp.where(all_positive, magnitude, jnp.where(all_negative, -magnitude, 0.0))
+
+
+def _limited_slope(primitive: Array, axis: int, boundary: Boundary, theta: float) -> Array:
+    values = jnp.moveaxis(primitive, axis, 0)
+    if boundary == "periodic":
+        before = jnp.roll(values, 1, axis=0)
+        after = jnp.roll(values, -1, axis=0)
+    elif boundary == "outflow":
+        before = jnp.concatenate((values[:1], values[:-1]), axis=0)
+        after = jnp.concatenate((values[1:], values[-1:]), axis=0)
+    else:
+        raise ValueError(f"unsupported hydro boundary: {boundary}")
+    slope = _minmod3(theta * (values - before), 0.5 * (after - before), theta * (after - values))
+    return jnp.moveaxis(slope, 0, axis)
+
+
+def _interface_states(
+    primitive: Array,
+    axis: int,
+    boundary: Boundary,
+    theta: float,
+    density_floor: float,
+    pressure_floor: float,
+) -> tuple[Array, Array]:
+    """Reconstruct primitive states on all ``n + 1`` faces along one axis."""
+
+    values = jnp.moveaxis(primitive, axis, 0)
+    slopes = jnp.moveaxis(_limited_slope(primitive, axis, boundary, theta), axis, 0)
+    high_left_interior = values[:-1] + 0.5 * slopes[:-1]
+    high_right_interior = values[1:] - 0.5 * slopes[1:]
+    low_left_interior = values[:-1]
+    low_right_interior = values[1:]
+
+    if boundary == "periodic":
+        high_left_boundary = values[-1] + 0.5 * slopes[-1]
+        high_right_boundary = values[0] - 0.5 * slopes[0]
+        low_left_boundary = values[-1]
+        low_right_boundary = values[0]
+    else:
+        high_left_boundary = values[0]
+        high_right_boundary = values[0] - 0.5 * slopes[0]
+        low_left_boundary = values[0]
+        low_right_boundary = values[0]
+
+    high_left = jnp.concatenate(
+        (high_left_boundary[None, ...], high_left_interior, (values[-1] + 0.5 * slopes[-1])[None, ...]),
+        axis=0,
+    )
+    high_right = jnp.concatenate(
+        (high_right_boundary[None, ...], high_right_interior, high_right_boundary[None, ...]),
+        axis=0,
+    )
+    low_left = jnp.concatenate(
+        (low_left_boundary[None, ...], low_left_interior, values[-1][None, ...]),
+        axis=0,
+    )
+    low_right = jnp.concatenate(
+        (low_right_boundary[None, ...], low_right_interior, low_right_boundary[None, ...]),
+        axis=0,
+    )
+
+    if boundary == "outflow":
+        high_right = high_right.at[-1].set(values[-1])
+        low_right = low_right.at[-1].set(values[-1])
+
+    valid_left = (
+        jnp.all(jnp.isfinite(high_left), axis=-1)
+        & (high_left[..., DENSITY] > density_floor)
+        & (high_left[..., ENERGY] > pressure_floor)
+    )
+    valid_right = (
+        jnp.all(jnp.isfinite(high_right), axis=-1)
+        & (high_right[..., DENSITY] > density_floor)
+        & (high_right[..., ENERGY] > pressure_floor)
+    )
+    use_high_order = (valid_left & valid_right)[..., None]
+    left = jnp.where(use_high_order, high_left, low_left)
+    right = jnp.where(use_high_order, high_right, low_right)
+    return jnp.moveaxis(left, 0, axis), jnp.moveaxis(right, 0, axis)
+
+
+@dataclass(frozen=True)
+class IonEuler2D:
+    """MUSCL-HLLC finite-volume operator for an ideal ion fluid."""
+
+    dx: float
+    dy: float
+    gamma: float = 5.0 / 3.0
+    boundaries: tuple[Boundary, Boundary] = ("periodic", "periodic")
+    limiter_theta: float = 1.5
+    density_floor: float = 1.0e-12
+    pressure_floor: float = 1.0e-12
+
+    def __post_init__(self) -> None:
+        _check_gamma(self.gamma)
+        if self.dx <= 0.0 or self.dy <= 0.0:
+            raise ValueError("dx and dy must be positive")
+        if len(self.boundaries) != 2 or any(boundary not in ("periodic", "outflow") for boundary in self.boundaries):
+            raise ValueError("boundaries must contain periodic/outflow choices for x and y")
+        if not 1.0 <= self.limiter_theta <= 2.0:
+            raise ValueError("limiter_theta must lie between 1 and 2")
+        if self.density_floor <= 0.0 or self.pressure_floor <= 0.0:
+            raise ValueError("density_floor and pressure_floor must be positive")
+
+    def fluxes(self, conserved: Array, axis: int) -> Array:
+        """Return numerical fluxes on all faces along ``axis``."""
+
+        conserved = jnp.asarray(conserved)
+        _check_state_shape(conserved)
+        if conserved.ndim != 3:
+            raise ValueError("IonEuler2D expects state shape (nx, ny, 5)")
+        if axis not in (0, 1):
+            raise ValueError("axis must be 0 (x) or 1 (y)")
+        primitive = conserved_to_primitive(
+            conserved,
+            self.gamma,
+            density_floor=self.density_floor,
+            pressure_floor=self.pressure_floor,
+        )
+        left, right = _interface_states(
+            primitive,
+            axis,
+            self.boundaries[axis],
+            self.limiter_theta,
+            self.density_floor,
+            self.pressure_floor,
+        )
+        return hllc_flux(left, right, axis, self.gamma)
+
+    def rhs(self, conserved: Array) -> Array:
+        """Return the conservative semidiscrete spatial operator."""
+
+        flux_x = self.fluxes(conserved, axis=0)
+        flux_y = self.fluxes(conserved, axis=1)
+        return -(flux_x[1:] - flux_x[:-1]) / self.dx - (flux_y[:, 1:] - flux_y[:, :-1]) / self.dy
+
+    def step(self, conserved: Array, dt: float | Array) -> Array:
+        """Advance one second-order strong-stability-preserving Runge--Kutta step."""
+
+        first_stage = conserved + dt * self.rhs(conserved)
+        return 0.5 * (conserved + first_stage + dt * self.rhs(first_stage))
+
+    def cfl_timestep(self, conserved: Array, cfl: float = 0.4) -> Array:
+        """Return the unsplit acoustic/advection CFL timestep."""
+
+        if not 0.0 < cfl <= 1.0:
+            raise ValueError("cfl must lie in (0, 1]")
+        primitive = conserved_to_primitive(
+            conserved,
+            self.gamma,
+            density_floor=self.density_floor,
+            pressure_floor=self.pressure_floor,
+        )
+        sound_speed = jnp.sqrt(self.gamma * primitive[..., ENERGY] / primitive[..., DENSITY])
+        rate = (jnp.abs(primitive[..., 1]) + sound_speed) / self.dx
+        rate = rate + (jnp.abs(primitive[..., 2]) + sound_speed) / self.dy
+        maximum_rate = jnp.max(rate)
+        return jnp.where(maximum_rate > 0.0, cfl / maximum_rate, jnp.inf)

--- a/adept/vfp2d/moving_frame.py
+++ b/adept/vfp2d/moving_frame.py
@@ -1,0 +1,214 @@
+"""Ion-frame kinematic operators for the spherical-harmonic electron state.
+
+The mixed coordinates keep position and time in the laboratory frame while
+representing velocity as ``c = v - u_i(x, t)``.  For
+``A_ij = partial_j u_i`` and ``a_i = D_t u_i``, the frame terms are
+
+``-div_x(u_i f) + div_c(A c f) + a_i . grad_c(f)``.
+
+Together with relative streaming, these terms are the non-relativistic limit
+of the mixed-frame VFP equation.  The deformation operator is evaluated by an
+angular Galerkin projection and a conservative radial velocity flux.  This is
+an equation-level reference implementation; coupling it to the production
+hydro/VFP split and optimizing the angular matrix products are later phases.
+"""
+
+from __future__ import annotations
+
+from math import factorial
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+from scipy.special import lpmv
+
+from adept.vfp2d.harmonics import HarmonicLayout, TzoufrasVlasov
+
+
+class _AngularGalerkin:
+    """Quadrature transforms for ADEPT's unnormalized associated-Legendre basis."""
+
+    def __init__(self, layout: HarmonicLayout):
+        n_mu = max(3, layout.l_max + 3)
+        n_phi = max(5, 2 * layout.l_max + 5)
+        mu, weight_mu = np.polynomial.legendre.leggauss(n_mu)
+        phi = 2.0 * np.pi * np.arange(n_phi) / n_phi
+        sin_theta = np.sqrt(1.0 - mu**2)
+
+        mu_grid, phi_grid = np.meshgrid(mu, phi, indexing="ij")
+        sin_grid = np.sqrt(1.0 - mu_grid**2)
+        directions = np.stack(
+            (
+                mu_grid,
+                sin_grid * np.cos(phi_grid),
+                sin_grid * np.sin(phi_grid),
+            ),
+            axis=-1,
+        ).reshape(-1, 3)
+        theta_directions = np.stack(
+            (
+                -sin_grid,
+                mu_grid * np.cos(phi_grid),
+                mu_grid * np.sin(phi_grid),
+            ),
+            axis=-1,
+        ).reshape(-1, 3)
+        phi_directions = np.stack(
+            (
+                np.zeros_like(phi_grid),
+                -np.sin(phi_grid),
+                np.cos(phi_grid),
+            ),
+            axis=-1,
+        ).reshape(-1, 3)
+        weights = (weight_mu[:, None] * np.full((1, n_phi), 2.0 * np.pi / n_phi)).reshape(-1)
+
+        basis = []
+        dtheta_basis = []
+        dphi_basis = []
+        norms = []
+        multiplicity = []
+        for ell, m in layout.pairs:
+            # scipy includes the Condon--Shortley (-1)^m phase; ADEPT/Tzoufras does not.
+            associated = (-1) ** m * lpmv(m, ell, mu)
+            if ell == 0:
+                derivative_mu = np.zeros_like(mu)
+            else:
+                lower = np.zeros_like(mu) if m > ell - 1 else (-1) ** m * lpmv(m, ell - 1, mu)
+                derivative_mu = (ell * mu * associated - (ell + m) * lower) / (mu**2 - 1.0)
+            phase = np.exp(1j * m * phi)
+            harmonic = (associated[:, None] * phase[None, :]).reshape(-1)
+            dtheta = (-sin_theta[:, None] * derivative_mu[:, None] * phase[None, :]).reshape(-1)
+            basis.append(harmonic)
+            dtheta_basis.append(dtheta)
+            dphi_basis.append(1j * m * harmonic)
+            norms.append(4.0 * np.pi * factorial(ell + m) / ((2 * ell + 1) * factorial(ell - m)))
+            multiplicity.append(1.0 if m == 0 else 2.0)
+
+        basis_array = np.asarray(basis)
+        self.basis = jnp.asarray(basis_array)
+        self.reconstruction_basis = jnp.asarray(np.asarray(multiplicity)[:, None] * basis_array)
+        self.dtheta_reconstruction_basis = jnp.asarray(np.asarray(multiplicity)[:, None] * np.asarray(dtheta_basis))
+        self.dphi_reconstruction_basis = jnp.asarray(np.asarray(multiplicity)[:, None] * np.asarray(dphi_basis))
+        self.projection_basis = jnp.asarray(np.conjugate(basis_array) * weights[None, :] / np.asarray(norms)[:, None])
+        self.coefficient_scale = jnp.asarray(np.sqrt(norms))
+        self.directions = jnp.asarray(directions)
+        self.theta_directions = jnp.asarray(theta_directions)
+        self.phi_directions = jnp.asarray(phi_directions)
+        self.sin_theta = jnp.asarray(np.repeat(sin_theta, n_phi))
+        self.layout = layout
+
+    @staticmethod
+    def _evaluate(coefficients: Array, basis: Array) -> Array:
+        return jnp.real(jnp.einsum("...hv,hq->...qv", coefficients, basis))
+
+    def reconstruct(self, coefficients: Array) -> Array:
+        return self._evaluate(coefficients, self.reconstruction_basis)
+
+    def angular_derivatives(self, coefficients: Array) -> tuple[Array, Array]:
+        return (
+            self._evaluate(coefficients, self.dtheta_reconstruction_basis),
+            self._evaluate(coefficients, self.dphi_reconstruction_basis),
+        )
+
+    def project(self, values: Array) -> Array:
+        coefficients = jnp.einsum("...qv,hq->...hv", values, self.projection_basis)
+        for index, (_ell, m) in enumerate(self.layout.pairs):
+            if m == 0:
+                coefficients = coefficients.at[..., index, :].set(jnp.real(coefficients[..., index, :]))
+        return coefficients
+
+
+class IonFrameVlasov:
+    """Add prescribed ion-frame kinematics to a ``TzoufrasVlasov`` operator.
+
+    ``velocity_gradient[..., i, j]`` is ``partial_j u_i``.  The supplied
+    electric field is in the laboratory frame; ``u_i x B`` is added before the
+    peculiar-velocity Lorentz push.  ``material_acceleration`` must use the
+    same normalized acceleration units as the electric-force coefficient.
+    """
+
+    def __init__(self, vlasov: TzoufrasVlasov):
+        self.vlasov = vlasov
+        self.layout = vlasov.layout
+        self.angular = _AngularGalerkin(self.layout)
+
+    def velocity_gradient(self, ion_velocity: Array) -> Array:
+        """Return ``partial_j u_i`` with unresolved z derivatives set to zero."""
+
+        if ion_velocity.shape[-1] != 3:
+            raise ValueError("ion_velocity must have a final component axis of length 3")
+        derivative_x = jnp.real(self.vlasov.spatial_derivative(ion_velocity, axis=0))
+        derivative_y = jnp.real(self.vlasov.spatial_derivative(ion_velocity, axis=1))
+        return jnp.stack((derivative_x, derivative_y, jnp.zeros_like(derivative_x)), axis=-1)
+
+    def bulk_advection(self, f: Array, ion_velocity: Array, dfdz: Array | None = None) -> Array:
+        """Conservative periodic transport ``-div_x(u_i f)``."""
+
+        if ion_velocity.shape != (*f.shape[:-2], 3):
+            raise ValueError("ion_velocity shape must match the spatial VFP grid and have three components")
+        flux_x = ion_velocity[..., 0, None, None] * f
+        flux_y = ion_velocity[..., 1, None, None] * f
+        result = -self.vlasov.spatial_derivative(flux_x, axis=0)
+        result -= self.vlasov.spatial_derivative(flux_y, axis=1)
+        if dfdz is not None:
+            result -= ion_velocity[..., 2, None, None] * dfdz
+        return result
+
+    def deformation(self, f: Array, velocity_gradient: Array) -> Array:
+        """Return the conservative velocity-space term ``div_c((grad u_i)c f)``."""
+
+        expected_shape = (*f.shape[:-2], 3, 3)
+        if velocity_gradient.shape != expected_shape:
+            raise ValueError(f"velocity_gradient must have shape {expected_shape}")
+
+        samples = self.angular.reconstruct(f)
+        dtheta, dphi = self.angular.angular_derivatives(f)
+        gradient_times_direction = jnp.einsum("...ij,qj->...qi", velocity_gradient, self.angular.directions)
+        radial_coefficient = jnp.einsum("qi,...qi->...q", self.angular.directions, gradient_times_direction)
+        theta_coefficient = jnp.einsum("qi,...qi->...q", self.angular.theta_directions, gradient_times_direction)
+        phi_coefficient = jnp.einsum("qi,...qi->...q", self.angular.phi_directions, gradient_times_direction)
+        trace = jnp.trace(velocity_gradient, axis1=-2, axis2=-1)
+
+        face_speed = jnp.arange(self.vlasov.v.size + 1, dtype=self.vlasov.v.dtype) * self.vlasov.dv
+        interior_flux = (
+            radial_coefficient[..., None] * face_speed[1:-1] ** 3 * 0.5 * (samples[..., 1:] + samples[..., :-1])
+        )
+        zero_flux = jnp.zeros_like(samples[..., :1])
+        radial_flux = jnp.concatenate((zero_flux, interior_flux, zero_flux), axis=-1)
+        radial_divergence = (radial_flux[..., 1:] - radial_flux[..., :-1]) / (self.vlasov.v**2 * self.vlasov.dv)
+
+        angular_divergence = theta_coefficient[..., None] * dtheta
+        angular_divergence += phi_coefficient[..., None] * dphi / self.angular.sin_theta[..., None]
+        angular_divergence += (trace[..., None] - 3.0 * radial_coefficient)[..., None] * samples
+        return self.angular.project(radial_divergence + angular_divergence)
+
+    def frame_acceleration(self, f: Array, material_acceleration: Array) -> Array:
+        """Return ``D_t u_i . grad_c(f)`` using the existing force operator."""
+
+        return self.vlasov.electric(f, material_acceleration)
+
+    def __call__(
+        self,
+        f: Array,
+        electric_field: Array,
+        magnetic_field: Array,
+        ion_velocity: Array,
+        *,
+        velocity_gradient: Array | None = None,
+        material_acceleration: Array | None = None,
+        dfdz: Array | None = None,
+    ) -> Array:
+        if velocity_gradient is None:
+            velocity_gradient = self.velocity_gradient(ion_velocity)
+        if material_acceleration is None:
+            material_acceleration = jnp.zeros_like(ion_velocity)
+        rest_frame_electric = electric_field + jnp.cross(ion_velocity, magnetic_field)
+        result = self.vlasov(f, rest_frame_electric, magnetic_field, dfdz=dfdz)
+        result += self.bulk_advection(f, ion_velocity, dfdz=dfdz)
+        result += self.deformation(f, velocity_gradient)
+        result += self.frame_acceleration(f, material_acceleration)
+        for index, (_ell, m) in enumerate(self.layout.pairs):
+            if m == 0:
+                result = result.at[..., index, :].set(jnp.real(result[..., index, :]))
+        return result

--- a/adept/vfp2d/moving_frame.py
+++ b/adept/vfp2d/moving_frame.py
@@ -7,15 +7,15 @@ representing velocity as ``c = v - u_i(x, t)``.  For
 ``-div_x(u_i f) + div_c(A c f) + a_i . grad_c(f)``.
 
 Together with relative streaming, these terms are the non-relativistic limit
-of the mixed-frame VFP equation.  The deformation operator is evaluated by an
-angular Galerkin projection and a conservative radial velocity flux.  This is
-an equation-level reference implementation; coupling it to the production
-hydro/VFP split and optimizing the angular matrix products are later phases.
+of the mixed-frame VFP equation. The deformation operator compiles the angular
+Galerkin projection into sparse real-harmonic coupling rules and retains the
+dense quadrature implementation as a verification oracle.
 """
 
 from __future__ import annotations
 
 from math import factorial
+from typing import ClassVar
 
 import jax.numpy as jnp
 import numpy as np
@@ -119,6 +119,119 @@ class _AngularGalerkin:
         return coefficients
 
 
+class _SparseAngularCoupling:
+    """Sparse real-linear harmonic maps compiled from the Galerkin oracle."""
+
+    _operator_cache: ClassVar[dict[tuple[int, int], tuple[tuple[np.ndarray, ...], tuple[np.ndarray, ...]]]] = {}
+
+    def __init__(self, angular: _AngularGalerkin):
+        self.layout = angular.layout
+        self._dofs = tuple(
+            (index, imaginary)
+            for index, (_ell, m) in enumerate(self.layout.pairs)
+            for imaginary in ((False,) if m == 0 else (False, True))
+        )
+        key = (self.layout.l_max, self.layout.m_max)
+        if key not in self._operator_cache:
+            self._operator_cache[key] = self._compile(angular)
+        radial_edges, angular_edges = self._operator_cache[key]
+        self.radial_edges = tuple(jnp.asarray(value) for value in radial_edges)
+        self.angular_edges = tuple(jnp.asarray(value) for value in angular_edges)
+
+    def _pack_numpy(self, coefficients: np.ndarray) -> np.ndarray:
+        parts = [
+            np.imag(coefficients[..., index]) if imaginary else np.real(coefficients[..., index])
+            for index, imaginary in self._dofs
+        ]
+        return np.stack(parts, axis=-1)
+
+    @staticmethod
+    def _edges(matrices: np.ndarray) -> tuple[np.ndarray, ...]:
+        nonzero = np.argwhere(np.abs(matrices) > 1.0e-12)
+        component, output, input_ = nonzero.T
+        values = matrices[component, output, input_]
+        return (
+            component.astype(np.int32),
+            output.astype(np.int32),
+            input_.astype(np.int32),
+            values,
+        )
+
+    def _compile(self, angular: _AngularGalerkin) -> tuple[tuple[np.ndarray, ...], tuple[np.ndarray, ...]]:
+        number_dofs = len(self._dofs)
+        number_harmonics = self.layout.size
+        basis_coefficients = np.zeros((number_dofs, number_harmonics), dtype=np.complex128)
+        for dof, (index, imaginary) in enumerate(self._dofs):
+            basis_coefficients[dof, index] = 1j if imaginary else 1.0
+
+        reconstruction = np.asarray(angular.reconstruction_basis)
+        dtheta_reconstruction = np.asarray(angular.dtheta_reconstruction_basis)
+        dphi_reconstruction = np.asarray(angular.dphi_reconstruction_basis)
+        projection = np.asarray(angular.projection_basis)
+        directions = np.asarray(angular.directions)
+        theta_directions = np.asarray(angular.theta_directions)
+        phi_directions = np.asarray(angular.phi_directions)
+        sin_theta = np.asarray(angular.sin_theta)
+
+        samples = np.real(np.einsum("dh,hq->dq", basis_coefficients, reconstruction))
+        dtheta = np.real(np.einsum("dh,hq->dq", basis_coefficients, dtheta_reconstruction))
+        dphi = np.real(np.einsum("dh,hq->dq", basis_coefficients, dphi_reconstruction))
+        radial_matrices = np.zeros((9, number_dofs, number_dofs))
+        angular_matrices = np.zeros_like(radial_matrices)
+        for i in range(3):
+            for j in range(3):
+                component = 3 * i + j
+                radial_coefficient = directions[:, i] * directions[:, j]
+                theta_coefficient = theta_directions[:, i] * directions[:, j]
+                phi_coefficient = phi_directions[:, i] * directions[:, j]
+                radial_values = radial_coefficient[None, :] * samples
+                angular_values = theta_coefficient[None, :] * dtheta
+                angular_values += phi_coefficient[None, :] * dphi / sin_theta[None, :]
+                angular_values += ((1.0 if i == j else 0.0) - 3.0 * radial_coefficient)[None, :] * samples
+                radial_coefficients = np.einsum("dq,hq->dh", radial_values, projection)
+                angular_coefficients = np.einsum("dq,hq->dh", angular_values, projection)
+                radial_matrices[component] = self._pack_numpy(radial_coefficients).T
+                angular_matrices[component] = self._pack_numpy(angular_coefficients).T
+        return self._edges(radial_matrices), self._edges(angular_matrices)
+
+    def _pack(self, coefficients: Array) -> Array:
+        parts = [
+            jnp.imag(coefficients[..., index, :]) if imaginary else jnp.real(coefficients[..., index, :])
+            for index, imaginary in self._dofs
+        ]
+        return jnp.stack(parts, axis=-2)
+
+    def _unpack(self, coefficients: Array) -> Array:
+        output = jnp.zeros(
+            (*coefficients.shape[:-2], self.layout.size, coefficients.shape[-1]),
+            dtype=jnp.result_type(coefficients.dtype, jnp.complex64),
+        )
+        for dof, (index, imaginary) in enumerate(self._dofs):
+            value = 1j * coefficients[..., dof, :] if imaginary else coefficients[..., dof, :]
+            output = output.at[..., index, :].add(value)
+        return output
+
+    def _apply(self, coefficients: Array, velocity_gradient: Array, edges: tuple[Array, ...]) -> Array:
+        component, output, input_, values = edges
+        real_coefficients = self._pack(coefficients)
+        gradient_weights = velocity_gradient[..., component // 3, component % 3]
+        contributions = gradient_weights[..., None] * real_coefficients[..., input_, :]
+        contributions *= values[..., None]
+        result = jnp.zeros_like(real_coefficients)
+        result = result.at[..., output, :].add(contributions)
+        return self._unpack(result)
+
+    def radial(self, coefficients: Array, velocity_gradient: Array) -> Array:
+        return self._apply(coefficients, velocity_gradient, self.radial_edges)
+
+    def angular(self, coefficients: Array, velocity_gradient: Array) -> Array:
+        return self._apply(coefficients, velocity_gradient, self.angular_edges)
+
+    @property
+    def nnz(self) -> int:
+        return int(self.radial_edges[3].size + self.angular_edges[3].size)
+
+
 class IonFrameVlasov:
     """Add prescribed ion-frame kinematics to a ``TzoufrasVlasov`` operator.
 
@@ -132,6 +245,7 @@ class IonFrameVlasov:
         self.vlasov = vlasov
         self.layout = vlasov.layout
         self.angular = _AngularGalerkin(self.layout)
+        self.sparse_angular = _SparseAngularCoupling(self.angular)
 
     def velocity_gradient(self, ion_velocity: Array) -> Array:
         """Return ``partial_j u_i`` with unresolved z derivatives set to zero."""
@@ -155,8 +269,8 @@ class IonFrameVlasov:
             result -= ion_velocity[..., 2, None, None] * dfdz
         return result
 
-    def deformation(self, f: Array, velocity_gradient: Array) -> Array:
-        """Return the conservative velocity-space term ``div_c((grad u_i)c f)``."""
+    def deformation_reference(self, f: Array, velocity_gradient: Array) -> Array:
+        """Dense Galerkin oracle for ``div_c((grad u_i)c f)``."""
 
         expected_shape = (*f.shape[:-2], 3, 3)
         if velocity_gradient.shape != expected_shape:
@@ -182,6 +296,21 @@ class IonFrameVlasov:
         angular_divergence += phi_coefficient[..., None] * dphi / self.angular.sin_theta[..., None]
         angular_divergence += (trace[..., None] - 3.0 * radial_coefficient)[..., None] * samples
         return self.angular.project(radial_divergence + angular_divergence)
+
+    def deformation(self, f: Array, velocity_gradient: Array) -> Array:
+        """Return ``div_c((grad u_i)c f)`` using sparse harmonic couplings."""
+
+        expected_shape = (*f.shape[:-2], 3, 3)
+        if velocity_gradient.shape != expected_shape:
+            raise ValueError(f"velocity_gradient must have shape {expected_shape}")
+
+        face_speed = jnp.arange(self.vlasov.v.size + 1, dtype=self.vlasov.v.dtype) * self.vlasov.dv
+        face_average = 0.5 * (f[..., 1:] + f[..., :-1])
+        interior_flux = face_speed[1:-1] ** 3 * self.sparse_angular.radial(face_average, velocity_gradient)
+        zero_flux = jnp.zeros_like(f[..., :1])
+        radial_flux = jnp.concatenate((zero_flux, interior_flux, zero_flux), axis=-1)
+        radial_divergence = (radial_flux[..., 1:] - radial_flux[..., :-1]) / (self.vlasov.v**2 * self.vlasov.dv)
+        return radial_divergence + self.sparse_angular.angular(f, velocity_gradient)
 
     def frame_acceleration(self, f: Array, material_acceleration: Array) -> Array:
         """Return ``D_t u_i . grad_c(f)`` using the existing force operator."""

--- a/adept/vfp2d/pressure.py
+++ b/adept/vfp2d/pressure.py
@@ -1,0 +1,97 @@
+"""Kinetic electron-pressure feedback for the VFP-2D ion fluid."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+
+from adept.vfp2d.exchange import electron_energy_moment_correction
+from adept.vfp2d.harmonics import HarmonicLayout, density, scalar_velocity_moment, tensor_velocity_moment
+from adept.vfp2d.moving_frame import IonFrameVlasov
+
+
+def electron_pressure_tensor(
+    f: Array,
+    layout: HarmonicLayout,
+    v: Array,
+    dv: float,
+    electron_mass: float = 1.0,
+) -> Array:
+    """Return the full peculiar-frame pressure tensor from ``f0 + f2``."""
+
+    if electron_mass <= 0.0:
+        raise ValueError("electron_mass must be positive")
+    electron_density = density(f, layout, v, dv)
+    mean_square_speed = scalar_velocity_moment(f, layout, v, dv, power=2)
+    scalar_pressure = float(electron_mass) * electron_density * mean_square_speed / 3.0
+    anisotropic_pressure = (
+        float(electron_mass) * electron_density[..., None, None] * tensor_velocity_moment(f, layout, v, dv, power=0)
+    )
+    identity = jnp.eye(3, dtype=scalar_pressure.dtype)
+    return scalar_pressure[..., None, None] * identity + anisotropic_pressure
+
+
+class ElectronPressureCoupling:
+    """Map kinetic electron pressure into conservative ion sources.
+
+    The ion momentum source is ``-div(P_e)``. Its total-energy source is the
+    resolved mechanical work ``u_i . [-div(P_e)]``, with an exactly opposite
+    density-neutral electron energy correction. The independently diagnosed
+    moving-frame deformation work converges to ``-P_e : grad(u_i)``.
+    """
+
+    def __init__(self, ion_frame: IonFrameVlasov, *, electron_mass: float = 1.0):
+        if electron_mass <= 0.0:
+            raise ValueError("electron_mass must be positive")
+        self.ion_frame = ion_frame
+        self.layout = ion_frame.layout
+        self.v = ion_frame.vlasov.v
+        self.dv = ion_frame.vlasov.dv
+        self.electron_mass = float(electron_mass)
+
+    def pressure_tensor(self, f: Array) -> Array:
+        return electron_pressure_tensor(
+            f,
+            self.layout,
+            self.v,
+            self.dv,
+            self.electron_mass,
+        )
+
+    def pressure_divergence(self, f: Array) -> Array:
+        pressure = self.pressure_tensor(f)
+        derivative_x = jnp.real(self.ion_frame.vlasov.spatial_derivative(pressure[..., :, 0], axis=0))
+        derivative_y = jnp.real(self.ion_frame.vlasov.spatial_derivative(pressure[..., :, 1], axis=1))
+        return derivative_x + derivative_y
+
+    def __call__(self, f: Array, ion_conserved: Array) -> tuple[Array, Array, dict[str, Array]]:
+        if ion_conserved.shape != (*f.shape[:-2], 5):
+            raise ValueError("ion_conserved must match the spatial VFP shape and have five conserved variables")
+        pressure = self.pressure_tensor(f)
+        force = -self.pressure_divergence(f)
+        ion_velocity = ion_conserved[..., 1:4] / ion_conserved[..., :1]
+        ion_rate = jnp.zeros_like(ion_conserved)
+        ion_rate = ion_rate.at[..., 1:4].set(force)
+        ion_rate = ion_rate.at[..., 4].set(jnp.sum(ion_velocity * force, axis=-1))
+        electron_rate = electron_energy_moment_correction(
+            f,
+            self.layout,
+            self.v,
+            self.dv,
+            -ion_rate[..., 4],
+            self.electron_mass,
+        )
+        electron_work = -jnp.einsum(
+            "...ij,...ij->...",
+            pressure,
+            self.ion_frame.velocity_gradient(ion_velocity),
+        )
+        diagnostics = {
+            "electron_pressure": pressure,
+            "ion_pressure_force": force,
+            "ion_pressure_work": ion_rate[..., 4],
+            "electron_pressure_work": -ion_rate[..., 4],
+            "electron_deformation_work": electron_work,
+            "local_pressure_work_residual": jnp.zeros_like(ion_rate[..., 4]),
+        }
+        return electron_rate, ion_rate, diagnostics

--- a/adept/vfp2d/vector_field.py
+++ b/adept/vfp2d/vector_field.py
@@ -48,7 +48,14 @@ def _ib_gate(t: float, args: dict | None) -> Array:
 
 
 class Maxwell2D:
-    """Full three-component Maxwell curl operator with ``d/dz = 0``."""
+    """Full three-component Maxwell curl operator with ``d/dz = 0``.
+
+    ``relative_permittivity`` provides the deliberately slowed explicit
+    Ampere response used by transport VFP codes. It divides the complete
+    Ampere residual, preserving the steady constraint
+    ``J = c^2 curl(B)`` while reducing both the light and plasma frequencies
+    by its square root.
+    """
 
     def __init__(
         self,
@@ -56,13 +63,17 @@ class Maxwell2D:
         ky: Array,
         c: float,
         *,
+        relative_permittivity: float = 1.0,
         dx: float | None = None,
         dy: float | None = None,
         mesh: Mesh | None = None,
     ):
+        if relative_permittivity < 1.0:
+            raise ValueError("relative_permittivity must be at least one")
         self.kx = jnp.asarray(kx)
         self.ky = jnp.asarray(ky)
         self.c2 = float(c) ** 2
+        self.relative_permittivity = float(relative_permittivity)
         self.dx = None if dx is None else float(dx)
         self.dy = None if dy is None else float(dy)
         self.mesh = mesh
@@ -82,7 +93,7 @@ class Maxwell2D:
         return jnp.stack((self.ddy(az), -self.ddx(az), self.ddx(ay) - self.ddy(ax)), axis=-1)
 
     def __call__(self, electric_field: Array, magnetic_field: Array, plasma_current: Array) -> tuple[Array, Array]:
-        dedt = self.c2 * self.curl(magnetic_field) - plasma_current
+        dedt = (self.c2 * self.curl(magnetic_field) - plasma_current) / self.relative_permittivity
         dbdt = -self.curl(electric_field)
         return dedt, dbdt
 
@@ -198,6 +209,164 @@ class SplitStepVFP2D:
         k2 = self.rhs(t + 0.5 * self.dt, midpoint, args)
         result = jtu.tree_map(lambda value, slope: value + self.dt * slope, state, k2)
         return self._collide(t + self.dt, result, args, 0.5 * self.dt)
+
+
+class OSHUNImplicitStep:
+    """Quasineutral kinetic-current response following Tzoufras et al. (2013).
+
+    Faraday's law advances ``B`` explicitly from the stored electric field,
+    while displacement current is omitted from Ampere's law. At each cell,
+    three discrete electric-force responses form the matrix ``dJ_i / dE_j``.
+    A batched 3x3 solve then chooses the next electric field whose kinetically
+    updated distribution satisfies ``J = c^2 curl(B)``. Unlike the kinetic-Ohm
+    mode, this changes the complete distribution through the Vlasov force
+    operator and never projects ``f1``. This is an implicit current response,
+    not a fully implicit Maxwell solve.
+    """
+
+    def __init__(
+        self,
+        vlasov: TzoufrasVlasov,
+        maxwell: Maxwell2D,
+        layout: HarmonicLayout,
+        v: Array,
+        dv: float,
+        dt: float,
+        *,
+        collisions: CollisionStep | None = None,
+        real_storage: bool = False,
+        streaming_speed: Array | None = None,
+        enforce_f00_positivity: bool = False,
+        spatial_filter: HouLiFilter2D | None = None,
+        response_regularization: float = 0.0,
+    ):
+        if dt <= 0.0:
+            raise ValueError("dt must be positive")
+        if layout.index(1, 1) < 0:
+            raise ValueError("the OSHUN implicit-current solver requires lmax >= 1 and mmax >= 1")
+        if response_regularization < 0.0:
+            raise ValueError("response_regularization must be nonnegative")
+        self.vlasov = vlasov
+        self.maxwell = maxwell
+        self.layout = layout
+        self.v = jnp.asarray(v)
+        self.dv = float(dv)
+        self.dt = float(dt)
+        self.collisions = collisions
+        self.real_storage = bool(real_storage)
+        self.streaming_speed = self.v if streaming_speed is None else jnp.asarray(streaming_speed)
+        self.enforce_f00_positivity = bool(enforce_f00_positivity)
+        self.spatial_filter = spatial_filter
+        self.response_regularization = float(response_regularization)
+
+    def _positive_f00(self, flm: Array) -> Array:
+        if not self.enforce_f00_positivity:
+            return flm
+        return conservative_f00_positivity(flm, self.layout, self.v, self.dv)
+
+    def _filter(self, value: Array) -> Array:
+        return value if self.spatial_filter is None else self.spatial_filter(value)
+
+    def _collide(self, t: float, flm: Array, args: dict | None, dt: float) -> Array:
+        if self.collisions is None:
+            return flm
+        z = 1.0 if not args else args.get("Z", 1.0)
+        ni = 1.0 if not args else args.get("ni", 1.0)
+        heating = {}
+        if args:
+            for key in ("D0_heating", "ib_vosc2", "ib_Z2ni_w0"):
+                if key in args:
+                    heating[key] = args[key]
+        if "ib_vosc2" in heating:
+            heating["ib_vosc2"] = heating["ib_vosc2"] * _ib_gate(t, args)
+        return self.collisions(flm, Z=z, ni=ni, dt=dt, **heating)
+
+    def _non_electric_rate(self, flm: Array, magnetic_field: Array) -> Array:
+        return self.vlasov.streaming(flm) + self.vlasov.magnetic(flm, magnetic_field)
+
+    def _non_electric_step(self, flm: Array, magnetic_field: Array) -> Array:
+        rate1 = self._non_electric_rate(flm, magnetic_field)
+        midpoint = flm + 0.5 * self.dt * rate1
+        rate2 = self._non_electric_rate(midpoint, magnetic_field)
+        return flm + self.dt * rate2
+
+    def electric_increment(self, flm: Array, electric_field: Array) -> Array:
+        """Return the discrete linear electric-force increment used by the response solve."""
+
+        return self.dt * self.vlasov.electric(flm, electric_field)
+
+    def current_response(self, flm: Array) -> tuple[Array, Array]:
+        """Return ``J(E=0)`` and the local discrete ``dJ_i/dE_j`` tensor."""
+
+        baseline = current(
+            flm,
+            self.layout,
+            self.v,
+            self.dv,
+            streaming_speed=self.streaming_speed,
+        )
+        spatial_shape = flm.shape[:-2]
+        basis = jnp.eye(3, dtype=jnp.real(flm).dtype)
+        columns = []
+        for component in range(3):
+            field = jnp.broadcast_to(basis[component], (*spatial_shape, 3))
+            response_flm = self.electric_increment(flm, field)
+            columns.append(
+                current(
+                    response_flm,
+                    self.layout,
+                    self.v,
+                    self.dv,
+                    streaming_speed=self.streaming_speed,
+                )
+            )
+        return baseline, jnp.stack(columns, axis=-1)
+
+    def solve_electric_field(
+        self,
+        flm: Array,
+        magnetic_field: Array,
+        *,
+        response: tuple[Array, Array] | None = None,
+    ) -> tuple[Array, Array, Array]:
+        """Apply the electric response and return ``(f, E, J-J_Ampere)``."""
+
+        baseline, matrix = self.current_response(flm) if response is None else response
+        target = self.maxwell.c2 * self.maxwell.curl(magnetic_field)
+        if self.response_regularization > 0.0:
+            matrix = matrix + self.response_regularization * jnp.eye(3, dtype=matrix.dtype)
+        electric_field = jnp.linalg.solve(matrix, (target - baseline)[..., None])[..., 0]
+        updated = flm + self.electric_increment(flm, electric_field)
+        residual = (
+            current(
+                updated,
+                self.layout,
+                self.v,
+                self.dv,
+                streaming_speed=self.streaming_speed,
+            )
+            - target
+        )
+        return updated, electric_field, residual
+
+    def __call__(self, t: float, state: dict[str, Array], args: dict | None = None) -> dict[str, Array]:
+        flm = real_to_complex(state["flm"]) if self.real_storage else state["flm"]
+        old_electric = state["e"]
+        old_magnetic = state["b"]
+
+        flm = self._positive_f00(self._collide(t, flm, args, 0.5 * self.dt))
+        magnetic_field = old_magnetic - self.dt * self.maxwell.curl(old_electric)
+        magnetic_field = jnp.real(self._filter(magnetic_field))
+        midpoint_magnetic = 0.5 * (old_magnetic + magnetic_field)
+        flm = self._positive_f00(self._non_electric_step(flm, midpoint_magnetic))
+        flm = self._positive_f00(self._collide(t + self.dt, flm, args, 0.5 * self.dt))
+        flm = self._positive_f00(self._filter(flm))
+
+        result_f, electric_field, _residual = self.solve_electric_field(flm, magnetic_field)
+        result_f = self._positive_f00(result_f)
+        if self.real_storage:
+            result_f = complex_to_real(result_f)
+        return {"flm": result_f, "e": electric_field, "b": magnetic_field}
 
 
 class KineticOhmStep:

--- a/adept/vfp2d/vector_field.py
+++ b/adept/vfp2d/vector_field.py
@@ -272,6 +272,17 @@ class KineticOhmStep:
             self._target_current(magnetic_field),
         )
 
+    def _projection_energy_density(self, before: Array, after: Array, args: dict | None) -> Array:
+        """Return lab-frame electron energy added by a current projection."""
+
+        if self.ion_frame is None:
+            return jnp.zeros(before.shape[:-2], dtype=jnp.real(before).dtype)
+        if not args or "ion_velocity" not in args:
+            raise ValueError("ion-frame current-projection accounting requires ion_velocity in args")
+        ion_velocity = jnp.broadcast_to(jnp.asarray(args["ion_velocity"]), (*before.shape[:-2], 3))
+        momentum_change = current(after - before, self.layout, self.v, self.dv, charge=1.0)
+        return jnp.sum(ion_velocity * momentum_change, axis=-1)
+
     def electric_field(
         self,
         flm: Array,
@@ -342,7 +353,10 @@ class KineticOhmStep:
         flm = real_to_complex(state["flm"]) if self.real_storage else state["flm"]
         magnetic_field = state["b"]
         flm = self._positive_f00(self._collide(t, flm, args, 0.5 * self.dt))
-        flm = self._project(flm, magnetic_field)
+        projection_energy = jnp.zeros(flm.shape[:-2], dtype=jnp.real(flm).dtype)
+        projected_f = self._project(flm, magnetic_field)
+        projection_energy += self._projection_energy_density(flm, projected_f, args)
+        flm = projected_f
 
         df1, db1, _electric1 = self._rates(t, flm, magnetic_field, args)
         stage2_b = magnetic_field + 0.5 * self.dt * db1
@@ -359,14 +373,18 @@ class KineticOhmStep:
 
         result_b = magnetic_field + (self.dt / 6.0) * (db1 + 2.0 * db2 + 2.0 * db3 + db4)
         result_f = flm + (self.dt / 6.0) * (df1 + 2.0 * df2 + 2.0 * df3 + df4)
-        result_f = self._positive_f00(self._project(result_f, result_b))
+        projected_f = self._project(result_f, result_b)
+        projection_energy += self._projection_energy_density(result_f, projected_f, args)
+        result_f = self._positive_f00(projected_f)
         result_f = self._positive_f00(self._collide(t + self.dt, result_f, args, 0.5 * self.dt))
         # Pseudospectral field products feed unresolved power into the grid
         # scale during long heated runs. Filter only configuration space, once
         # per full step, then restore the f00 and Ampere-moment invariants.
         result_b = jnp.real(self._filter(result_b))
         result_f = self._positive_f00(self._filter(result_f))
-        result_f = self._project(result_f, result_b)
+        projected_f = self._project(result_f, result_b)
+        projection_energy += self._projection_energy_density(result_f, projected_f, args)
+        result_f = projected_f
         hidden_dndz = self._hidden_dndz(t + self.dt, args, result_b[..., 0])
         result_e, _terms = self.electric_field(
             result_f,
@@ -376,4 +394,7 @@ class KineticOhmStep:
         )
         if self.real_storage:
             result_f = complex_to_real(result_f)
-        return {"flm": result_f, "e": result_e, "b": result_b}
+        result = {"flm": result_f, "e": result_e, "b": result_b}
+        if "current_projection_energy" in state:
+            result["current_projection_energy"] = state["current_projection_energy"] + projection_energy
+        return result

--- a/adept/vfp2d/vector_field.py
+++ b/adept/vfp2d/vector_field.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import jax.numpy as jnp
 import jax.tree_util as jtu
 from jax import Array
@@ -20,6 +22,9 @@ from adept.vfp2d.harmonics import (
     real_to_complex,
 )
 from adept.vfp2d.ohm import KineticOhm2D, project_current_moment
+
+if TYPE_CHECKING:
+    from adept.vfp2d.moving_frame import IonFrameVlasov
 
 
 def _ib_gate(t: float, args: dict | None) -> Array:
@@ -218,6 +223,7 @@ class KineticOhmStep:
         real_storage: bool = False,
         enforce_f00_positivity: bool = False,
         spatial_filter: HouLiFilter2D | None = None,
+        ion_frame: IonFrameVlasov | None = None,
     ):
         self.vlasov = vlasov
         self.maxwell = maxwell
@@ -230,6 +236,7 @@ class KineticOhmStep:
         self.real_storage = bool(real_storage)
         self.enforce_f00_positivity = bool(enforce_f00_positivity)
         self.spatial_filter = spatial_filter
+        self.ion_frame = ion_frame
 
     def _positive_f00(self, flm: Array) -> Array:
         if not self.enforce_f00_positivity:
@@ -265,6 +272,30 @@ class KineticOhmStep:
             self._target_current(magnetic_field),
         )
 
+    def electric_field(
+        self,
+        flm: Array,
+        magnetic_field: Array,
+        args: dict | None,
+        *,
+        hidden_dndz: Array,
+    ) -> tuple[Array, dict[str, Array]]:
+        """Return the laboratory electric field and resolved Ohm terms."""
+
+        electric_field, terms = self.ohm(
+            flm,
+            magnetic_field,
+            plasma_current=self._target_current(magnetic_field),
+            hidden_dndz=hidden_dndz,
+        )
+        if self.ion_frame is None:
+            return electric_field, terms
+        if not args or "ion_velocity" not in args:
+            raise ValueError("ion-frame kinetic stepping requires ion_velocity in args")
+        ion_velocity = jnp.broadcast_to(jnp.asarray(args["ion_velocity"]), magnetic_field.shape)
+        bulk = -jnp.cross(ion_velocity, magnetic_field)
+        return electric_field + bulk, {"bulk": bulk, **terms}
+
     @staticmethod
     def _hidden_dndz(t: float, args: dict | None, template: Array) -> Array:
         if not args or "hidden_dndz" not in args:
@@ -281,20 +312,31 @@ class KineticOhmStep:
     def _rates(self, t: float, flm: Array, magnetic_field: Array, args: dict | None) -> tuple[Array, Array, Array]:
         flm = self._project(flm, magnetic_field)
         hidden_dndz = self._hidden_dndz(t, args, magnetic_field[..., 0])
-        electric_field, _terms = self.ohm(
+        electric_field, _terms = self.electric_field(
             flm,
             magnetic_field,
-            plasma_current=self._target_current(magnetic_field),
+            args,
             hidden_dndz=hidden_dndz,
         )
         ne = density(flm, self.layout, self.v, self.dv)
         safe_ne = jnp.maximum(ne, jnp.finfo(ne.dtype).tiny)
         dfdz = hidden_dndz[..., None, None] * flm / safe_ne[..., None, None]
-        return (
-            self.vlasov(flm, electric_field, magnetic_field, dfdz=dfdz),
-            -self.maxwell.curl(electric_field),
-            electric_field,
-        )
+        if self.ion_frame is None:
+            dfdt = self.vlasov(flm, electric_field, magnetic_field, dfdz=dfdz)
+        else:
+            ion_velocity = jnp.broadcast_to(jnp.asarray(args["ion_velocity"]), magnetic_field.shape)
+            velocity_gradient = args.get("ion_velocity_gradient")
+            material_acceleration = args.get("ion_material_acceleration")
+            dfdt = self.ion_frame(
+                flm,
+                electric_field,
+                magnetic_field,
+                ion_velocity,
+                velocity_gradient=velocity_gradient,
+                material_acceleration=material_acceleration,
+                dfdz=dfdz,
+            )
+        return dfdt, -self.maxwell.curl(electric_field), electric_field
 
     def __call__(self, t: float, state: dict[str, Array], args: dict | None = None) -> dict[str, Array]:
         flm = real_to_complex(state["flm"]) if self.real_storage else state["flm"]
@@ -326,10 +368,10 @@ class KineticOhmStep:
         result_f = self._positive_f00(self._filter(result_f))
         result_f = self._project(result_f, result_b)
         hidden_dndz = self._hidden_dndz(t + self.dt, args, result_b[..., 0])
-        result_e, _terms = self.ohm(
+        result_e, _terms = self.electric_field(
             result_f,
             result_b,
-            plasma_current=self._target_current(result_b),
+            args,
             hidden_dndz=hidden_dndz,
         )
         if self.real_storage:

--- a/docs/source/solvers/vfp2d/config.md
+++ b/docs/source/solvers/vfp2d/config.md
@@ -123,6 +123,42 @@ omitted) or with a differentiable tanh gate (`switch_width` set). Output variabl
 with `ohm_` contain the resistive, Hall, Nernst, scalar-pressure, and $f_2$ tensor-pressure
 contributions.
 
+## Moving ion-fluid coupling (Gate 2a)
+
+The first opt-in production coupling slice is available for non-relativistic,
+unsharded `kinetic-ohm` runs on periodic grids:
+
+```yaml
+terms:
+  field_solver: {mode: kinetic-ohm}
+  ion_fluid:
+    active: true
+    mass_ratio: 1836.0
+    gamma: 1.6666666666666667
+    cfl: 0.4
+    boundaries: [periodic, periodic]
+    initial_velocity: [0.0, 0.0, 0.0]  # normalized to c
+    frozen: false
+    temperature_relaxation_rate: 0.0   # normalized inverse time
+    momentum_relaxation_rate: 0.0
+```
+
+`CoupledIonKineticStep` applies an ion Euler half-step, advances the kinetic-Ohm
+system with midpoint ion velocity/gradient/acceleration, applies midpoint local
+temperature exchange, and finishes the ion Euler step. The laboratory electric
+field includes the ideal bulk term $-\mathbf u_i\times\mathbf B$. Initial ion
+density is taken from the discretely integrated electron density, so
+$n_e=Z n_i$ is exact on the radial grid.
+
+Gate 2a intentionally rejects spatial sharding, nonperiodic boundaries,
+relativistic velocity coordinates, and nonzero production momentum relaxation.
+The last restriction avoids claiming lab-frame momentum conservation before the
+finite-mass velocity-frame remap is implemented. Electron-pressure feedback into
+the ion momentum equation and quantitative Spitzer--Härm/Epperlein--Haines
+convergence are Gate 2b requirements.
+The initial ion half-step is checked against the configured acoustic/advection
+`cfl`; the run timestep must remain conservative as the ion state evolves.
+
 The reconnection diagnostics report a normalized rate and flux only when the upstream
 $B_x$ fields are antiparallel and balanced and the origin contains both an in-plane null/
 $A_z$ saddle and a central current sheet. Invalid samples are stored as NaN rather than
@@ -148,7 +184,13 @@ save:
 
 Post-processing returns an xarray dataset with `flm_real`, `flm_imag`, `e`, `b`, density,
 temperature, current, Nernst velocity, and the traceless pressure-anisotropy moment. Harmonics
-are labeled by the `ell` and `m` coordinates.
+are labeled by the `ell` and `m` coordinates. Coupled runs additionally save the ion conserved
+state and primitives, particle counts, quasineutrality residual, lab-frame total momentum,
+separate electron/ion/magnetic energies, total energy, magnetic-divergence residual, negative
+isotropic mass, harmonic free energy, and the `ohm_bulk` field.
+Because `kinetic-ohm` has no displacement-current evolution, its algebraic electric field
+does not carry a separately evolved field-energy term; `total_energy` is electron lab-frame
+kinetic plus ion total plus magnetic energy.
 
 See the [Joglekar 2014 reconstruction and hydro-coupling design](joglekar2014.md) for the
 distinction between the runnable reduced benchmark and the planned long-time implicit solve.

--- a/docs/source/solvers/vfp2d/moving_frame.md
+++ b/docs/source/solvers/vfp2d/moving_frame.md
@@ -54,9 +54,9 @@ Gate 1a tests establish:
 - the analytic pressure-anisotropy rate under prescribed trace-free strain; and
 - cancellation between a uniform force and an oppositely accelerating frame.
 
-This implementation is not yet wired into the production split step. The angular
-Galerkin path is intentionally a correctness reference; a sparse precomputed operator
-is required before high-$\ell$ production runs.
+Gate 2a wires this implementation into the opt-in `CoupledIonKineticStep`. The angular
+Galerkin path remains a correctness reference; a sparse precomputed operator is required
+before high-$\ell$ production runs.
 
 ## Gate 1b moment-exchange reference
 
@@ -81,5 +81,7 @@ residuals.
 This is a differential, weak-drift moment-relaxation reference, not a replacement for
 the full finite-mass Landau collision operator. In particular, momentum relaxation is
 energy-neutral to first order in the relative drift; drift-energy thermalization is a
-higher-order effect. Production coupling still requires the full moving-frame energy
-budget, time-centered exchange, and integration into the hydro/VFP split in Gate 2.
+higher-order effect. Gate 2a integrates time-centered thermal exchange into the hydro/VFP
+split and saves the resulting energy budget. Production momentum exchange remains disabled
+until Gate 2b adds the finite-mass velocity-frame remap; electron-pressure feedback and
+quantitative local transport convergence are also still required.

--- a/docs/source/solvers/vfp2d/moving_frame.md
+++ b/docs/source/solvers/vfp2d/moving_frame.md
@@ -1,0 +1,85 @@
+# Ion-frame electron operators
+
+The moving-ion model represents the electron distribution in peculiar velocity
+$\mathbf c=\mathbf v-\mathbf u_i(\mathbf x,t)$ while retaining laboratory position
+and time. If $F(\mathbf x,\mathbf v,t)=f(\mathbf x,\mathbf c,t)$ and
+$A_{ij}=\partial_j u_{i}$, the non-relativistic mixed-frame Vlasov equation can be
+written in conservative phase-space form as
+
+$$
+\partial_t f
++\nabla_x\!\cdot[(\mathbf u_i+\mathbf c)f]
++\nabla_c\!\cdot\left[
+  \left(\mathbf a_e-D_t\mathbf u_i-A\mathbf c\right)f
+\right]
+=C[f].
+$$
+
+Thus the terms added to the stationary-ion `TzoufrasVlasov` right-hand side are
+
+$$
+-\nabla_x\!\cdot(\mathbf u_i f)
++\nabla_c\!\cdot(A\mathbf c f)
++D_t\mathbf u_i\!\cdot\nabla_c f.
+$$
+
+The laboratory Lorentz force is evaluated with
+$\mathbf E+\mathbf u_i\times\mathbf B$ before the existing peculiar-velocity
+electric and magnetic operators are applied. This is the non-relativistic limit of
+the mixed-frame fictitious-force terms derived by Schween and Reville,
+[*MNRAS* **529**, 1970 (2024)](https://doi.org/10.1093/mnras/stae596), especially
+their equations (5), (43), and (48).
+
+## Gate 1a discretization
+
+`IonFrameVlasov` supplies four equation-level operators:
+
+- conservative periodic bulk transport of every $(\ell,m,v)$ cell;
+- $\partial_j u_i$ computed with the same spatial derivative backend as VFP-2D;
+- a conservative radial-velocity flux and angular Galerkin projection for
+  $\nabla_c\cdot(A\mathbf c f)$; and
+- frame acceleration through the existing arbitrary-harmonic electric-force operator.
+
+The angular quadrature uses ADEPT's unnormalized associated-Legendre convention and
+projects the continuous product before truncating back to the configured harmonic
+layout. This avoids the top-mode product error that occurs when two already-truncated
+direction matrices are multiplied.
+
+Gate 1a tests establish:
+
+- angular reconstruction/projection round trips;
+- conservative bulk transport and the $\partial_j u_i$ index convention;
+- exact invariance of a uniform Maxwellian under constant Galilean translation;
+- particle-conserving isotropic compression with $T_e\propto n_e^{2/3}$;
+- the analytic pressure-anisotropy rate under prescribed trace-free strain; and
+- cancellation between a uniform force and an oppositely accelerating frame.
+
+This implementation is not yet wired into the production split step. The angular
+Galerkin path is intentionally a correctness reference; a sparse precomputed operator
+is required before high-$\ell$ production runs.
+
+## Gate 1b moment-exchange reference
+
+`ElectronIonExchange` supplies the local finite-ion-mass relaxation check required by
+Gate 1. It acts only on the moments needed by the acceptance tests:
+
+$$
+\frac{d\mathbf P_e}{dt}=-\nu_m\mathbf P_e,
+\qquad
+\frac{dT_e}{dt}=-\nu_T(T_e-T_i).
+$$
+
+The momentum correction is projected onto $f_1$ without changing $f_0$ or higher
+harmonics. The thermal correction changes the $f_0$ energy moment while having zero
+discrete density moment. Rather than trusting the requested rates analytically, the
+operator measures the resulting electron momentum and energy rates with the same
+quadrature used by VFP-2D and writes their exact negatives into the ion conserved
+state. Tests cover both directions of temperature relaxation, all three momentum
+components, density preservation, JIT execution, and machine-small exchange
+residuals.
+
+This is a differential, weak-drift moment-relaxation reference, not a replacement for
+the full finite-mass Landau collision operator. In particular, momentum relaxation is
+energy-neutral to first order in the relative drift; drift-energy thermalization is a
+higher-order effect. Production coupling still requires the full moving-frame energy
+budget, time-centered exchange, and integration into the hydro/VFP split in Gate 2.

--- a/docs/source/solvers/vfp2d/overview.md
+++ b/docs/source/solvers/vfp2d/overview.md
@@ -76,9 +76,15 @@ plan:
    electron--ion temperature and momentum relaxation with measured, equal-and-opposite
    ion updates. This verifies the discrete exchange accounting but is not yet a full
    finite-mass Landau operator.
-5. **Gate 2:** production split integration, total exchange accounting, and coupled
-   local-limit tests.
+5. **Gate 2a (implemented, opt in):** time-centered kinetic-Ohm/ideal-ion production
+   split, ideal bulk magnetic advection, local temperature exchange, coupled invariant
+   histories, and an exact frozen-ion regression limit.
+6. **Gate 2b:** electron-pressure feedback, finite-mass momentum-frame remapping,
+   sparse high-$\ell$ operators, and quantitative Spitzer--Härm/Epperlein--Haines and
+   Biermann convergence tests.
 
-The production `vfp-2d` time loop still uses stationary ions until Gates 0b--2 land.
+The default production `vfp-2d` time loop still uses stationary ions. Gate 2a moving
+ions must be enabled explicitly and should not yet be used for production parameter
+scans; Gate 0b and Gate 2b remain acceptance boundaries.
 
 See the [configuration reference](config.md), the [Joglekar 2014 reconstruction design](joglekar2014.md), and [`configs/vfp-2d/landau-damping.yaml`](../../../../configs/vfp-2d/landau-damping.yaml).

--- a/docs/source/solvers/vfp2d/overview.md
+++ b/docs/source/solvers/vfp2d/overview.md
@@ -28,7 +28,7 @@ The solver includes:
 - all three components of Maxwell's equations with $\partial_z=0$;
 - a spectral initial Poisson solve;
 - density-conserving implicit isotropic electron-electron collisions;
-- the linearized Tzoufras anisotropic electron-electron and electron-ion operator for every retained $(\ell,m)$.
+- the linearized Tzoufras anisotropic electron-electron and electron-ion operator for every retained $(\ell,m)$;
 - spatially shaped inverse-bremsstrahlung or Maxwellian heating;
 - distribution-function diagnostics for the scalar, vector, $f_2$ tensor, and Nernst moments used in kinetic Ohm's law.
 
@@ -69,9 +69,15 @@ plan:
    contact, conservation, and coordinate-rotated Sod tests.
 2. **Gate 0b:** strong-shock, Sedov, isentropic-vortex, and magnetic-divergence tests,
    followed by configuration and diagnostic integration.
-3. **Gate 1:** conservative bulk advection and the compression, shear, and inertial
-   terms for spherical harmonics in the ion peculiar-velocity frame.
-4. **Gate 2:** equal-and-opposite kinetic/fluid exchange and coupled local-limit tests.
+3. **Gate 1a (implemented as an equation-level reference):** conservative bulk
+   advection plus compression, shear, and frame acceleration for arbitrary spherical
+   harmonics. See the [ion-frame derivation and tests](moving_frame.md).
+4. **Gate 1b (implemented as a local moment-exchange reference):** finite-mass
+   electron--ion temperature and momentum relaxation with measured, equal-and-opposite
+   ion updates. This verifies the discrete exchange accounting but is not yet a full
+   finite-mass Landau operator.
+5. **Gate 2:** production split integration, total exchange accounting, and coupled
+   local-limit tests.
 
 The production `vfp-2d` time loop still uses stationary ions until Gates 0b--2 land.
 

--- a/docs/source/solvers/vfp2d/overview.md
+++ b/docs/source/solvers/vfp2d/overview.md
@@ -53,4 +53,26 @@ on a periodic box.
 - `kinetic-ohm` is inertia-free and uses a current-moment projection; a fully implicit kinetic-current response is not yet implemented;
 - moving-ion fluid coupling is not yet implemented.
 
+## Ion-fluid development phases
+
+The first moving-ion component is available as the standalone `IonEuler2D` finite-volume
+operator. It advances cell averages of
+$(\rho_i,\rho_i u_x,\rho_i u_y,\rho_i u_z,\mathcal E_i)$ with MUSCL reconstruction,
+HLLC fluxes, periodic or outflow boundaries, and SSP-RK2 time stepping. Keeping the
+operator separate from the kinetic split initially makes its conservation and shock
+tests auditable before electron pressure work or collisional exchange are introduced.
+
+Development follows the verification gates in the kinetic-electron / ion-fluid research
+plan:
+
+1. **Gate 0a (implemented):** conservative Euler core; uniform-flow, smooth-advection,
+   contact, conservation, and coordinate-rotated Sod tests.
+2. **Gate 0b:** strong-shock, Sedov, isentropic-vortex, and magnetic-divergence tests,
+   followed by configuration and diagnostic integration.
+3. **Gate 1:** conservative bulk advection and the compression, shear, and inertial
+   terms for spherical harmonics in the ion peculiar-velocity frame.
+4. **Gate 2:** equal-and-opposite kinetic/fluid exchange and coupled local-limit tests.
+
+The production `vfp-2d` time loop still uses stationary ions until Gates 0b--2 land.
+
 See the [configuration reference](config.md), the [Joglekar 2014 reconstruction design](joglekar2014.md), and [`configs/vfp-2d/landau-damping.yaml`](../../../../configs/vfp-2d/landau-damping.yaml).

--- a/tests/test_vfp2d/test_base.py
+++ b/tests/test_vfp2d/test_base.py
@@ -84,7 +84,7 @@ def test_uniform_collisionless_state_is_stationary_and_uses_real_diffrax_storage
     np.testing.assert_array_equal(dataset.m, [0, 0, 1, 0, 1, 2])
 
 
-def test_gate2a_uniform_coupled_run_saves_ion_state_and_invariants():
+def test_gate2b_uniform_coupled_run_saves_ion_state_and_invariants():
     cfg = _config(collisions=False)
     cfg["terms"].update(
         {
@@ -94,6 +94,7 @@ def test_gate2a_uniform_coupled_run_saves_ion_state_and_invariants():
                 "mass_ratio": 100.0,
                 "gamma": 5.0 / 3.0,
                 "boundaries": ["periodic", "periodic"],
+                "momentum_relaxation_rate": 0.25,
             },
         }
     )

--- a/tests/test_vfp2d/test_base.py
+++ b/tests/test_vfp2d/test_base.py
@@ -84,6 +84,29 @@ def test_uniform_collisionless_state_is_stationary_and_uses_real_diffrax_storage
     np.testing.assert_array_equal(dataset.m, [0, 0, 1, 0, 1, 2])
 
 
+def test_stationary_alternative_field_solvers_run_and_save_their_acceptance_diagnostics():
+    cases = (
+        ({"mode": "ampere", "relative_permittivity": 1.0e6}, "ampere"),
+        ({"mode": "oshun-implicit"}, "oshun-implicit"),
+    )
+    for field_solver, expected_mode in cases:
+        cfg = _config(collisions=False)
+        cfg["terms"]["field_solver"] = field_solver
+        module, output = _setup_and_run(cfg)
+        dataset = module.post_process(output, "")["vfp2d"]
+
+        assert module.field_mode == expected_mode
+        assert dataset.attrs["field_solver_mode"] == expected_mode
+        assert jnp.all(jnp.isfinite(output["solver result"].ys["flm"]))
+        assert dataset.ampere_residual.dims == ("t", "x", "y", "component")
+        np.testing.assert_allclose(dataset.ampere_residual_linf, 0.0, atol=2e-12)
+        if expected_mode == "ampere":
+            assert dataset.attrs["relative_permittivity"] == 1.0e6
+            assert "electromagnetic_field_energy" in dataset
+        else:
+            assert "electromagnetic_field_energy" not in dataset
+
+
 def test_gate2b_uniform_coupled_run_saves_ion_state_and_invariants():
     cfg = _config(collisions=False)
     cfg["terms"].update(

--- a/tests/test_vfp2d/test_base.py
+++ b/tests/test_vfp2d/test_base.py
@@ -84,6 +84,65 @@ def test_uniform_collisionless_state_is_stationary_and_uses_real_diffrax_storage
     np.testing.assert_array_equal(dataset.m, [0, 0, 1, 0, 1, 2])
 
 
+def test_gate2a_uniform_coupled_run_saves_ion_state_and_invariants():
+    cfg = _config(collisions=False)
+    cfg["terms"].update(
+        {
+            "field_solver": {"mode": "kinetic-ohm"},
+            "ion_fluid": {
+                "active": True,
+                "mass_ratio": 100.0,
+                "gamma": 5.0 / 3.0,
+                "boundaries": ["periodic", "periodic"],
+            },
+        }
+    )
+    module, output = _setup_and_run(cfg)
+    saved = output["solver result"].ys
+    assert saved["ions"].shape == (3, 2, 2, 5)
+    np.testing.assert_allclose(saved["ions"][0], saved["ions"][-1], rtol=2e-12, atol=2e-12)
+
+    dataset = module.post_process(output, "")["vfp2d"]
+    for name in (
+        "ions",
+        "ni",
+        "ion_velocity",
+        "ion_pressure",
+        "ion_temperature",
+        "electron_number",
+        "ion_number",
+        "quasineutrality_linf",
+        "total_momentum",
+        "electron_energy",
+        "ion_energy",
+        "magnetic_energy",
+        "total_energy",
+        "div_b_linf",
+        "negative_f00_mass",
+        "harmonic_free_energy",
+        "ohm_bulk",
+    ):
+        assert name in dataset
+    np.testing.assert_allclose(dataset.quasineutrality_linf, 0.0, atol=2e-13)
+    np.testing.assert_allclose(dataset.total_energy, dataset.total_energy[0], rtol=2e-12, atol=2e-12)
+    np.testing.assert_allclose(dataset.total_momentum, 0.0, atol=2e-13)
+    np.testing.assert_allclose(dataset.div_b_linf, 0.0, atol=2e-13)
+    np.testing.assert_allclose(dataset.negative_f00_mass, 0.0, atol=0.0)
+    np.testing.assert_allclose(dataset.ohm_bulk, 0.0, atol=2e-13)
+    reconstructed_e = sum(
+        dataset[name]
+        for name in (
+            "ohm_bulk",
+            "ohm_resistive",
+            "ohm_hall",
+            "ohm_nernst",
+            "ohm_scalar_pressure",
+            "ohm_tensor_pressure",
+        )
+    )
+    np.testing.assert_allclose(reconstructed_e, dataset.e, rtol=2e-12, atol=2e-12)
+
+
 def test_collisional_end_to_end_step_is_finite():
     _module, output = _setup_and_run(_config(collisions=True))
     for value in output["solver result"].ys.values():

--- a/tests/test_vfp2d/test_base.py
+++ b/tests/test_vfp2d/test_base.py
@@ -118,6 +118,8 @@ def test_gate2b_uniform_coupled_run_saves_ion_state_and_invariants():
         "ion_energy",
         "magnetic_energy",
         "total_energy",
+        "current_projection_energy",
+        "accounted_total_energy",
         "div_b_linf",
         "negative_f00_mass",
         "harmonic_free_energy",

--- a/tests/test_vfp2d/test_coupled_convergence.py
+++ b/tests/test_vfp2d/test_coupled_convergence.py
@@ -1,0 +1,154 @@
+"""Nonlinear conservation and refinement gate for coupled VFP-2D."""
+
+from functools import cache
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept.vfp2d import (
+    CoupledIonKineticStep,
+    ElectronPressureCoupling,
+    Grid,
+    HarmonicLayout,
+    IonEuler2D,
+    IonFrameVlasov,
+    KineticOhm2D,
+    KineticOhmStep,
+    Maxwell2D,
+    TzoufrasVlasov,
+    coupled_invariants,
+    primitive_to_conserved,
+)
+
+ENERGY_DEFECT_TOLERANCE = 3.1e-9
+
+
+@cache
+def _run_nonlinear_benchmark(dt=1.0e-3, nx=8, nv=64):
+    final_time = 4.0e-3
+    grid = Grid(
+        xmin=0.0,
+        xmax=2.0 * np.pi,
+        nx=nx,
+        ymin=0.0,
+        ymax=2.0 * np.pi,
+        ny=nx,
+        vmax=7.0,
+        nv=nv,
+        dt=dt,
+        l_max=2,
+    )
+    layout = HarmonicLayout(2)
+    vlasov = TzoufrasVlasov(layout, grid.v, grid.dv, grid.kx, grid.ky)
+    maxwell = Maxwell2D(grid.kx, grid.ky, c=5.0)
+    electron_step = KineticOhmStep(
+        vlasov,
+        maxwell,
+        KineticOhm2D(layout, grid.v, grid.dv, grid.kx, grid.ky),
+        layout,
+        grid.v,
+        grid.dv,
+        dt,
+        ion_frame=IonFrameVlasov(vlasov),
+    )
+
+    x, y = grid.x[:, None], grid.y[None, :]
+    electron_density = 1.0 + 0.08 * jnp.cos(x) * jnp.cos(y)
+    electron_temperature = 0.5 * (1.0 + 0.08 * jnp.sin(x - 2.0 * y))
+    radial = jnp.exp(-(grid.v[None, None, :] ** 2) / (2.0 * electron_temperature[..., None]))
+    radial_density = 4.0 * jnp.pi * jnp.sum(radial * grid.v**2, axis=-1) * grid.dv
+    radial *= electron_density[..., None] / radial_density[..., None]
+    flm = jnp.zeros((nx, nx, layout.size, nv), dtype=jnp.complex128)
+    flm = flm.at[..., layout.index(0, 0), :].set(radial)
+
+    ion_mass = 100.0
+    ion_primitive = jnp.concatenate(
+        (
+            (ion_mass * electron_density)[..., None],
+            jnp.zeros((nx, nx, 3)),
+            (0.2 * electron_density)[..., None],
+        ),
+        axis=-1,
+    )
+    ions = primitive_to_conserved(ion_primitive)
+    field = jnp.zeros((nx, nx, 3))
+    state = {
+        "flm": flm,
+        "e": field,
+        "b": field,
+        "ions": ions,
+        "current_projection_energy": jnp.zeros((nx, nx)),
+    }
+    coupled = CoupledIonKineticStep(
+        electron_step,
+        IonEuler2D(grid.dx, grid.dy),
+        dt,
+        pressure=ElectronPressureCoupling(electron_step.ion_frame),
+    )
+
+    def invariants(current_state):
+        return coupled_invariants(
+            current_state["flm"],
+            current_state["ions"],
+            current_state["b"],
+            layout,
+            grid.v,
+            grid.dv,
+            dx=grid.dx,
+            dy=grid.dy,
+            ion_mass=ion_mass,
+            ion_charge=1.0,
+            light_speed=5.0,
+            current_projection_energy=current_state["current_projection_energy"],
+        )
+
+    initial = invariants(state)
+    advance = jax.jit(coupled)
+    for step in range(round(final_time / dt)):
+        state = advance(step * dt, state, {})
+    final = invariants(state)
+    energy_scale = initial["total_energy"]
+    raw_energy_error = (final["total_energy"] - initial["total_energy"]) / energy_scale
+    accounted_energy_error = (final["accounted_total_energy"] - initial["accounted_total_energy"]) / energy_scale
+    projection_energy = final["current_projection_energy"] / energy_scale
+    ion_velocity = state["ions"][..., 1:4] / state["ions"][..., :1]
+    return tuple(
+        float(value)
+        for value in (
+            raw_energy_error,
+            accounted_energy_error,
+            projection_energy,
+            jnp.max(jnp.linalg.norm(ion_velocity, axis=-1)),
+            jnp.max(jnp.abs(state["b"][..., 2])),
+        )
+    )
+
+
+def test_nonlinear_energy_budget_is_below_tolerance_and_second_order_in_time():
+    coarse = _run_nonlinear_benchmark(dt=2.0e-3)
+    medium = _run_nonlinear_benchmark(dt=1.0e-3)
+    fine = _run_nonlinear_benchmark(dt=5.0e-4)
+
+    for raw_error, accounted_error, projection_energy, _ion_velocity, _magnetic_field in (coarse, medium, fine):
+        np.testing.assert_allclose(raw_error - projection_energy, accounted_error, atol=2e-16)
+        assert abs(accounted_error) < ENERGY_DEFECT_TOLERANCE
+
+    ion_order = np.log2(abs(coarse[3] - medium[3]) / abs(medium[3] - fine[3]))
+    magnetic_order = np.log2(abs(coarse[4] - medium[4]) / abs(medium[4] - fine[4]))
+    assert ion_order > 1.8
+    assert magnetic_order > 1.8
+    assert fine[3] > 0.0
+    assert fine[4] > 0.0
+
+
+def test_nonlinear_energy_defect_converges_under_spatial_and_radial_refinement():
+    radial_coarse = _run_nonlinear_benchmark(nv=24)
+    radial_fine = _run_nonlinear_benchmark(nv=96)
+    spatial_coarse = _run_nonlinear_benchmark(nx=6)
+    spatial_fine = _run_nonlinear_benchmark(nx=12)
+
+    assert abs(radial_coarse[1]) / abs(radial_fine[1]) > 8.0
+    assert abs(radial_fine[1]) < 2.0e-9
+    assert abs(spatial_coarse[1]) / abs(spatial_fine[1]) > 8.0
+    assert abs(spatial_fine[1]) < 1.0e-9

--- a/tests/test_vfp2d/test_coupling.py
+++ b/tests/test_vfp2d/test_coupling.py
@@ -1,4 +1,4 @@
-"""Coupled local-limit tests for the Gate 2a production split."""
+"""Coupled local-limit tests for the ion-fluid production split."""
 
 import jax
 import jax.numpy as jnp
@@ -7,6 +7,7 @@ import numpy as np
 from adept.vfp2d import (
     CoupledIonKineticStep,
     ElectronIonExchange,
+    ElectronPressureCoupling,
     Grid,
     HarmonicLayout,
     IonEuler2D,
@@ -149,3 +150,86 @@ def test_midpoint_temperature_exchange_preserves_coupled_energy():
     assert jnp.all(jnp.abs(density(updated_f - flm, layout, grid.v, grid.dv)) < 2e-14)
     assert after["electron_energy"] < before["electron_energy"]
     assert after["ion_energy"] > before["ion_energy"]
+
+
+def test_midpoint_momentum_exchange_preserves_lab_momentum_and_energy():
+    grid, layout, _maxwell, _stationary, moving, hydro, flm, field, ions, ion_mass = _make_problem()
+    f00 = jnp.real(flm[..., layout.index(0, 0), :])
+    flm = flm.at[..., layout.index(1, 0), :].set(0.07 * grid.v * f00)
+    flm = flm.at[..., layout.index(1, 1), :].set((-0.03 + 0.02j) * grid.v * f00)
+    exchange = ElectronIonExchange(layout, grid.v, grid.dv, ion_mass=ion_mass)
+    coupled = CoupledIonKineticStep(moving, hydro, moving.dt, exchange=exchange, evolve_ions=False)
+    before = coupled_invariants(
+        flm,
+        ions,
+        field,
+        layout,
+        grid.v,
+        grid.dv,
+        dx=grid.dx,
+        dy=grid.dy,
+        ion_mass=ion_mass,
+        ion_charge=1.0,
+        light_speed=5.0,
+    )
+    updated_f, updated_ions = jax.jit(coupled._exchange)(
+        0.0,
+        flm,
+        ions,
+        {"ei_momentum_relaxation_rate": 0.4},
+    )
+    after = coupled_invariants(
+        updated_f,
+        updated_ions,
+        field,
+        layout,
+        grid.v,
+        grid.dv,
+        dx=grid.dx,
+        dy=grid.dy,
+        ion_mass=ion_mass,
+        ion_charge=1.0,
+        light_speed=5.0,
+    )
+
+    np.testing.assert_allclose(after["total_momentum"], before["total_momentum"], rtol=3e-13, atol=3e-13)
+    np.testing.assert_allclose(after["total_energy"], before["total_energy"], rtol=3e-13, atol=3e-13)
+    np.testing.assert_allclose(after["electron_number"], before["electron_number"], rtol=3e-14, atol=3e-14)
+    assert jnp.linalg.norm(updated_ions[..., 1:4]) > 0.0
+
+
+def test_midpoint_pressure_feedback_preserves_global_momentum_and_energy():
+    grid, layout, _maxwell, _stationary, moving, hydro, flm, field, ions, ion_mass = _make_problem()
+    pressure = ElectronPressureCoupling(moving.ion_frame)
+    coupled = CoupledIonKineticStep(moving, hydro, moving.dt, pressure=pressure, evolve_ions=False)
+    before = coupled_invariants(
+        flm,
+        ions,
+        field,
+        layout,
+        grid.v,
+        grid.dv,
+        dx=grid.dx,
+        dy=grid.dy,
+        ion_mass=ion_mass,
+        ion_charge=1.0,
+        light_speed=5.0,
+    )
+    updated_f, updated_ions = jax.jit(coupled._exchange)(0.0, flm, ions, {})
+    after = coupled_invariants(
+        updated_f,
+        updated_ions,
+        field,
+        layout,
+        grid.v,
+        grid.dv,
+        dx=grid.dx,
+        dy=grid.dy,
+        ion_mass=ion_mass,
+        ion_charge=1.0,
+        light_speed=5.0,
+    )
+
+    np.testing.assert_allclose(after["total_momentum"], before["total_momentum"], rtol=3e-13, atol=3e-13)
+    np.testing.assert_allclose(after["total_energy"], before["total_energy"], rtol=3e-13, atol=3e-13)
+    assert jnp.linalg.norm(updated_ions[..., 1:4]) > 0.0

--- a/tests/test_vfp2d/test_coupling.py
+++ b/tests/test_vfp2d/test_coupling.py
@@ -107,6 +107,58 @@ def test_lab_electric_field_recovers_ideal_bulk_magnetic_advection():
     np.testing.assert_allclose(divergence_rate, 0.0, atol=2e-13)
 
 
+def test_current_projection_ledger_matches_lab_frame_energy_change():
+    grid, layout, _maxwell, _stationary, moving, _hydro, flm, field, ions, ion_mass = _make_problem()
+    f00 = jnp.real(flm[..., layout.index(0, 0), :])
+    flm = flm.at[..., layout.index(1, 0), :].set(0.05 * grid.v * f00)
+    flm = flm.at[..., layout.index(1, 1), :].set((-0.02 + 0.01j) * grid.v * f00)
+    x = grid.x[:, None]
+    ion_velocity = jnp.stack(
+        (
+            0.2 + 0.03 * jnp.cos(x) * jnp.ones((1, grid.ny)),
+            -0.1 * jnp.ones((grid.nx, grid.ny)),
+            0.04 * jnp.ones((grid.nx, grid.ny)),
+        ),
+        axis=-1,
+    )
+    ion_density = ions[..., 0]
+    moving_ions = ions.at[..., 1:4].set(ion_density[..., None] * ion_velocity)
+    moving_ions = moving_ions.at[..., 4].add(0.5 * ion_density * jnp.sum(ion_velocity**2, axis=-1))
+
+    projected = moving._project(flm, field)
+    projection_work = moving._projection_energy_density(
+        flm,
+        projected,
+        {"ion_velocity": ion_velocity},
+    )
+    common = {
+        "layout": layout,
+        "v": grid.v,
+        "dv": grid.dv,
+        "dx": grid.dx,
+        "dy": grid.dy,
+        "ion_mass": ion_mass,
+        "ion_charge": 1.0,
+        "light_speed": 5.0,
+    }
+    before = coupled_invariants(flm, moving_ions, field, **common)
+    after = coupled_invariants(
+        projected,
+        moving_ions,
+        field,
+        current_projection_energy=projection_work,
+        **common,
+    )
+
+    np.testing.assert_allclose(
+        after["total_energy"] - before["total_energy"],
+        after["current_projection_energy"],
+        rtol=2e-13,
+        atol=2e-13,
+    )
+    np.testing.assert_allclose(after["accounted_total_energy"], before["total_energy"], rtol=2e-13, atol=2e-13)
+
+
 def test_midpoint_temperature_exchange_preserves_coupled_energy():
     grid, layout, _maxwell, _stationary, moving, hydro, flm, field, ions, ion_mass = _make_problem()
     exchange = ElectronIonExchange(layout, grid.v, grid.dv, ion_mass=ion_mass)

--- a/tests/test_vfp2d/test_coupling.py
+++ b/tests/test_vfp2d/test_coupling.py
@@ -1,0 +1,151 @@
+"""Coupled local-limit tests for the Gate 2a production split."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept.vfp2d import (
+    CoupledIonKineticStep,
+    ElectronIonExchange,
+    Grid,
+    HarmonicLayout,
+    IonEuler2D,
+    IonFrameVlasov,
+    KineticOhm2D,
+    KineticOhmStep,
+    Maxwell2D,
+    TzoufrasVlasov,
+    coupled_invariants,
+    density,
+    primitive_to_conserved,
+)
+
+
+def _make_problem(nx=6, ny=4, nv=48, dt=2.0e-3):
+    grid = Grid(
+        xmin=0.0,
+        xmax=2.0 * np.pi,
+        nx=nx,
+        ymin=0.0,
+        ymax=2.0 * np.pi,
+        ny=ny,
+        vmax=7.0,
+        nv=nv,
+        dt=dt,
+        l_max=2,
+    )
+    layout = HarmonicLayout(2)
+    vlasov = TzoufrasVlasov(layout, grid.v, grid.dv, grid.kx, grid.ky)
+    maxwell = Maxwell2D(grid.kx, grid.ky, c=5.0)
+    ohm = KineticOhm2D(layout, grid.v, grid.dv, grid.kx, grid.ky)
+    stationary_step = KineticOhmStep(vlasov, maxwell, ohm, layout, grid.v, grid.dv, dt)
+    moving_step = KineticOhmStep(
+        vlasov,
+        maxwell,
+        ohm,
+        layout,
+        grid.v,
+        grid.dv,
+        dt,
+        ion_frame=IonFrameVlasov(vlasov),
+    )
+
+    profile = 1.0 + 0.05 * jnp.cos(grid.x)[:, None] * jnp.ones((1, grid.ny))
+    radial = jnp.exp(-(grid.v**2))
+    radial /= 4.0 * jnp.pi * jnp.sum(radial * grid.v**2) * grid.dv
+    flm = jnp.zeros((nx, ny, layout.size, nv), dtype=jnp.complex128)
+    flm = flm.at[..., layout.index(0, 0), :].set(profile[..., None] * radial)
+    field = jnp.zeros((nx, ny, 3))
+
+    ion_mass = 100.0
+    ion_primitive = jnp.concatenate(
+        (
+            (ion_mass * profile)[..., None],
+            jnp.zeros((nx, ny, 3)),
+            (0.2 * jnp.ones_like(profile))[..., None],
+        ),
+        axis=-1,
+    )
+    ions = primitive_to_conserved(ion_primitive)
+    hydro = IonEuler2D(grid.dx, grid.dy)
+    return grid, layout, maxwell, stationary_step, moving_step, hydro, flm, field, ions, ion_mass
+
+
+def test_zero_velocity_coupling_reproduces_frozen_ion_kinetic_step():
+    _grid, _layout, _maxwell, stationary, moving, hydro, flm, field, ions, _ion_mass = _make_problem()
+    state = {"flm": flm, "e": field, "b": field}
+    reference = stationary(0.0, state)
+    coupled = CoupledIonKineticStep(moving, hydro, moving.dt, evolve_ions=False)
+    result = jax.jit(coupled)(0.0, {**state, "ions": ions})
+
+    for key in ("flm", "e", "b"):
+        np.testing.assert_allclose(result[key], reference[key], rtol=3e-12, atol=3e-12)
+    np.testing.assert_allclose(result["ions"], ions, rtol=0.0, atol=0.0)
+
+
+def test_lab_electric_field_recovers_ideal_bulk_magnetic_advection():
+    grid, _layout, maxwell, stationary, moving, _hydro, flm, field, _ions, _ion_mass = _make_problem(nx=16)
+    magnetic = field.at[..., 2].set(jnp.sin(grid.x)[:, None])
+    ion_velocity = jnp.broadcast_to(jnp.asarray([0.3, -0.1, 0.0]), magnetic.shape)
+    hidden = jnp.zeros(magnetic.shape[:-1])
+    stationary_e, _stationary_terms = stationary.electric_field(flm, magnetic, {}, hidden_dndz=hidden)
+    moving_e, terms = moving.electric_field(
+        flm,
+        magnetic,
+        {"ion_velocity": ion_velocity},
+        hidden_dndz=hidden,
+    )
+
+    bulk_e = moving_e - stationary_e
+    np.testing.assert_allclose(bulk_e, -jnp.cross(ion_velocity, magnetic), rtol=2e-13, atol=2e-13)
+    np.testing.assert_allclose(terms["bulk"], bulk_e, rtol=2e-15, atol=2e-15)
+    magnetic_rate = -maxwell.curl(bulk_e)
+    expected_bz_rate = -ion_velocity[..., 0] * jnp.cos(grid.x)[:, None]
+    np.testing.assert_allclose(magnetic_rate[..., 2], expected_bz_rate, rtol=2e-12, atol=2e-12)
+    divergence_rate = maxwell.ddx(magnetic_rate[..., 0]) + maxwell.ddy(magnetic_rate[..., 1])
+    np.testing.assert_allclose(divergence_rate, 0.0, atol=2e-13)
+
+
+def test_midpoint_temperature_exchange_preserves_coupled_energy():
+    grid, layout, _maxwell, _stationary, moving, hydro, flm, field, ions, ion_mass = _make_problem()
+    exchange = ElectronIonExchange(layout, grid.v, grid.dv, ion_mass=ion_mass)
+    coupled = CoupledIonKineticStep(moving, hydro, moving.dt, exchange=exchange, evolve_ions=False)
+    before = coupled_invariants(
+        flm,
+        ions,
+        field,
+        layout,
+        grid.v,
+        grid.dv,
+        dx=grid.dx,
+        dy=grid.dy,
+        ion_mass=ion_mass,
+        ion_charge=1.0,
+        light_speed=5.0,
+    )
+    updated_f, updated_ions = jax.jit(coupled._exchange)(
+        0.0,
+        flm,
+        ions,
+        {"ei_temperature_relaxation_rate": 0.4},
+    )
+    after = coupled_invariants(
+        updated_f,
+        updated_ions,
+        field,
+        layout,
+        grid.v,
+        grid.dv,
+        dx=grid.dx,
+        dy=grid.dy,
+        ion_mass=ion_mass,
+        ion_charge=1.0,
+        light_speed=5.0,
+    )
+
+    np.testing.assert_allclose(after["electron_number"], before["electron_number"], rtol=2e-14, atol=2e-14)
+    np.testing.assert_allclose(after["ion_number"], before["ion_number"], rtol=0.0, atol=0.0)
+    np.testing.assert_allclose(after["total_energy"], before["total_energy"], rtol=2e-14, atol=2e-14)
+    assert jnp.all(jnp.abs(density(updated_f - flm, layout, grid.v, grid.dv)) < 2e-14)
+    assert after["electron_energy"] < before["electron_energy"]
+    assert after["ion_energy"] > before["ion_energy"]

--- a/tests/test_vfp2d/test_exchange.py
+++ b/tests/test_vfp2d/test_exchange.py
@@ -9,6 +9,9 @@ from adept.vfp2d import (
     ElectronIonExchange,
     Grid,
     HarmonicLayout,
+    IonFrameVlasov,
+    TzoufrasVlasov,
+    VelocityFrameRemap,
     density,
     electron_kinetic_energy_density,
     electron_momentum_density,
@@ -98,6 +101,43 @@ def test_momentum_relaxation_is_equal_opposite_and_energy_neutral():
     np.testing.assert_allclose(diondt[..., 1:4], 0.35 * momentum_before, rtol=2e-13, atol=2e-13)
     np.testing.assert_allclose(electron_kinetic_energy_density(dfdt, layout, grid.v, grid.dv), 0.0, atol=2e-14)
     np.testing.assert_allclose(diondt[..., 4], 0.0, atol=2e-14)
+
+
+def test_velocity_frame_remap_preserves_lab_moments_exactly():
+    grid, layout, _exchange, f, _ions = _make_state(nx=3, ny=2, nv=192, l_max=3)
+    f00 = jnp.real(f[..., layout.index(0, 0), :])
+    f = f.at[..., layout.index(1, 0), :].set(0.06 * grid.v * f00)
+    f = f.at[..., layout.index(1, 1), :].set((-0.025 + 0.035j) * grid.v * f00)
+    f = f.at[..., layout.index(2, 0), :].set(0.015 * grid.v**2 * f00)
+
+    vlasov = TzoufrasVlasov(layout, grid.v, grid.dv, grid.kx, grid.ky)
+    remap = VelocityFrameRemap(IonFrameVlasov(vlasov))
+    old_velocity = jnp.broadcast_to(jnp.asarray([0.12, -0.07, 0.04]), (*f.shape[:2], 3))
+    velocity_change = jnp.broadcast_to(jnp.asarray([0.018, -0.011, 0.009]), old_velocity.shape)
+
+    old_density = density(f, layout, grid.v, grid.dv)
+    old_relative_momentum = electron_momentum_density(f, layout, grid.v, grid.dv)
+    old_relative_energy = electron_kinetic_energy_density(f, layout, grid.v, grid.dv)
+    translated = jax.jit(remap)(f, velocity_change)
+    new_relative_momentum = electron_momentum_density(translated, layout, grid.v, grid.dv)
+    new_relative_energy = electron_kinetic_energy_density(translated, layout, grid.v, grid.dv)
+
+    target_momentum = old_relative_momentum - old_density[..., None] * velocity_change
+    target_energy = old_relative_energy - jnp.sum(velocity_change * old_relative_momentum, axis=-1)
+    target_energy += 0.5 * old_density * jnp.sum(velocity_change**2, axis=-1)
+    np.testing.assert_allclose(density(translated, layout, grid.v, grid.dv), old_density, rtol=2e-14, atol=2e-14)
+    np.testing.assert_allclose(new_relative_momentum, target_momentum, rtol=3e-13, atol=3e-13)
+    np.testing.assert_allclose(new_relative_energy, target_energy, rtol=3e-13, atol=3e-13)
+
+    new_velocity = old_velocity + velocity_change
+    old_lab_momentum = old_relative_momentum + old_density[..., None] * old_velocity
+    new_lab_momentum = new_relative_momentum + old_density[..., None] * new_velocity
+    old_lab_energy = old_relative_energy + jnp.sum(old_velocity * old_relative_momentum, axis=-1)
+    old_lab_energy += 0.5 * old_density * jnp.sum(old_velocity**2, axis=-1)
+    new_lab_energy = new_relative_energy + jnp.sum(new_velocity * new_relative_momentum, axis=-1)
+    new_lab_energy += 0.5 * old_density * jnp.sum(new_velocity**2, axis=-1)
+    np.testing.assert_allclose(new_lab_momentum, old_lab_momentum, rtol=3e-13, atol=3e-13)
+    np.testing.assert_allclose(new_lab_energy, old_lab_energy, rtol=3e-13, atol=3e-13)
 
 
 def test_combined_exchange_moves_temperatures_toward_equilibrium():

--- a/tests/test_vfp2d/test_exchange.py
+++ b/tests/test_vfp2d/test_exchange.py
@@ -1,0 +1,120 @@
+"""Conservative moment tests for finite-mass electron--ion relaxation."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from adept.vfp2d import (
+    ElectronIonExchange,
+    Grid,
+    HarmonicLayout,
+    density,
+    electron_kinetic_energy_density,
+    electron_momentum_density,
+    primitive_to_conserved,
+    scalar_velocity_moment,
+)
+
+
+def _make_state(nx=2, ny=2, nv=160, l_max=2, ion_mass=100.0, ion_temperature=0.15):
+    grid = Grid(
+        xmin=0.0,
+        xmax=1.0,
+        nx=nx,
+        ymin=0.0,
+        ymax=1.0,
+        ny=ny,
+        vmax=8.0,
+        nv=nv,
+        dt=0.01,
+        l_max=l_max,
+    )
+    layout = HarmonicLayout(l_max)
+    f = jnp.zeros((nx, ny, layout.size, nv), dtype=jnp.complex128)
+    f00 = jnp.exp(-(grid.v**2))
+    normalization = 4.0 * jnp.pi * jnp.sum(f00 * grid.v**2) * grid.dv
+    f = f.at[..., layout.index(0, 0), :].set(f00 / normalization)
+
+    ion_primitive = jnp.broadcast_to(
+        jnp.asarray([ion_mass, 0.0, 0.0, 0.0, ion_temperature]),
+        (nx, ny, 5),
+    )
+    ions = primitive_to_conserved(ion_primitive, gamma=5.0 / 3.0)
+    exchange = ElectronIonExchange(layout, grid.v, grid.dv, ion_mass=ion_mass)
+    return grid, layout, exchange, f, ions
+
+
+@pytest.mark.parametrize(("ion_temperature", "energy_sign"), [(0.15, -1.0), (0.85, 1.0)])
+def test_temperature_relaxation_preserves_density_and_total_energy(ion_temperature, energy_sign):
+    grid, layout, exchange, f, ions = _make_state(ion_temperature=ion_temperature)
+    dfdt, diondt, diagnostics = jax.jit(exchange)(
+        f,
+        ions,
+        momentum_relaxation_rate=0.0,
+        temperature_relaxation_rate=0.4,
+    )
+
+    np.testing.assert_allclose(density(dfdt, layout, grid.v, grid.dv), 0.0, atol=2e-14)
+    np.testing.assert_allclose(diagnostics["momentum_residual"], 0.0, atol=2e-14)
+    np.testing.assert_allclose(diagnostics["energy_residual"], 0.0, atol=2e-14)
+    np.testing.assert_allclose(
+        electron_kinetic_energy_density(dfdt, layout, grid.v, grid.dv) + diondt[..., 4],
+        0.0,
+        atol=2e-14,
+    )
+    assert jnp.all(energy_sign * diagnostics["electron_energy_rate"] > 0.0)
+    assert jnp.all(energy_sign * diagnostics["ion_energy_rate"] < 0.0)
+    np.testing.assert_allclose(diondt[..., 0], 0.0, atol=0.0)
+
+    electron_temperature_rate = 2.0 * electron_kinetic_energy_density(dfdt, layout, grid.v, grid.dv) / 3.0
+    expected = -0.4 * (diagnostics["electron_temperature"] - diagnostics["ion_temperature"])
+    np.testing.assert_allclose(electron_temperature_rate, expected, rtol=2e-13, atol=2e-13)
+
+
+def test_momentum_relaxation_is_equal_opposite_and_energy_neutral():
+    grid, layout, exchange, f, ions = _make_state()
+    i10, i11 = layout.index(1, 0), layout.index(1, 1)
+    radial = grid.v * jnp.real(f[..., layout.index(0, 0), :])
+    f = f.at[..., i10, :].set(0.08 * radial)
+    f = f.at[..., i11, :].set((0.03 - 0.02j) * radial)
+    momentum_before = electron_momentum_density(f, layout, grid.v, grid.dv)
+
+    dfdt, diondt, diagnostics = exchange(
+        f,
+        ions,
+        momentum_relaxation_rate=0.35,
+        temperature_relaxation_rate=0.0,
+    )
+
+    np.testing.assert_allclose(
+        electron_momentum_density(dfdt, layout, grid.v, grid.dv),
+        -0.35 * momentum_before,
+        rtol=2e-13,
+        atol=2e-13,
+    )
+    np.testing.assert_allclose(diagnostics["momentum_residual"], 0.0, atol=2e-14)
+    np.testing.assert_allclose(diagnostics["energy_residual"], 0.0, atol=2e-14)
+    np.testing.assert_allclose(diondt[..., 1:4], 0.35 * momentum_before, rtol=2e-13, atol=2e-13)
+    np.testing.assert_allclose(electron_kinetic_energy_density(dfdt, layout, grid.v, grid.dv), 0.0, atol=2e-14)
+    np.testing.assert_allclose(diondt[..., 4], 0.0, atol=2e-14)
+
+
+def test_combined_exchange_moves_temperatures_toward_equilibrium():
+    grid, layout, exchange, f, ions = _make_state(ion_temperature=0.1)
+    dfdt, diondt, diagnostics = exchange(
+        f,
+        ions,
+        momentum_relaxation_rate=0.0,
+        temperature_relaxation_rate=0.2,
+    )
+    dt = 0.01
+    updated_f = f + dt * dfdt
+    updated_ions = ions + dt * diondt
+    electron_temperature_after = scalar_velocity_moment(updated_f, layout, grid.v, grid.dv, power=2) / 3.0
+    ion_internal_energy = updated_ions[..., 4]
+    ion_temperature_after = (5.0 / 3.0 - 1.0) * ion_internal_energy
+    difference_before = diagnostics["electron_temperature"] - diagnostics["ion_temperature"]
+    difference_after = electron_temperature_after - ion_temperature_after
+
+    assert jnp.all(jnp.abs(difference_after) < jnp.abs(difference_before))

--- a/tests/test_vfp2d/test_field_solvers.py
+++ b/tests/test_vfp2d/test_field_solvers.py
@@ -1,0 +1,138 @@
+"""Verification for explicit and implicit VFP2D field responses."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept.vfp2d import Grid, HarmonicLayout, Maxwell2D, OSHUNImplicitStep, TzoufrasVlasov, current
+
+
+def _problem(nx=6, ny=4, nv=48, dt=1.0e-3):
+    grid = Grid(
+        xmin=0.0,
+        xmax=2.0 * np.pi,
+        nx=nx,
+        ymin=0.0,
+        ymax=2.0 * np.pi,
+        ny=ny,
+        vmax=7.0,
+        nv=nv,
+        dt=dt,
+        l_max=2,
+    )
+    layout = HarmonicLayout(2)
+    vlasov = TzoufrasVlasov(layout, grid.v, grid.dv, grid.kx, grid.ky)
+    maxwell = Maxwell2D(grid.kx, grid.ky, c=5.0)
+    radial = jnp.exp(-(grid.v**2))
+    radial /= 4.0 * jnp.pi * jnp.sum(radial * grid.v**2) * grid.dv
+    flm = jnp.zeros((nx, ny, layout.size, nv), dtype=jnp.complex128)
+    flm = flm.at[..., layout.index(0, 0), :].set(radial)
+    step = OSHUNImplicitStep(vlasov, maxwell, layout, grid.v, grid.dv, dt)
+    return grid, layout, vlasov, maxwell, step, flm
+
+
+def test_relative_permittivity_slows_only_the_explicit_ampere_response():
+    grid, _layout, _vlasov, physical, _step, _flm = _problem()
+    relaxed = Maxwell2D(grid.kx, grid.ky, c=5.0, relative_permittivity=1.0e6)
+    x, y = grid.x[:, None], grid.y[None, :]
+    electric = jnp.stack(
+        (
+            jnp.sin(x) * jnp.ones_like(y),
+            jnp.ones_like(x) * jnp.cos(y),
+            jnp.sin(x) * jnp.cos(y),
+        ),
+        axis=-1,
+    )
+    magnetic = jnp.stack(
+        (
+            jnp.ones_like(x) * jnp.sin(y),
+            jnp.cos(x) * jnp.ones_like(y),
+            jnp.cos(x) * jnp.sin(y),
+        ),
+        axis=-1,
+    )
+    plasma_current = 0.03 * electric
+
+    physical_dedt, physical_dbdt = physical(electric, magnetic, plasma_current)
+    relaxed_dedt, relaxed_dbdt = relaxed(electric, magnetic, plasma_current)
+
+    np.testing.assert_allclose(relaxed_dedt, physical_dedt / 1.0e6, rtol=2e-15, atol=2e-15)
+    np.testing.assert_allclose(relaxed_dbdt, physical_dbdt, rtol=0.0, atol=0.0)
+
+
+def test_oshun_response_tensor_matches_direct_three_field_perturbations():
+    grid, _layout, _vlasov, _maxwell, step, flm = _problem()
+    baseline, response = step.current_response(flm)
+    x, y = grid.x[:, None], grid.y[None, :]
+    direction = jnp.stack(
+        (
+            0.3 + 0.1 * jnp.cos(x) * jnp.ones_like(y),
+            -0.2 * jnp.ones_like(x) * jnp.sin(y),
+            0.05 * jnp.sin(x) * jnp.cos(y),
+        ),
+        axis=-1,
+    )
+    epsilon = 1.0e-7
+    perturbed = flm + step.electric_increment(flm, epsilon * direction)
+    measured = (current(perturbed, step.layout, step.v, step.dv) - baseline) / epsilon
+    predicted = jnp.einsum("...ij,...j->...i", response, direction)
+
+    np.testing.assert_allclose(measured, predicted, rtol=2e-9, atol=2e-12)
+
+
+def test_oshun_direct_solve_enforces_ampere_current_without_f1_projection():
+    grid, layout, _vlasov, maxwell, step, flm = _problem()
+    x, y = grid.x[:, None], grid.y[None, :]
+    magnetic = jnp.zeros((grid.nx, grid.ny, 3))
+    magnetic = magnetic.at[..., 2].set(0.002 * jnp.sin(x) * jnp.cos(y))
+    flm = flm.at[..., layout.index(1, 0), :].set(1.0e-4 * flm[..., layout.index(0, 0), :])
+    f2_before = flm[..., layout.index(2, 0), :]
+
+    updated, electric, residual = jax.jit(step.solve_electric_field)(flm, magnetic)
+
+    assert jnp.all(jnp.isfinite(electric))
+    np.testing.assert_allclose(residual, 0.0, rtol=0.0, atol=3e-15)
+    np.testing.assert_allclose(
+        current(updated, layout, grid.v, grid.dv),
+        maxwell.c2 * maxwell.curl(magnetic),
+        rtol=2e-13,
+        atol=2e-13,
+    )
+    assert jnp.max(jnp.abs(updated[..., layout.index(2, 0), :] - f2_before)) > 0.0
+
+
+def test_oshun_step_uses_explicit_faraday_and_enforces_the_new_ampere_target():
+    grid, layout, _vlasov, maxwell, step, flm = _problem()
+    x, y = grid.x[:, None], grid.y[None, :]
+    electric = jnp.stack(
+        (
+            jnp.zeros((grid.nx, grid.ny)),
+            jnp.zeros((grid.nx, grid.ny)),
+            1.0e-4 * jnp.sin(x) * jnp.cos(y),
+        ),
+        axis=-1,
+    )
+    magnetic = jnp.zeros_like(electric).at[..., 2].set(2.0e-5 * jnp.sin(x) * jnp.cos(y))
+
+    result = jax.jit(step)(0.0, {"flm": flm, "e": electric, "b": magnetic}, {})
+
+    expected_magnetic = magnetic - step.dt * maxwell.curl(electric)
+    np.testing.assert_allclose(result["b"], expected_magnetic, rtol=2e-13, atol=2e-13)
+    np.testing.assert_allclose(
+        current(result["flm"], layout, grid.v, grid.dv),
+        maxwell.c2 * maxwell.curl(result["b"]),
+        rtol=2e-12,
+        atol=2e-12,
+    )
+
+
+def test_oshun_step_is_jittable_and_leaves_a_uniform_equilibrium_unchanged():
+    grid, _layout, _vlasov, _maxwell, step, flm = _problem()
+    field = jnp.zeros((grid.nx, grid.ny, 3))
+    state = {"flm": flm, "e": field, "b": field}
+
+    result = jax.jit(step)(0.0, state, {})
+
+    np.testing.assert_allclose(result["flm"], flm, rtol=2e-13, atol=2e-13)
+    np.testing.assert_allclose(result["e"], 0.0, atol=2e-13)
+    np.testing.assert_allclose(result["b"], 0.0, atol=2e-13)

--- a/tests/test_vfp2d/test_harmonics.py
+++ b/tests/test_vfp2d/test_harmonics.py
@@ -275,14 +275,37 @@ def test_periodic_streaming_conserves_total_particle_number():
     np.testing.assert_allclose(jnp.sum(dndt), 0.0, atol=2e-12)
 
 
-def test_maxwell_curl_keeps_divergence_of_b_constant():
+def test_multistep_faraday_update_preserves_magnetic_divergence():
     grid, _layout, _operator, _flm = _make_problem()
     maxwell = Maxwell2D(grid.kx, grid.ky, c=3.0)
-    e = jnp.zeros((grid.nx, grid.ny, 3)).at[..., 2].set(jnp.sin(grid.x)[:, None] * jnp.cos(2.0 * grid.y)[None, :])
-    b = jnp.zeros_like(e)
-    _dedt, dbdt = maxwell(e, b, jnp.zeros_like(e))
-    divergence = maxwell.ddx(dbdt[..., 0]) + maxwell.ddy(dbdt[..., 1])
-    np.testing.assert_allclose(divergence, 0.0, atol=2e-12)
+    x = grid.x[:, None]
+    y = grid.y[None, :]
+    b = jnp.stack(
+        (
+            2.0 * jnp.sin(x) * jnp.cos(2.0 * y),
+            -jnp.cos(x) * jnp.sin(2.0 * y),
+            0.1 * jnp.cos(2.0 * x - y),
+        ),
+        axis=-1,
+    )
+    initial_divergence = maxwell.ddx(b[..., 0]) + maxwell.ddy(b[..., 1])
+    np.testing.assert_allclose(initial_divergence, 0.0, atol=2e-12)
+
+    for step in range(24):
+        phase = 0.17 * step
+        electric = jnp.stack(
+            (
+                0.2 * jnp.cos(x + phase) * jnp.sin(y),
+                0.3 * jnp.sin(2.0 * x) * jnp.cos(y - phase),
+                jnp.sin(x + phase) * jnp.cos(2.0 * y - phase),
+            ),
+            axis=-1,
+        )
+        _dedt, dbdt = maxwell(electric, b, jnp.zeros_like(b))
+        b = b + 0.013 * dbdt
+
+    final_divergence = maxwell.ddx(b[..., 0]) + maxwell.ddy(b[..., 1])
+    np.testing.assert_allclose(final_divergence, initial_divergence, atol=2e-12)
 
 
 def test_operator_is_jittable_and_differentiable():

--- a/tests/test_vfp2d/test_hydro.py
+++ b/tests/test_vfp2d/test_hydro.py
@@ -1,0 +1,146 @@
+"""Verification tests for the conservative ion-fluid backbone."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept.vfp2d import (
+    IonEuler2D,
+    conserved_to_primitive,
+    euler_flux,
+    hllc_flux,
+    primitive_to_conserved,
+)
+
+
+def _constant_primitive(shape, values):
+    return jnp.broadcast_to(jnp.asarray(values), (*shape, 5))
+
+
+def test_primitive_round_trip_and_directional_fluxes():
+    primitive = jnp.asarray(
+        [
+            [1.2, 0.7, -0.2, 0.3, 2.5],
+            [0.4, -0.1, 0.8, -0.5, 0.2],
+        ]
+    )
+    conserved = primitive_to_conserved(primitive, gamma=1.4)
+    np.testing.assert_allclose(conserved_to_primitive(conserved, gamma=1.4), primitive, rtol=1e-14, atol=1e-14)
+
+    flux_x = euler_flux(primitive, normal_axis=0, gamma=1.4)
+    flux_y = euler_flux(primitive, normal_axis=1, gamma=1.4)
+    np.testing.assert_allclose(flux_x[..., 0], conserved[..., 1])
+    np.testing.assert_allclose(flux_y[..., 0], conserved[..., 2])
+    np.testing.assert_allclose(flux_x[..., 2], conserved[..., 2] * primitive[..., 1])
+    np.testing.assert_allclose(flux_y[..., 1], conserved[..., 1] * primitive[..., 2])
+
+
+def test_hllc_is_consistent_and_resolves_a_stationary_contact():
+    state = jnp.asarray([1.3, 0.4, -0.2, 0.1, 0.9])
+    np.testing.assert_allclose(hllc_flux(state, state, 0, 1.4), euler_flux(state, 0, 1.4), atol=1e-14)
+    np.testing.assert_allclose(hllc_flux(state, state, 1, 1.4), euler_flux(state, 1, 1.4), atol=1e-14)
+
+    left = jnp.asarray([1.0, 0.0, 0.3, -0.2, 1.0])
+    right = jnp.asarray([0.125, 0.0, 0.3, -0.2, 1.0])
+    expected = jnp.asarray([0.0, 1.0, 0.0, 0.0, 0.0])
+    np.testing.assert_allclose(hllc_flux(left, right, 0, 1.4), expected, atol=2e-14)
+
+
+def test_uniform_flow_is_exact_for_periodic_and_outflow_boundaries():
+    primitive = _constant_primitive((9, 7), [0.8, 0.6, -0.25, 0.1, 1.4])
+    conserved = primitive_to_conserved(primitive, gamma=1.4)
+    for boundaries in (("periodic", "periodic"), ("outflow", "outflow")):
+        solver = IonEuler2D(dx=0.2, dy=0.3, gamma=1.4, boundaries=boundaries)
+        np.testing.assert_allclose(solver.rhs(conserved), 0.0, atol=2e-14)
+        np.testing.assert_allclose(solver.step(conserved, 0.01), conserved, rtol=2e-14, atol=2e-14)
+
+
+def test_periodic_step_conserves_every_cell_integrated_quantity():
+    nx, ny = 18, 14
+    x = (jnp.arange(nx) + 0.5) / nx
+    y = (jnp.arange(ny) + 0.5) / ny
+    xx, yy = jnp.meshgrid(x, y, indexing="ij")
+    primitive = jnp.stack(
+        (
+            1.0 + 0.08 * jnp.sin(2.0 * jnp.pi * xx) * jnp.cos(2.0 * jnp.pi * yy),
+            0.2 + 0.04 * jnp.cos(2.0 * jnp.pi * yy),
+            -0.1 + 0.03 * jnp.sin(2.0 * jnp.pi * xx),
+            0.05 * jnp.cos(2.0 * jnp.pi * (xx + yy)),
+            1.0 + 0.05 * jnp.cos(2.0 * jnp.pi * xx),
+        ),
+        axis=-1,
+    )
+    conserved = primitive_to_conserved(primitive, gamma=5.0 / 3.0)
+    solver = IonEuler2D(dx=1.0 / nx, dy=1.0 / ny)
+    advanced = solver.step(conserved, 0.2 * solver.cfl_timestep(conserved))
+    np.testing.assert_allclose(jnp.sum(advanced, axis=(0, 1)), jnp.sum(conserved, axis=(0, 1)), rtol=2e-14, atol=2e-13)
+
+
+def _advect_density_wave(nx):
+    x = (jnp.arange(nx) + 0.5) / nx
+    rho = 1.0 + 0.2 * jnp.sin(2.0 * jnp.pi * x)
+    primitive = jnp.stack((rho, jnp.full_like(x, 0.7), jnp.zeros_like(x), jnp.zeros_like(x), jnp.ones_like(x)), axis=-1)
+    conserved = primitive_to_conserved(primitive[:, None, :], gamma=1.4)
+    solver = IonEuler2D(dx=1.0 / nx, dy=1.0, gamma=1.4)
+    final_time = 0.2
+    stable_dt = float(solver.cfl_timestep(conserved, cfl=0.35))
+    steps = int(np.ceil(final_time / stable_dt))
+    dt = final_time / steps
+    advance = jax.jit(lambda state: solver.step(state, dt))
+    for _ in range(steps):
+        conserved = advance(conserved)
+    exact = 1.0 + 0.2 * jnp.sin(2.0 * jnp.pi * ((x - 0.7 * final_time) % 1.0))
+    return float(jnp.mean(jnp.abs(conserved[:, 0, 0] - exact)))
+
+
+def test_smooth_density_advection_converges_at_second_order():
+    coarse_error = _advect_density_wave(32)
+    fine_error = _advect_density_wave(64)
+    observed_order = np.log2(coarse_error / fine_error)
+    assert observed_order > 1.75
+
+
+def _advance_sod(normal_axis):
+    normal_cells, transverse_cells = 80, 4
+    normal = (jnp.arange(normal_cells) + 0.5) / normal_cells
+    rho = jnp.where(normal < 0.5, 1.0, 0.125)
+    pressure = jnp.where(normal < 0.5, 1.0, 0.1)
+    primitive_1d = jnp.stack((rho, jnp.zeros_like(rho), jnp.zeros_like(rho), jnp.zeros_like(rho), pressure), axis=-1)
+    if normal_axis == 0:
+        primitive = jnp.broadcast_to(primitive_1d[:, None, :], (normal_cells, transverse_cells, 5))
+        solver = IonEuler2D(
+            dx=1.0 / normal_cells,
+            dy=1.0 / transverse_cells,
+            gamma=1.4,
+            boundaries=("outflow", "periodic"),
+        )
+    else:
+        primitive = jnp.broadcast_to(primitive_1d[None, :, :], (transverse_cells, normal_cells, 5))
+        solver = IonEuler2D(
+            dx=1.0 / transverse_cells,
+            dy=1.0 / normal_cells,
+            gamma=1.4,
+            boundaries=("periodic", "outflow"),
+        )
+    conserved = primitive_to_conserved(primitive, gamma=1.4)
+    final_time = 0.08
+    stable_dt = float(solver.cfl_timestep(conserved, cfl=0.3))
+    steps = int(np.ceil(final_time / stable_dt))
+    dt = final_time / steps
+    advance = jax.jit(lambda state: solver.step(state, dt))
+    for _ in range(steps):
+        conserved = advance(conserved)
+    return conserved_to_primitive(conserved, gamma=1.4)
+
+
+def test_sod_tube_is_positive_and_rotation_invariant():
+    result_x = _advance_sod(normal_axis=0)
+    result_y = _advance_sod(normal_axis=1)
+    rotated_y = jnp.swapaxes(result_y, 0, 1)
+    rotated_y = rotated_y.at[..., 1].set(result_y.swapaxes(0, 1)[..., 2])
+    rotated_y = rotated_y.at[..., 2].set(result_y.swapaxes(0, 1)[..., 1])
+
+    assert jnp.all(result_x[..., 0] > 0.0)
+    assert jnp.all(result_x[..., 4] > 0.0)
+    assert jnp.max(result_x[..., 1]) > 0.5
+    np.testing.assert_allclose(result_x, rotated_y, rtol=3e-12, atol=3e-12)

--- a/tests/test_vfp2d/test_hydro_benchmarks.py
+++ b/tests/test_vfp2d/test_hydro_benchmarks.py
@@ -1,0 +1,246 @@
+"""Gate 0b benchmarks for the conservative ion-fluid backbone."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from adept.vfp2d import IonEuler2D, conserved_to_primitive, primitive_to_conserved
+
+GAMMA = 1.4
+
+
+def _pressure_function(pressure, density, reference_pressure, sound_speed):
+    if pressure > reference_pressure:
+        a = 2.0 / ((GAMMA + 1.0) * density)
+        b = (GAMMA - 1.0) * reference_pressure / (GAMMA + 1.0)
+        root = np.sqrt(a / (pressure + b))
+        value = (pressure - reference_pressure) * root
+        derivative = root * (1.0 - 0.5 * (pressure - reference_pressure) / (pressure + b))
+        return value, derivative
+    exponent = (GAMMA - 1.0) / (2.0 * GAMMA)
+    ratio = pressure / reference_pressure
+    value = 2.0 * sound_speed * (ratio**exponent - 1.0) / (GAMMA - 1.0)
+    derivative = ratio ** (-(GAMMA + 1.0) / (2.0 * GAMMA)) / (density * sound_speed)
+    return value, derivative
+
+
+def _star_state(left, right):
+    rho_l, velocity_l, pressure_l = left
+    rho_r, velocity_r, pressure_r = right
+    sound_l = np.sqrt(GAMMA * pressure_l / rho_l)
+    sound_r = np.sqrt(GAMMA * pressure_r / rho_r)
+    guess = max(
+        1.0e-12,
+        0.5 * (pressure_l + pressure_r) - 0.125 * (velocity_r - velocity_l) * (rho_l + rho_r) * (sound_l + sound_r),
+    )
+    pressure = guess
+    for _ in range(30):
+        value_l, derivative_l = _pressure_function(pressure, rho_l, pressure_l, sound_l)
+        value_r, derivative_r = _pressure_function(pressure, rho_r, pressure_r, sound_r)
+        updated = pressure - (value_l + value_r + velocity_r - velocity_l) / (derivative_l + derivative_r)
+        updated = max(updated, 1.0e-12)
+        if abs(updated - pressure) < 1.0e-12 * (updated + pressure):
+            pressure = updated
+            break
+        pressure = updated
+    value_l, _ = _pressure_function(pressure, rho_l, pressure_l, sound_l)
+    value_r, _ = _pressure_function(pressure, rho_r, pressure_r, sound_r)
+    velocity = 0.5 * (velocity_l + velocity_r + value_r - value_l)
+    return pressure, velocity
+
+
+def _sample_riemann(similarity, left, right, star_pressure, star_velocity):
+    rho_l, velocity_l, pressure_l = left
+    rho_r, velocity_r, pressure_r = right
+    sound_l = np.sqrt(GAMMA * pressure_l / rho_l)
+    sound_r = np.sqrt(GAMMA * pressure_r / rho_r)
+    g_ratio = (GAMMA - 1.0) / (GAMMA + 1.0)
+
+    if similarity <= star_velocity:
+        if star_pressure > pressure_l:
+            shock = velocity_l - sound_l * np.sqrt(
+                (GAMMA + 1.0) * star_pressure / (2.0 * GAMMA * pressure_l) + (GAMMA - 1.0) / (2.0 * GAMMA)
+            )
+            if similarity <= shock:
+                return left
+            star_density = rho_l * (star_pressure / pressure_l + g_ratio) / (g_ratio * star_pressure / pressure_l + 1.0)
+            return star_density, star_velocity, star_pressure
+        head = velocity_l - sound_l
+        star_sound = sound_l * (star_pressure / pressure_l) ** ((GAMMA - 1.0) / (2.0 * GAMMA))
+        tail = star_velocity - star_sound
+        if similarity <= head:
+            return left
+        if similarity >= tail:
+            star_density = rho_l * (star_pressure / pressure_l) ** (1.0 / GAMMA)
+            return star_density, star_velocity, star_pressure
+        velocity = 2.0 * (sound_l + 0.5 * (GAMMA - 1.0) * velocity_l + similarity) / (GAMMA + 1.0)
+        sound = 2.0 * (sound_l + 0.5 * (GAMMA - 1.0) * (velocity_l - similarity)) / (GAMMA + 1.0)
+        ratio = sound / sound_l
+        return rho_l * ratio ** (2.0 / (GAMMA - 1.0)), velocity, pressure_l * ratio ** (2.0 * GAMMA / (GAMMA - 1.0))
+
+    if star_pressure > pressure_r:
+        shock = velocity_r + sound_r * np.sqrt(
+            (GAMMA + 1.0) * star_pressure / (2.0 * GAMMA * pressure_r) + (GAMMA - 1.0) / (2.0 * GAMMA)
+        )
+        if similarity >= shock:
+            return right
+        star_density = rho_r * (star_pressure / pressure_r + g_ratio) / (g_ratio * star_pressure / pressure_r + 1.0)
+        return star_density, star_velocity, star_pressure
+    head = velocity_r + sound_r
+    star_sound = sound_r * (star_pressure / pressure_r) ** ((GAMMA - 1.0) / (2.0 * GAMMA))
+    tail = star_velocity + star_sound
+    if similarity >= head:
+        return right
+    if similarity <= tail:
+        star_density = rho_r * (star_pressure / pressure_r) ** (1.0 / GAMMA)
+        return star_density, star_velocity, star_pressure
+    velocity = 2.0 * (-sound_r + 0.5 * (GAMMA - 1.0) * velocity_r + similarity) / (GAMMA + 1.0)
+    sound = 2.0 * (sound_r - 0.5 * (GAMMA - 1.0) * (velocity_r - similarity)) / (GAMMA + 1.0)
+    ratio = sound / sound_r
+    return rho_r * ratio ** (2.0 / (GAMMA - 1.0)), velocity, pressure_r * ratio ** (2.0 * GAMMA / (GAMMA - 1.0))
+
+
+def _exact_riemann(coordinates, time, left, right):
+    star_pressure, star_velocity = _star_state(left, right)
+    return np.asarray(
+        [
+            _sample_riemann((coordinate - 0.5) / time, left, right, star_pressure, star_velocity)
+            for coordinate in coordinates
+        ]
+    )
+
+
+def _advance_tube(left, right, normal_axis, cells=160, final_time=0.006):
+    transverse_cells = 3
+    coordinate = (jnp.arange(cells) + 0.5) / cells
+    rho = jnp.where(coordinate < 0.5, left[0], right[0])
+    velocity = jnp.where(coordinate < 0.5, left[1], right[1])
+    pressure = jnp.where(coordinate < 0.5, left[2], right[2])
+    zeros = jnp.zeros_like(rho)
+    if normal_axis == 0:
+        primitive_1d = jnp.stack((rho, velocity, zeros, zeros, pressure), axis=-1)
+        primitive = jnp.broadcast_to(primitive_1d[:, None, :], (cells, transverse_cells, 5))
+        solver = IonEuler2D(1.0 / cells, 1.0 / transverse_cells, gamma=GAMMA, boundaries=("outflow", "periodic"))
+    else:
+        primitive_1d = jnp.stack((rho, zeros, velocity, zeros, pressure), axis=-1)
+        primitive = jnp.broadcast_to(primitive_1d[None, :, :], (transverse_cells, cells, 5))
+        solver = IonEuler2D(1.0 / transverse_cells, 1.0 / cells, gamma=GAMMA, boundaries=("periodic", "outflow"))
+    conserved = primitive_to_conserved(primitive, gamma=GAMMA)
+    stable_dt = float(solver.cfl_timestep(conserved, cfl=0.25))
+    steps = int(np.ceil(final_time / stable_dt))
+    dt = final_time / steps
+    advance = jax.jit(lambda state: solver.step(state, dt))
+    for _ in range(steps):
+        conserved = advance(conserved)
+    return coordinate, conserved_to_primitive(conserved, gamma=GAMMA)
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "relative_l1_tolerance"),
+    [
+        ((1.0, 0.0, 1.0), (0.125, 0.0, 0.1), 0.035),
+        ((1.0, 0.0, 1000.0), (1.0, 0.0, 0.01), 0.12),
+    ],
+)
+def test_sod_and_strong_shock_tubes_match_exact_solution_in_both_directions(
+    left,
+    right,
+    relative_l1_tolerance,
+):
+    coordinate, result_x = _advance_tube(left, right, normal_axis=0)
+    _coordinate, result_y = _advance_tube(left, right, normal_axis=1)
+    rotated_y = jnp.swapaxes(result_y, 0, 1)
+    rotated_y = rotated_y.at[..., 1].set(result_y.swapaxes(0, 1)[..., 2])
+    rotated_y = rotated_y.at[..., 2].set(result_y.swapaxes(0, 1)[..., 1])
+    np.testing.assert_allclose(result_x, rotated_y, rtol=5e-12, atol=5e-12)
+
+    exact = _exact_riemann(np.asarray(coordinate), 0.006, left, right)
+    numerical = np.asarray(result_x[:, 0])[:, (0, 1, 4)]
+    scales = np.ptp(exact, axis=0)
+    relative_l1 = np.mean(np.abs(numerical - exact), axis=0) / np.maximum(scales, 1.0e-12)
+    assert np.max(relative_l1) < relative_l1_tolerance
+    assert jnp.all(result_x[..., 0] > 0.0)
+    assert jnp.all(result_x[..., 4] > 0.0)
+
+
+def _isentropic_vortex(n, time):
+    length = 10.0
+    coordinate = -5.0 + (jnp.arange(n) + 0.5) * length / n
+    x, y = jnp.meshgrid(coordinate, coordinate, indexing="ij")
+    center_x = -2.0 + time
+    center_y = -2.0 + 0.5 * time
+    dx = (x - center_x + 0.5 * length) % length - 0.5 * length
+    dy = (y - center_y + 0.5 * length) % length - 0.5 * length
+    radius_squared = dx**2 + dy**2
+    beta = 5.0
+    envelope = jnp.exp(0.5 * (1.0 - radius_squared))
+    delta_u = -beta * dy * envelope / (2.0 * jnp.pi)
+    delta_v = beta * dx * envelope / (2.0 * jnp.pi)
+    temperature = 1.0 - (GAMMA - 1.0) * beta**2 * jnp.exp(1.0 - radius_squared) / (8.0 * GAMMA * jnp.pi**2)
+    density = temperature ** (1.0 / (GAMMA - 1.0))
+    pressure = density**GAMMA
+    return jnp.stack((density, 1.0 + delta_u, 0.5 + delta_v, jnp.zeros_like(x), pressure), axis=-1)
+
+
+def _vortex_error(n):
+    final_time = 0.2
+    solver = IonEuler2D(10.0 / n, 10.0 / n, gamma=GAMMA)
+    conserved = primitive_to_conserved(_isentropic_vortex(n, 0.0), gamma=GAMMA)
+    stable_dt = float(solver.cfl_timestep(conserved, cfl=0.35))
+    steps = int(np.ceil(final_time / stable_dt))
+    dt = final_time / steps
+    advance = jax.jit(lambda state: solver.step(state, dt))
+    for _ in range(steps):
+        conserved = advance(conserved)
+    numerical_density = conserved[..., 0]
+    exact_density = _isentropic_vortex(n, final_time)[..., 0]
+    return float(jnp.mean(jnp.abs(numerical_density - exact_density)))
+
+
+def test_translating_isentropic_vortex_converges_at_second_order():
+    coarse_error = _vortex_error(24)
+    fine_error = _vortex_error(48)
+    assert np.log2(coarse_error / fine_error) > 1.7
+
+
+def test_sedov_blast_conserves_energy_and_remains_radially_symmetric():
+    n = 48
+    length = 1.0
+    dx = length / n
+    coordinate = -0.5 + (jnp.arange(n) + 0.5) * dx
+    x, y = jnp.meshgrid(coordinate, coordinate, indexing="ij")
+    density = jnp.ones((n, n))
+    pressure = jnp.full((n, n), 1.0e-5)
+    central = (jnp.abs(x) < dx) & (jnp.abs(y) < dx)
+    pressure = pressure + central * (GAMMA - 1.0) / (4.0 * dx**2)
+    primitive = jnp.stack(
+        (density, jnp.zeros_like(x), jnp.zeros_like(x), jnp.zeros_like(x), pressure),
+        axis=-1,
+    )
+    conserved = primitive_to_conserved(primitive, gamma=GAMMA)
+    initial_energy = jnp.sum(conserved[..., 4]) * dx**2
+    solver = IonEuler2D(dx, dx, gamma=GAMMA, boundaries=("outflow", "outflow"))
+    final_time = 0.02
+    time = 0.0
+    advance = jax.jit(lambda state, timestep: solver.step(state, timestep))
+    while time < final_time:
+        dt = min(float(solver.cfl_timestep(conserved, cfl=0.3)), final_time - time)
+        conserved = advance(conserved, dt)
+        time += dt
+
+    result = conserved_to_primitive(conserved, gamma=GAMMA)
+    final_energy = jnp.sum(conserved[..., 4]) * dx**2
+    np.testing.assert_allclose(final_energy, initial_energy, rtol=3e-12, atol=3e-12)
+    np.testing.assert_allclose(result, jnp.swapaxes(result, 0, 1)[..., [0, 2, 1, 3, 4]], rtol=3e-11, atol=3e-11)
+    assert jnp.all(result[..., 0] > 0.0)
+    assert jnp.all(result[..., 4] > 0.0)
+
+    radial_velocity = (result[..., 1] * x + result[..., 2] * y) / jnp.maximum(
+        jnp.sqrt(x**2 + y**2),
+        dx / 2.0,
+    )
+    kinetic_weight = 0.5 * conserved[..., 0] * radial_velocity**2
+    angle = jnp.arctan2(y, x)
+    cartesian_anisotropy = jnp.abs(jnp.sum(kinetic_weight * jnp.cos(4.0 * angle))) / jnp.sum(kinetic_weight)
+    assert cartesian_anisotropy < 0.05

--- a/tests/test_vfp2d/test_local_limits.py
+++ b/tests/test_vfp2d/test_local_limits.py
@@ -1,0 +1,124 @@
+"""Quantitative collisional-local-limit tests for Gate 2b."""
+
+import jax.numpy as jnp
+import numpy as np
+
+from adept.vfp1d.fokker_planck import FLMCollisions
+from adept.vfp1d.grid import Grid as CollisionGrid
+from adept.vfp2d import (
+    AnisotropicCollisions,
+    Grid,
+    HarmonicLayout,
+    KineticOhm2D,
+    Maxwell2D,
+    vector_velocity_moment,
+)
+
+
+def _biermann_error(nxy: int) -> float:
+    grid = Grid(
+        xmin=0.0,
+        xmax=2.0 * np.pi,
+        nx=nxy,
+        ymin=0.0,
+        ymax=2.0 * np.pi,
+        ny=nxy,
+        vmax=7.0,
+        nv=96,
+        dt=1.0e-3,
+        l_max=2,
+    )
+    layout = HarmonicLayout(2)
+    x, y = grid.x[:, None], grid.y[None, :]
+    log_density = 0.12 * jnp.sin(x) + 0.08 * jnp.cos(y)
+    electron_density = jnp.exp(log_density)
+    temperature = 0.5 + 0.04 * jnp.cos(x + y) + 0.03 * jnp.sin(2.0 * x - y)
+
+    radial = jnp.exp(-(grid.v[None, None, :] ** 2) / (2.0 * temperature[..., None]))
+    radial_density = 4.0 * jnp.pi * jnp.sum(radial * grid.v**2, axis=-1) * grid.dv
+    radial *= electron_density[..., None] / radial_density[..., None]
+    flm = jnp.zeros((nxy, nxy, layout.size, grid.nv), dtype=jnp.complex128)
+    flm = flm.at[..., layout.index(0, 0), :].set(radial)
+    magnetic = jnp.zeros((nxy, nxy, 3))
+
+    electric, _terms = KineticOhm2D(layout, grid.v, grid.dv, grid.kx, grid.ky)(flm, magnetic)
+    magnetic_rate = -Maxwell2D(grid.kx, grid.ky, c=1.0).curl(electric)
+    dtemperature_dx = -0.04 * jnp.sin(x + y) + 0.06 * jnp.cos(2.0 * x - y)
+    dtemperature_dy = -0.04 * jnp.sin(x + y) - 0.03 * jnp.cos(2.0 * x - y)
+    dlog_density_dx = 0.12 * jnp.cos(x) + jnp.zeros_like(y)
+    dlog_density_dy = -0.08 * jnp.sin(y) + jnp.zeros_like(x)
+    classical_biermann = dtemperature_dx * dlog_density_dy - dtemperature_dy * dlog_density_dx
+    return float(jnp.max(jnp.abs(magnetic_rate[..., 2] - classical_biermann)))
+
+
+def test_local_maxwellian_biermann_generation_converges_to_classical_rate():
+    coarse_error = _biermann_error(12)
+    fine_error = _biermann_error(16)
+    assert coarse_error / fine_error > 50.0
+    assert fine_error < 2.0e-6
+
+
+def _local_eh_heat_flux(nv: int) -> tuple[float, float]:
+    vmax = 7.0
+    dv = vmax / nv
+    v = (jnp.arange(nv) + 0.5) * dv
+    layout = HarmonicLayout(1)
+    temperature = 0.5
+    electron_density = 1.0
+    temperature_gradient = 0.03
+    ionization = 6.0
+    collision_coefficient = 0.4
+
+    f0 = jnp.exp(-(v**2) / (2.0 * temperature))
+    f0 *= electron_density / (4.0 * jnp.pi * jnp.sum(f0 * v**2) * dv)
+    temperature_derivative = f0 * (-1.5 / temperature + v**2 / (2.0 * temperature**2))
+    velocity_derivative = -(v / temperature) * f0
+    thermal_force = -2.5 * temperature_gradient
+    streaming_source = -v * temperature_derivative * temperature_gradient + thermal_force * velocity_derivative
+
+    steady_step = 1.0e12
+    flm = jnp.zeros((1, 1, layout.size, nv), dtype=jnp.complex128)
+    flm = flm.at[..., layout.index(0, 0), :].set(f0)
+    flm = flm.at[..., layout.index(1, 0), :].set(steady_step * streaming_source)
+    collision_grid = CollisionGrid(
+        xmin=0.0,
+        xmax=1.0,
+        nx=1,
+        tmin=0.0,
+        tmax=1.0,
+        dt=0.1,
+        nv=nv,
+        vmax=vmax,
+        nl=1,
+    )
+    operator = FLMCollisions(
+        Z=ionization,
+        nuee_coeff=collision_coefficient,
+        grid=collision_grid,
+        full_aniso_ee=False,
+    )
+    updated = AnisotropicCollisions(operator, layout)(
+        flm,
+        Z=jnp.ones((1, 1)),
+        ni=jnp.full((1, 1), electron_density / ionization),
+        dt=steady_step,
+    )
+    heat_flux = 0.5 * electron_density * vector_velocity_moment(updated, layout, v, dv, power=2)[0, 0, 0]
+
+    z_star = (ionization + 4.2) / (ionization + 0.24)
+    expected = (
+        -16.0
+        * (2.0 * temperature) ** 2.5
+        * temperature_gradient
+        / (np.sqrt(np.pi) * collision_coefficient * ionization * z_star)
+    )
+    return float(heat_flux), float(expected)
+
+
+def test_epperlein_haines_local_heat_flux_recovers_spitzer_harm_scaling():
+    coarse, expected = _local_eh_heat_flux(12)
+    fine, _expected = _local_eh_heat_flux(16)
+    coarse_error = abs(coarse - expected)
+    fine_error = abs(fine - expected)
+    assert coarse_error / fine_error > 40.0
+    np.testing.assert_allclose(fine, expected, rtol=2.0e-6)

--- a/tests/test_vfp2d/test_moving_frame.py
+++ b/tests/test_vfp2d/test_moving_frame.py
@@ -1,0 +1,207 @@
+"""Equation-level tests for the ion peculiar-velocity representation."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept.vfp2d import (
+    Grid,
+    HarmonicLayout,
+    IonFrameVlasov,
+    TzoufrasVlasov,
+    density,
+    scalar_velocity_moment,
+    tensor_velocity_moment,
+)
+
+
+def _make_problem(l_max=3, nx=4, ny=3, nv=96, vmax=7.0):
+    grid = Grid(
+        xmin=0.0,
+        xmax=2.0 * np.pi,
+        nx=nx,
+        ymin=0.0,
+        ymax=2.0 * np.pi,
+        ny=ny,
+        vmax=vmax,
+        nv=nv,
+        dt=0.01,
+        l_max=l_max,
+    )
+    layout = HarmonicLayout(l_max)
+    vlasov = TzoufrasVlasov(layout, grid.v, grid.dv, grid.kx, grid.ky)
+    frame = IonFrameVlasov(vlasov)
+    f = jnp.zeros((nx, ny, layout.size, nv), dtype=jnp.complex128)
+    f = f.at[..., layout.index(0, 0), :].set(jnp.exp(-(grid.v**2)))
+    return grid, layout, vlasov, frame, f
+
+
+def test_angular_galerkin_transform_round_trips_physical_coefficients():
+    _grid, layout, _vlasov, frame, f = _make_problem(l_max=9, nx=1, ny=1, nv=4)
+    rng = np.random.default_rng(42)
+    # Equal-amplitude normalized harmonics correspond to stored coefficients
+    # scaled by the inverse norm of ADEPT's unnormalized Legendre basis.
+    scale = np.asarray(frame.angular.coefficient_scale)
+    coefficients = (rng.normal(size=f.shape) + 1j * rng.normal(size=f.shape)) / scale[None, None, :, None]
+    for index, (_ell, m) in enumerate(layout.pairs):
+        if m == 0:
+            coefficients[..., index, :] = coefficients[..., index, :].real
+
+    reconstructed = frame.angular.reconstruct(jnp.asarray(coefficients))
+    projected = frame.angular.project(reconstructed)
+    np.testing.assert_allclose(
+        projected * scale[None, None, :, None],
+        coefficients * scale[None, None, :, None],
+        rtol=2e-12,
+        atol=2e-12,
+    )
+
+
+def test_bulk_advection_is_conservative_for_every_harmonic_and_speed_cell():
+    grid, layout, _vlasov, frame, f = _make_problem(l_max=2, nx=12, ny=10, nv=8)
+    xx, yy = jnp.meshgrid(grid.x, grid.y, indexing="ij")
+    f = f.at[..., layout.index(0, 0), :].multiply(1.0 + 0.1 * jnp.cos(xx)[..., None])
+    f = f.at[..., layout.index(1, 0), :].set(0.03 * jnp.sin(yy)[..., None] * jnp.exp(-(grid.v**2)))
+    velocity = jnp.stack((0.2 + 0.04 * jnp.sin(yy), -0.1 + 0.03 * jnp.cos(xx), 0.02 * jnp.sin(xx + yy)), axis=-1)
+
+    rate = frame.bulk_advection(f, velocity)
+    np.testing.assert_allclose(jnp.sum(rate, axis=(0, 1)), 0.0, atol=2e-13)
+
+
+def test_velocity_gradient_uses_component_by_derivative_index_order():
+    grid, _layout, _vlasov, frame, _f = _make_problem(l_max=1, nx=12, ny=10, nv=8)
+    xx, yy = jnp.meshgrid(grid.x, grid.y, indexing="ij")
+    velocity = jnp.stack((jnp.sin(xx), jnp.cos(yy), jnp.sin(xx + 2.0 * yy)), axis=-1)
+    gradient = frame.velocity_gradient(velocity)
+    expected = jnp.stack(
+        (
+            jnp.stack((jnp.cos(xx), jnp.zeros_like(xx), jnp.zeros_like(xx)), axis=-1),
+            jnp.stack((jnp.zeros_like(yy), -jnp.sin(yy), jnp.zeros_like(yy)), axis=-1),
+            jnp.stack((jnp.cos(xx + 2.0 * yy), 2.0 * jnp.cos(xx + 2.0 * yy), jnp.zeros_like(xx)), axis=-1),
+        ),
+        axis=-2,
+    )
+    np.testing.assert_allclose(gradient, expected, rtol=2e-12, atol=2e-12)
+
+
+def test_uniform_maxwellian_is_exact_under_galilean_translation():
+    _grid, _layout, _vlasov, frame, f = _make_problem(l_max=3)
+    velocity = jnp.broadcast_to(jnp.asarray([0.7, -0.25, 0.15]), (*f.shape[:2], 3))
+    zeros = jnp.zeros_like(velocity)
+    gradient = jnp.zeros((*f.shape[:2], 3, 3))
+
+    rate = frame(
+        f,
+        electric_field=zeros,
+        magnetic_field=zeros,
+        ion_velocity=velocity,
+        velocity_gradient=gradient,
+        material_acceleration=zeros,
+    )
+    np.testing.assert_allclose(rate, 0.0, atol=2e-13)
+
+
+def test_isotropic_compression_preserves_particles_and_heats_adiabatically():
+    grid, layout, _vlasov, frame, f = _make_problem(l_max=2, nx=2, ny=2, nv=192, vmax=8.0)
+    alpha = -0.2
+    gradient = jnp.broadcast_to(alpha * jnp.eye(3), (*f.shape[:2], 3, 3))
+    deformation = jax.jit(frame.deformation)(f, gradient)
+    theta = 3.0 * alpha
+
+    np.testing.assert_allclose(density(deformation, layout, grid.v, grid.dv), 0.0, atol=3e-13)
+
+    # A homogeneous fluid element also receives -div(u f) = -theta*f from
+    # conservative bulk transport. Together the moments obey n~rho and
+    # T~rho^(2/3), the ideal collisionally isotropic electron limit.
+    local_rate = deformation - theta * f
+    number = density(f, layout, grid.v, grid.dv)
+    number_rate = density(local_rate, layout, grid.v, grid.dv)
+    moment2 = scalar_velocity_moment(f, layout, grid.v, grid.dv, power=2)
+    f00_rate = jnp.real(local_rate[..., layout.index(0, 0), :])
+    moment2_numerator_rate = 4.0 * jnp.pi * jnp.sum(f00_rate * grid.v**4, axis=-1) * grid.dv
+    moment2_rate = moment2_numerator_rate / number - moment2 * number_rate / number
+    temperature = moment2 / 3.0
+    temperature_rate = moment2_rate / 3.0
+
+    np.testing.assert_allclose(number_rate, -theta * number, rtol=2e-13, atol=2e-13)
+    np.testing.assert_allclose(temperature_rate, -2.0 * alpha * temperature, rtol=2e-3, atol=2e-5)
+
+
+def test_prescribed_shear_generates_the_expected_pressure_anisotropy():
+    grid, layout, _vlasov, frame, f = _make_problem(l_max=2, nx=2, ny=2, nv=192, vmax=8.0)
+    strain_rate = 0.12
+    strain = jnp.diag(jnp.asarray([strain_rate, -strain_rate, 0.0]))
+    gradient = jnp.broadcast_to(strain, (*f.shape[:2], 3, 3))
+    deformation = frame.deformation(f, gradient)
+
+    np.testing.assert_allclose(density(deformation, layout, grid.v, grid.dv), 0.0, atol=3e-13)
+    generated_tensor = tensor_velocity_moment(f + deformation, layout, grid.v, grid.dv, power=0)
+    moment2 = scalar_velocity_moment(f, layout, grid.v, grid.dv, power=2)
+    expected = -(2.0 / 3.0) * moment2[..., None, None] * gradient
+    np.testing.assert_allclose(generated_tensor, expected, rtol=3e-3, atol=3e-5)
+
+
+def test_deformation_preserves_particles_for_an_anisotropic_distribution():
+    grid, layout, _vlasov, frame, f = _make_problem(l_max=4, nx=2, ny=2, nv=48)
+    rng = np.random.default_rng(19)
+    for index, (ell, m) in enumerate(layout.pairs[1:], start=1):
+        radial = grid.v**ell * jnp.exp(-(grid.v**2))
+        coefficient = rng.normal() if m == 0 else rng.normal() + 1j * rng.normal()
+        f = f.at[..., index, :].set(0.01 * coefficient * radial)
+    gradient = jnp.broadcast_to(
+        jnp.asarray(
+            [
+                [0.08, -0.03, 0.02],
+                [0.04, -0.05, 0.01],
+                [-0.02, 0.03, 0.06],
+            ]
+        ),
+        (*f.shape[:2], 3, 3),
+    )
+
+    rate = frame.deformation(f, gradient)
+    np.testing.assert_allclose(density(rate, layout, grid.v, grid.dv), 0.0, atol=2e-12)
+
+
+def test_rigid_frame_rotation_matches_the_existing_angular_rotation_operator():
+    grid, layout, vlasov, frame, f = _make_problem(l_max=4, nx=2, ny=2, nv=32)
+    rng = np.random.default_rng(7)
+    for index, (ell, m) in enumerate(layout.pairs):
+        radial = grid.v**ell * jnp.exp(-(grid.v**2))
+        coefficient = rng.normal() if m == 0 else rng.normal() + 1j * rng.normal()
+        f = f.at[..., index, :].set(coefficient * radial)
+
+    angular_frequency = 0.17
+    rotation_gradient = jnp.asarray(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, -angular_frequency],
+            [0.0, angular_frequency, 0.0],
+        ]
+    )
+    gradient = jnp.broadcast_to(rotation_gradient, (*f.shape[:2], 3, 3))
+    magnetic_field = jnp.broadcast_to(jnp.asarray([-angular_frequency, 0.0, 0.0]), (*f.shape[:2], 3))
+
+    np.testing.assert_allclose(
+        frame.deformation(f, gradient),
+        vlasov.magnetic(f, magnetic_field),
+        rtol=3e-12,
+        atol=3e-12,
+    )
+
+
+def test_accelerating_frame_cancels_a_uniform_force_equilibrium():
+    _grid, _layout, _vlasov, frame, f = _make_problem(l_max=3)
+    force = jnp.broadcast_to(jnp.asarray([0.15, -0.08, 0.04]), (*f.shape[:2], 3))
+    zeros = jnp.zeros_like(force)
+    gradient = jnp.zeros((*f.shape[:2], 3, 3))
+
+    rate = frame(
+        f,
+        electric_field=force,
+        magnetic_field=zeros,
+        ion_velocity=zeros,
+        velocity_gradient=gradient,
+        material_acceleration=-force,
+    )
+    np.testing.assert_allclose(rate, 0.0, atol=2e-13)

--- a/tests/test_vfp2d/test_moving_frame.py
+++ b/tests/test_vfp2d/test_moving_frame.py
@@ -57,6 +57,25 @@ def test_angular_galerkin_transform_round_trips_physical_coefficients():
     )
 
 
+def test_sparse_deformation_matches_dense_galerkin_oracle():
+    _grid, layout, _vlasov, frame, f = _make_problem(l_max=5, nx=2, ny=1, nv=18)
+    rng = np.random.default_rng(123)
+    coefficients = rng.normal(size=f.shape) + 1j * rng.normal(size=f.shape)
+    for index, (_ell, m) in enumerate(layout.pairs):
+        if m == 0:
+            coefficients[..., index, :] = coefficients[..., index, :].real
+    f = jnp.asarray(coefficients)
+    gradient = jnp.asarray(rng.normal(scale=0.07, size=(*f.shape[:2], 3, 3)))
+
+    sparse = jax.jit(frame.deformation)(f, gradient)
+    dense = frame.deformation_reference(f, gradient)
+    np.testing.assert_allclose(sparse, dense, rtol=4e-12, atol=4e-12)
+
+    number_real_harmonics = (layout.l_max + 1) ** 2
+    dense_entries = 2 * 9 * number_real_harmonics**2
+    assert frame.sparse_angular.nnz < 0.3 * dense_entries
+
+
 def test_bulk_advection_is_conservative_for_every_harmonic_and_speed_cell():
     grid, layout, _vlasov, frame, f = _make_problem(l_max=2, nx=12, ny=10, nv=8)
     xx, yy = jnp.meshgrid(grid.x, grid.y, indexing="ij")

--- a/tests/test_vfp2d/test_pressure.py
+++ b/tests/test_vfp2d/test_pressure.py
@@ -1,0 +1,128 @@
+"""Electron-pressure feedback and pressure-work budget tests."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from adept.vfp2d import (
+    ElectronPressureCoupling,
+    Grid,
+    HarmonicLayout,
+    IonFrameVlasov,
+    TzoufrasVlasov,
+    electron_kinetic_energy_density,
+    electron_pressure_tensor,
+    primitive_to_conserved,
+    scalar_velocity_moment,
+)
+
+
+def _make_problem(nx=16, ny=12, nv=160):
+    grid = Grid(
+        xmin=0.0,
+        xmax=2.0 * np.pi,
+        nx=nx,
+        ymin=0.0,
+        ymax=2.0 * np.pi,
+        ny=ny,
+        vmax=8.0,
+        nv=nv,
+        dt=1.0e-3,
+        l_max=2,
+    )
+    layout = HarmonicLayout(2)
+    vlasov = TzoufrasVlasov(layout, grid.v, grid.dv, grid.kx, grid.ky)
+    frame = IonFrameVlasov(vlasov)
+    x, y = grid.x[:, None], grid.y[None, :]
+    electron_density = 1.0 + 0.08 * jnp.cos(x) * jnp.sin(y)
+    radial = jnp.exp(-(grid.v**2))
+    radial /= 4.0 * jnp.pi * jnp.sum(radial * grid.v**2) * grid.dv
+    f = jnp.zeros((nx, ny, layout.size, nv), dtype=jnp.complex128)
+    f = f.at[..., layout.index(0, 0), :].set(electron_density[..., None] * radial)
+    anisotropy = 0.018 * jnp.sin(2.0 * x - y)
+    f = f.at[..., layout.index(2, 0), :].set(anisotropy[..., None] * grid.v**2 * radial)
+    f = f.at[..., layout.index(2, 1), :].set((0.5 - 0.3j) * anisotropy[..., None] * grid.v**2 * radial)
+
+    ion_velocity = jnp.stack(
+        jnp.broadcast_arrays(
+            0.12 * jnp.sin(x) * jnp.cos(y),
+            -0.09 * jnp.cos(x) * jnp.sin(y),
+            0.05 * jnp.sin(x + y),
+        ),
+        axis=-1,
+    )
+    ion_primitive = jnp.concatenate(
+        (
+            (100.0 * electron_density)[..., None],
+            ion_velocity,
+            (0.2 * electron_density)[..., None],
+        ),
+        axis=-1,
+    )
+    return grid, layout, frame, f, primitive_to_conserved(ion_primitive)
+
+
+def test_pressure_tensor_recovers_scalar_f0_and_traceless_f2_parts():
+    grid, layout, _frame, f, _ions = _make_problem(nx=4, ny=3)
+    isotropic = f.at[..., layout.index(2, 0), :].set(0.0)
+    isotropic = isotropic.at[..., layout.index(2, 1), :].set(0.0)
+    pressure = electron_pressure_tensor(isotropic, layout, grid.v, grid.dv)
+    scalar_pressure = (
+        4.0
+        * jnp.pi
+        * jnp.sum(jnp.real(isotropic[..., layout.index(0, 0), :]) * grid.v**2, axis=-1)
+        * grid.dv
+        * scalar_velocity_moment(isotropic, layout, grid.v, grid.dv, power=2)
+        / 3.0
+    )
+    expected = scalar_pressure[..., None, None] * jnp.eye(3)
+    np.testing.assert_allclose(pressure, expected, rtol=2e-13, atol=2e-13)
+
+    full_pressure = electron_pressure_tensor(f, layout, grid.v, grid.dv)
+    np.testing.assert_allclose(full_pressure, jnp.swapaxes(full_pressure, -1, -2), rtol=0.0, atol=0.0)
+    np.testing.assert_allclose(jnp.trace(full_pressure, axis1=-2, axis2=-1), 3.0 * scalar_pressure, rtol=2e-13)
+
+
+def test_pressure_feedback_closes_periodic_deformation_work_budget():
+    grid, _layout, frame, f, ions = _make_problem()
+    pressure = ElectronPressureCoupling(frame)
+    electron_rate, ion_rate, diagnostics = jax.jit(pressure)(f, ions)
+    velocity = ions[..., 1:4] / ions[..., :1]
+    deformation_rate = frame.deformation(f, frame.velocity_gradient(velocity))
+    measured_electron_work = electron_kinetic_energy_density(
+        deformation_rate,
+        frame.layout,
+        grid.v,
+        grid.dv,
+    )
+
+    local_defect = jnp.max(jnp.abs(measured_electron_work - diagnostics["electron_deformation_work"]))
+    work_scale = jnp.max(jnp.abs(diagnostics["electron_deformation_work"]))
+    assert local_defect / work_scale < 3.0e-3
+    np.testing.assert_allclose(jnp.sum(ion_rate[..., 1:4], axis=(0, 1)), 0.0, atol=3e-13)
+    total_work = jnp.sum(measured_electron_work + ion_rate[..., 4]) * grid.dx * grid.dy
+    np.testing.assert_allclose(total_work, 0.0, atol=3e-12)
+    np.testing.assert_allclose(
+        electron_kinetic_energy_density(electron_rate, frame.layout, grid.v, grid.dv) + ion_rate[..., 4],
+        0.0,
+        atol=3e-13,
+    )
+
+
+def test_pressure_work_radial_defect_converges_at_second_order():
+    defects = []
+    for nv in (80, 160):
+        grid, _layout, frame, f, ions = _make_problem(nx=8, ny=6, nv=nv)
+        pressure = ElectronPressureCoupling(frame)
+        _electron_rate, _ion_rate, diagnostics = pressure(f, ions)
+        velocity = ions[..., 1:4] / ions[..., :1]
+        deformation_rate = frame.deformation(f, frame.velocity_gradient(velocity))
+        measured_work = electron_kinetic_energy_density(
+            deformation_rate,
+            frame.layout,
+            grid.v,
+            grid.dv,
+        )
+        defects.append(jnp.max(jnp.abs(measured_work - diagnostics["electron_deformation_work"])))
+
+    assert defects[0] / defects[1] > 3.8


### PR DESCRIPTION
## Summary

- add the Gate 0a standalone 2D ideal-ion MUSCL-HLLC finite-volume backbone
- close Gate 0b with quantitative Riemann, translating-vortex, Sedov, and magnetic-divergence benchmarks
- add Gate 1 ion-frame electron operators for bulk transport, deformation, frame acceleration, and local finite-mass exchange
- add the Gate 2a/2b ion-kinetic split with finite-mass remapping, full kinetic electron-pressure feedback, and sparse high-harmonic deformation operators
- close the nonlinear coupled-energy gate under timestep and spatial/radial refinement
- add a field-solver hierarchy: physical explicit Maxwell, slowed explicit Ampere, OSHUN-style implicit current response, and kinetic Ohm

## Field-solver hierarchy

- `maxwell` remains the physical fully explicit Vlasov-Maxwell mode.
- `ampere` uses a configurable `relative_permittivity >= 1` to divide the complete Ampere residual. This slows the light and plasma frequencies by `sqrt(relative_permittivity)` without changing the steady target `J = c^2 curl(B)`. Its saved electric-field energy uses the corresponding permittivity weight.
- `oshun-implicit` advances Faraday explicitly, constructs the local discrete 3x3 kinetic response `dJ_i/dE_j`, and directly solves for the electric field that makes the updated distribution satisfy `J = c^2 curl(B)`. It updates the full harmonic distribution through the Vlasov force operator rather than projecting `f1`.
- `kinetic-ohm` remains the long-timescale algebraic closure used by the moving-ion path.

The OSHUN-style mode is an implicit kinetic-current response, not a fully implicit Maxwell solve. It and the slowed-Ampere mode are currently stationary-ion capabilities; moving-ion coupling remains restricted to kinetic Ohm. The implicit mode is also intentionally rejected under spatial sharding until a distributed response solve is validated.

Saved outputs now include the Ampere target current, pointwise residual, residual Linf history, magnetic field energy, solver mode, and relative permittivity. Explicit modes additionally save electric and total electromagnetic field energy.

## Nonlinear energy gate

The coupled map is now the symmetric composition

1. ion hydro half-step;
2. coupled pressure/exchange half-step;
3. full kinetic-electron step at midpoint ion kinematics;
4. coupled pressure/exchange half-step; and
5. ion hydro half-step.

The kinetic-Ohm Ampere projection changes only `f1`, but in a moving ion frame that changes lab-frame electron energy by `u_i . Delta p_e`. Runs now accumulate that projection work explicitly and save both `total_energy` and `accounted_total_energy = total_energy - current_projection_energy`. A direct unit test compares the ledger to the independently measured lab-frame energy jump.

The nonlinear periodic benchmark evolves nonuniform electron density and temperature, accelerates the ions through the full `f0 + f2` electron pressure, and generates magnetic field. Its declared accounted-energy tolerance is `3.1e-9`:

- the tolerance is met for `dt = 2e-3, 1e-3, 5e-4`;
- ion-velocity and magnetic observables converge above order 1.8 in time;
- the energy defect decreases by more than 8x from `nv = 24` to `nv = 96`; and
- the energy defect decreases by more than 8x from `nx = 6` to `nx = 12`.

## Gate 0b benchmarks

- Sod and pressure-ratio `1e5` strong-shock tubes are compared with an exact Euler Riemann solution on both coordinate axes; normalized L1 tolerances are 3.5% and 12%, respectively.
- A translating isentropic vortex converges above order 1.7 from 24x24 to 48x48.
- A Cartesian Sedov blast preserves total energy to roundoff, stays positive and transpose-symmetric, and keeps fourfold kinetic-shell anisotropy below 5%.
- A divergence-free magnetic field remains divergence-free through 24 nontrivial Faraday updates to `2e-12` absolute tolerance.

## Physics demonstrated

- exact frozen-ion regression to the kinetic-Ohm solver when `u_i = 0`
- analytic ideal bulk magnetic advection with no magnetic-divergence source
- finite-mass velocity-frame translation preserving electron density and lab-frame momentum/energy to roundoff
- symmetric momentum, temperature, and electron-pressure exchange preserving coupled lab-frame invariants
- scalar `f0` plus traceless `f2` electron pressure and equal-and-opposite pressure work
- classical local-Maxwellian Biermann generation with spectral convergence
- Epperlein-Haines `Z*` response recovering the analytic Spitzer-Harm `T^(5/2)` heat-flux coefficient
- Galilean, compression, shear/`f2`, rigid-rotation, and accelerating-frame checks
- exact slowed-Ampere residual scaling with unchanged Faraday response
- direct OSHUN response-tensor agreement, nonprojective harmonic evolution, explicit Faraday update, and machine-precision quasineutral Ampere enforcement

## Explicit boundary

This remains a draft and is not ready for production parameter scans. Moving-ion production is still periodic, nonrelativistic, unsharded, kinetic-Ohm, and quasineutral. `ElectronIonExchange` remains a weak-drift moment model rather than a full finite-mass Landau operator. Nonperiodic coupled boundaries and production-scale validation remain future gates.

## Verification

- `uv run pytest -q tests/test_vfp2d` -- 72 passed
- GitHub Actions `test-vfp2d` -- 72 passed
- focused field-solver/operator and configuration tests -- 6 passed
- `uvx ruff check` on all touched solver and test files -- passed
- `uvx ruff format --check` on all touched solver and test files -- passed
- `git diff --check` -- passed

The earlier repository-wide non-slow run was interrupted after 7 passing tests because the existing `test_reuse_config_dict` path remained in `urllib3` network retry for four minutes. The complete relevant VFP2D suite is green.
