### PR TITLE
refactor(core): add explicit preparation contracts and solver registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,17 @@ Existing examples: `feat/vlasov1d-dougherty-nodrag`, `fix/vlasov1d-v0-units`, `f
 Commit subjects carry the same scope: `feat(vlasov1d): ...`.
 For repo-wide work with no solver (CI, docs, packaging), use the area instead: `ci/...`, `docs/...`, `chore/...`.
 
-## Everything is built on ergoExo
+## Legacy execution is built on ergoExo
 
 Solvers are never invoked directly. `ergoExo` (`adept/_base_.py`) owns the run: it creates the MLflow run and
 calls lifecycle methods on an `ADEPTModule` subclass in a fixed order. When adding or modifying a solver, work
-inside that contract rather than around it.
+inside that contract rather than around it unless the change is explicitly migrating the solver to the new
+architecture in `docs/adr/0001-explicit-simulation-boundaries.md`.
+
+New architecture work uses the logging-free contracts in `adept.core`. Do not add new tracking, artifact,
+filesystem, or process-global behavior to a `SolverBuilder` or `JaxProgram`. Existing `ergoExo` and
+`ADEPTModule` behavior remains compatibility-sensitive until it is replaced by the tested façade described in
+the ADR.
 
 Order — `ergoExo#_setup_()`, then `ergoExo#__call__()`:
 
@@ -34,9 +40,11 @@ Consequences that bite:
   first appear in `init_state_and_args()` if nothing put it in `cfg` during `get_solver_quantities()`.
 - The scalar/array split between steps 2 and 3 is load-bearing — arrays leaking into step 2 break param logging.
 - Gradients go through `vg()`; the base class raises unless the module implements a metric.
-- `ergoExo#_get_adept_module_()` is the registry: a hand-written branch mapping the `solver:` string to a class,
-  with no autodiscovery. One module directory can register several keys (`vlasov-1d` → `BaseVlasov1D`,
-  `vlasov-1d-iaw` → `IAWTurbulence1D`), so add a key per runnable module, not per directory.
+- `ergoExo#_get_adept_module_()` is the legacy registry: a hand-written branch mapping the `solver:` string to a
+  class, with no autodiscovery. One module directory can register several keys (`vlasov-1d` → `BaseVlasov1D`,
+  `vlasov-1d-iaw` → `IAWTurbulence1D`), so add a key per runnable module, not per directory. New logging-free
+  builders register stable names with `adept.core.SolverRegistry`; do not route an incomplete builder into
+  `ergoExo` before compatibility coverage exists.
 
 `docs/source/dev_guide.md` has the step-by-step for adding a solver — follow it rather than reconstructing the
 list. The step easiest to skip is the paths filter and job in `.github/workflows/cpu-tests.yaml`: CI only runs

--- a/adept/__init__.py
+++ b/adept/__init__.py
@@ -1,3 +1,76 @@
-from ._base_ import ADEPTModule, ergoExo  # noqa: I001
-from .mlflow_logging import MlflowLoggingModule
-from . import hermite_legendre_1d, hermite_poisson_1d, lpse2d, vfp2d, vlasov1d, vlasov2d
+"""ADEPT's public API.
+
+The architecture contracts are safe to import in configuration and submission
+processes. Legacy simulation and solver symbols remain available, but are resolved
+lazily because they intentionally bring in JAX and MLflow.
+"""
+
+from importlib import import_module
+from typing import Any
+
+from .core import (
+    Analyzer,
+    ExecutionKind,
+    JaxProgram,
+    Placement,
+    Precision,
+    PreparedSimulation,
+    RunManifest,
+    SimulationSpec,
+    SolverBuilder,
+    SolverCapabilities,
+    SolverRegistry,
+    solver_registry,
+)
+
+_LAZY_ATTRIBUTES = {
+    "ADEPTModule": ("._base_", "ADEPTModule"),
+    "MlflowLoggingModule": (".mlflow_logging", "MlflowLoggingModule"),
+    "ergoExo": ("._base_", "ergoExo"),
+    "hermite_legendre_1d": (".hermite_legendre_1d", None),
+    "hermite_poisson_1d": (".hermite_poisson_1d", None),
+    "lpse2d": (".lpse2d", None),
+    "vfp2d": (".vfp2d", None),
+    "vlasov1d": (".vlasov1d", None),
+    "vlasov2d": (".vlasov2d", None),
+}
+
+__all__ = [
+    "ADEPTModule",
+    "Analyzer",
+    "ExecutionKind",
+    "JaxProgram",
+    "MlflowLoggingModule",
+    "Placement",
+    "Precision",
+    "PreparedSimulation",
+    "RunManifest",
+    "SimulationSpec",
+    "SolverBuilder",
+    "SolverCapabilities",
+    "SolverRegistry",
+    "ergoExo",
+    "hermite_legendre_1d",
+    "hermite_poisson_1d",
+    "lpse2d",
+    "solver_registry",
+    "vfp2d",
+    "vlasov1d",
+    "vlasov2d",
+]
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attribute_name = _LAZY_ATTRIBUTES[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    module = import_module(module_name, __name__)
+    value = module if attribute_name is None else getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/adept/core/__init__.py
+++ b/adept/core/__init__.py
@@ -1,0 +1,44 @@
+"""Public, side-effect-free contracts for preparing ADEPT simulations.
+
+Importing this package deliberately uses only the Python standard library. Numerical
+solver implementations, JAX, and tracking backends are loaded by registered builders
+only when a simulation is prepared or executed.
+"""
+
+from .contracts import (
+    Analyzer,
+    ExecutionKind,
+    JaxProgram,
+    Placement,
+    Precision,
+    PreparedSimulation,
+    RunManifest,
+    SimulationSpec,
+    SolverBuilder,
+    SolverCapabilities,
+)
+from .registry import (
+    InvalidSolverNameError,
+    SolverAlreadyRegisteredError,
+    SolverRegistry,
+    UnknownSolverError,
+    solver_registry,
+)
+
+__all__ = [
+    "Analyzer",
+    "ExecutionKind",
+    "InvalidSolverNameError",
+    "JaxProgram",
+    "Placement",
+    "Precision",
+    "PreparedSimulation",
+    "RunManifest",
+    "SimulationSpec",
+    "SolverAlreadyRegisteredError",
+    "SolverBuilder",
+    "SolverCapabilities",
+    "SolverRegistry",
+    "UnknownSolverError",
+    "solver_registry",
+]

--- a/adept/core/contracts.py
+++ b/adept/core/contracts.py
@@ -1,0 +1,315 @@
+"""Host-side contracts shared by ADEPT builders and numerical programs.
+
+This module must remain importable without JAX, Equinox, MLflow, or a configured
+runtime. Array and PRNG-key types are generic so concrete builders can use JAX types
+without making specification and registry consumers import JAX themselves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any, Generic, Protocol, TypeVar, runtime_checkable
+
+
+class ExecutionKind(StrEnum):
+    """Kind of state transition implemented by a solver program."""
+
+    CONTINUOUS = "continuous"
+    DISCRETE = "discrete"
+    EXTERNAL = "external"
+
+
+class Precision(StrEnum):
+    """Numerical precision requirement advertised by a solver."""
+
+    DEFAULT = "default"
+    X64 = "x64"
+
+
+class Placement(StrEnum):
+    """Execution placements a prepared solver can support."""
+
+    SINGLE_DEVICE = "single-device"
+    MULTI_DEVICE = "multi-device"
+    MULTI_HOST = "multi-host"
+    EXTERNAL = "external"
+
+
+@dataclass(frozen=True, slots=True)
+class SolverCapabilities:
+    """Capabilities used later by executors for compatibility preflight."""
+
+    execution_kind: ExecutionKind
+    precision: Precision = Precision.DEFAULT
+    differentiable: bool = False
+    batchable: bool = False
+    placements: frozenset[Placement] = field(default_factory=lambda: frozenset({Placement.SINGLE_DEVICE}))
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "execution_kind", ExecutionKind(self.execution_kind))
+        object.__setattr__(self, "precision", Precision(self.precision))
+        object.__setattr__(self, "placements", frozenset(Placement(value) for value in self.placements))
+        if not self.placements:
+            raise ValueError("A solver must support at least one execution placement")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON/YAML-friendly representation."""
+
+        return {
+            "execution_kind": self.execution_kind.value,
+            "precision": self.precision.value,
+            "differentiable": self.differentiable,
+            "batchable": self.batchable,
+            "placements": sorted(placement.value for placement in self.placements),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SolverCapabilities:
+        """Restore capabilities from :meth:`to_dict` output."""
+
+        copied = _copy_mapping(value, name="capabilities")
+        try:
+            execution_kind = copied.pop("execution_kind")
+        except KeyError as exc:
+            raise ValueError("Capabilities are missing required 'execution_kind'") from exc
+        placements = copied.pop("placements", [Placement.SINGLE_DEVICE])
+        try:
+            capabilities = cls(execution_kind=execution_kind, placements=frozenset(placements), **copied)
+        except TypeError as exc:
+            raise ValueError(f"Invalid capabilities fields: {exc}") from exc
+        return capabilities
+
+
+def _copy_mapping(value: Mapping[str, Any], *, name: str) -> dict[str, Any]:
+    copied = deepcopy(dict(value))
+    non_string_keys = [key for key in copied if not isinstance(key, str)]
+    if non_string_keys:
+        raise TypeError(f"{name} keys must be strings; received {non_string_keys!r}")
+    return copied
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class SimulationSpec:
+    """Validated solver intent, independent of tracking and runtime services.
+
+    The stored configuration is defensive-copied. ``config`` and ``to_dict`` return
+    fresh copies, so a caller can reuse or mutate its original YAML dictionary without
+    changing an existing specification.
+    """
+
+    solver: str
+    schema_version: str
+    _config: dict[str, Any] = field(repr=False)
+
+    def __init__(self, solver: str, config: Mapping[str, Any], schema_version: str = "1") -> None:
+        solver = solver.strip()
+        schema_version = str(schema_version).strip()
+        if not solver:
+            raise ValueError("solver must be a non-empty stable registry name")
+        if not schema_version:
+            raise ValueError("schema_version must be non-empty")
+
+        copied = _copy_mapping(config, name="config")
+        reserved = sorted({"solver", "mlflow"}.intersection(copied))
+        if reserved:
+            joined = ", ".join(reserved)
+            raise ValueError(f"SimulationSpec config contains reserved host-side keys: {joined}")
+
+        object.__setattr__(self, "solver", solver)
+        object.__setattr__(self, "schema_version", schema_version)
+        object.__setattr__(self, "_config", copied)
+
+    @classmethod
+    def from_legacy_config(cls, config: Mapping[str, Any], *, schema_version: str = "1") -> SimulationSpec:
+        """Adapt an existing ADEPT YAML mapping without retaining MLflow settings."""
+
+        copied = _copy_mapping(config, name="legacy config")
+        try:
+            solver = copied.pop("solver")
+        except KeyError as exc:
+            raise ValueError("Legacy ADEPT config is missing required 'solver' key") from exc
+        copied.pop("mlflow", None)
+        return cls(str(solver), copied, schema_version)
+
+    @property
+    def config(self) -> Mapping[str, Any]:
+        """Return a read-only defensive copy of the solver configuration."""
+
+        return MappingProxyType(deepcopy(self._config))
+
+    def config_dict(self) -> dict[str, Any]:
+        """Return a mutable defensive copy for a builder to validate or adapt."""
+
+        return deepcopy(self._config)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON/YAML-friendly representation of the specification."""
+
+        return {
+            "solver": self.solver,
+            "schema_version": self.schema_version,
+            "config": self.config_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SimulationSpec:
+        """Restore a specification from :meth:`to_dict` output."""
+
+        copied = _copy_mapping(value, name="specification")
+        try:
+            solver = copied.pop("solver")
+            config = copied.pop("config")
+        except KeyError as exc:
+            raise ValueError(f"Serialized specification is missing required {exc.args[0]!r} field") from exc
+        schema_version = copied.pop("schema_version", "1")
+        if copied:
+            raise ValueError(f"Serialized specification contains unknown fields: {sorted(copied)!r}")
+        if not isinstance(config, Mapping):
+            raise TypeError("Serialized specification 'config' must be a mapping")
+        return cls(str(solver), config, str(schema_version))
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class RunManifest:
+    """Reproducibility metadata produced during deterministic preparation."""
+
+    structural_fingerprint: str
+    seed: int | None
+    key_provenance: str | None
+    _raw_config: dict[str, Any] = field(repr=False)
+    _resolved_config: dict[str, Any] = field(repr=False)
+    _units: dict[str, Any] = field(repr=False)
+    _code: dict[str, Any] = field(repr=False)
+    _dependencies: dict[str, Any] = field(repr=False)
+
+    def __init__(
+        self,
+        *,
+        raw_config: Mapping[str, Any],
+        resolved_config: Mapping[str, Any],
+        structural_fingerprint: str,
+        units: Mapping[str, Any] | None = None,
+        seed: int | None = None,
+        key_provenance: str | None = None,
+        code: Mapping[str, Any] | None = None,
+        dependencies: Mapping[str, Any] | None = None,
+    ) -> None:
+        structural_fingerprint = structural_fingerprint.strip()
+        if not structural_fingerprint:
+            raise ValueError("structural_fingerprint must be non-empty")
+
+        object.__setattr__(self, "structural_fingerprint", structural_fingerprint)
+        object.__setattr__(self, "seed", seed)
+        object.__setattr__(self, "key_provenance", key_provenance)
+        object.__setattr__(self, "_raw_config", _copy_mapping(raw_config, name="raw_config"))
+        object.__setattr__(self, "_resolved_config", _copy_mapping(resolved_config, name="resolved_config"))
+        object.__setattr__(self, "_units", _copy_mapping(units or {}, name="units"))
+        object.__setattr__(self, "_code", _copy_mapping(code or {}, name="code"))
+        object.__setattr__(self, "_dependencies", _copy_mapping(dependencies or {}, name="dependencies"))
+
+    @staticmethod
+    def _view(value: dict[str, Any]) -> Mapping[str, Any]:
+        return MappingProxyType(deepcopy(value))
+
+    @property
+    def raw_config(self) -> Mapping[str, Any]:
+        return self._view(self._raw_config)
+
+    @property
+    def resolved_config(self) -> Mapping[str, Any]:
+        return self._view(self._resolved_config)
+
+    @property
+    def units(self) -> Mapping[str, Any]:
+        return self._view(self._units)
+
+    @property
+    def code(self) -> Mapping[str, Any]:
+        return self._view(self._code)
+
+    @property
+    def dependencies(self) -> Mapping[str, Any]:
+        return self._view(self._dependencies)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serialization-friendly representation of the manifest."""
+
+        return {
+            "raw_config": deepcopy(self._raw_config),
+            "resolved_config": deepcopy(self._resolved_config),
+            "units": deepcopy(self._units),
+            "seed": self.seed,
+            "key_provenance": self.key_provenance,
+            "code": deepcopy(self._code),
+            "dependencies": deepcopy(self._dependencies),
+            "structural_fingerprint": self.structural_fingerprint,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RunManifest:
+        """Restore a manifest from :meth:`to_dict` output."""
+
+        copied = _copy_mapping(value, name="manifest")
+        try:
+            return cls(**copied)
+        except TypeError as exc:
+            raise ValueError(f"Invalid manifest fields: {exc}") from exc
+
+
+ProgramT = TypeVar("ProgramT")
+ParamsT = TypeVar("ParamsT")
+StateT = TypeVar("StateT")
+InputsT = TypeVar("InputsT")
+AnalyzerT = TypeVar("AnalyzerT")
+ProgramParamsT = TypeVar("ProgramParamsT", contravariant=True)
+ProgramStateT = TypeVar("ProgramStateT", contravariant=True)
+ProgramInputsT = TypeVar("ProgramInputsT", contravariant=True)
+KeyT = TypeVar("KeyT", contravariant=True)
+RawResultT = TypeVar("RawResultT", covariant=True)
+AnalyzedResultT = TypeVar("AnalyzedResultT", contravariant=True)
+ReportT = TypeVar("ReportT", covariant=True)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedSimulation(Generic[ProgramT, ParamsT, StateT, InputsT, AnalyzerT]):
+    """Explicit output of solver preparation.
+
+    The container cannot be mutated. Numerical PyTrees held by it are governed by the
+    same no-in-place-mutation rule as JAX inputs and can be replaced with
+    ``dataclasses.replace`` when constructing a modified simulation.
+    """
+
+    program: ProgramT
+    params: ParamsT
+    state: StateT
+    inputs: InputsT
+    manifest: RunManifest
+    analyzer: AnalyzerT
+    capabilities: SolverCapabilities
+
+
+@runtime_checkable
+class JaxProgram(Protocol[ProgramParamsT, ProgramStateT, ProgramInputsT, KeyT, RawResultT]):
+    """Pure numerical call boundary; concrete implementations are JAX PyTrees."""
+
+    def __call__(
+        self, params: ProgramParamsT, state: ProgramStateT, inputs: ProgramInputsT, key: KeyT
+    ) -> RawResultT: ...
+
+
+@runtime_checkable
+class Analyzer(Protocol[AnalyzedResultT, ReportT]):
+    """Host-side conversion of a numerical result into metrics and artifacts."""
+
+    def analyze(self, result: AnalyzedResultT, manifest: RunManifest) -> ReportT: ...
+
+
+@runtime_checkable
+class SolverBuilder(Protocol[KeyT]):
+    """Logging-free factory for an explicit prepared simulation."""
+
+    def prepare(self, spec: SimulationSpec, *, key: KeyT) -> PreparedSimulation[Any, Any, Any, Any, Any]: ...

--- a/adept/core/registry.py
+++ b/adept/core/registry.py
@@ -1,0 +1,124 @@
+"""Public registry for logging-free ADEPT solver builders."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from threading import RLock
+from typing import Any
+
+from .contracts import PreparedSimulation, SimulationSpec, SolverBuilder
+
+_STABLE_NAME = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+
+
+class InvalidSolverNameError(ValueError):
+    """Raised when a registry key is not a stable kebab-case solver name."""
+
+
+class SolverAlreadyRegisteredError(ValueError):
+    """Raised when registration would silently replace an existing builder."""
+
+
+class UnknownSolverError(LookupError):
+    """Raised when no builder is registered for a requested solver name."""
+
+
+class SolverRegistry:
+    """Map stable solver names to builder instances or lazy builder factories."""
+
+    def __init__(self) -> None:
+        self._builders: dict[str, SolverBuilder[Any]] = {}
+        self._lazy_factories: dict[str, Callable[[], SolverBuilder[Any]]] = {}
+        self._lock = RLock()
+
+    @staticmethod
+    def _validate_name(name: str) -> str:
+        name = name.strip()
+        if not _STABLE_NAME.fullmatch(name):
+            raise InvalidSolverNameError(
+                f"Invalid solver name {name!r}; expected lowercase kebab-case such as 'vlasov-1d'"
+            )
+        return name
+
+    def _ensure_available(self, name: str) -> None:
+        if name in self._builders or name in self._lazy_factories:
+            raise SolverAlreadyRegisteredError(
+                f"Solver {name!r} is already registered; unregister it explicitly before replacing its builder"
+            )
+
+    def register(self, name: str, builder: SolverBuilder[Any]) -> SolverBuilder[Any]:
+        """Register an already-constructed builder without importing other solvers."""
+
+        name = self._validate_name(name)
+        if not isinstance(builder, SolverBuilder):
+            raise TypeError(f"Builder for {name!r} must implement prepare(spec, *, key)")
+        with self._lock:
+            self._ensure_available(name)
+            self._builders[name] = builder
+        return builder
+
+    def register_lazy(self, name: str, factory: Callable[[], SolverBuilder[Any]]) -> None:
+        """Register a factory that imports and constructs its builder on first use."""
+
+        name = self._validate_name(name)
+        if not callable(factory):
+            raise TypeError(f"Lazy builder factory for {name!r} must be callable")
+        with self._lock:
+            self._ensure_available(name)
+            self._lazy_factories[name] = factory
+
+    def unregister(self, name: str) -> None:
+        """Remove a registration, primarily for isolated application/plugin setup."""
+
+        with self._lock:
+            if name not in self._builders and name not in self._lazy_factories:
+                raise self._unknown_solver(name)
+            self._builders.pop(name, None)
+            self._lazy_factories.pop(name, None)
+
+    def names(self) -> tuple[str, ...]:
+        """Return all registered names in stable order without loading builders."""
+
+        with self._lock:
+            return tuple(sorted(self._builders.keys() | self._lazy_factories.keys()))
+
+    def _unknown_solver(self, name: str) -> UnknownSolverError:
+        available = ", ".join(self.names()) or "<none>"
+        return UnknownSolverError(f"Unknown solver {name!r}. Registered solvers: {available}")
+
+    def resolve(self, name: str) -> SolverBuilder[Any]:
+        """Resolve a builder, loading and caching a lazy registration once."""
+
+        name = self._validate_name(name)
+        with self._lock:
+            if name in self._builders:
+                return self._builders[name]
+            try:
+                factory = self._lazy_factories[name]
+            except KeyError as exc:
+                raise self._unknown_solver(name) from exc
+
+            builder = factory()
+            if not isinstance(builder, SolverBuilder):
+                raise TypeError(f"Lazy factory for {name!r} returned an object without prepare(spec, *, key)")
+            self._builders[name] = builder
+            del self._lazy_factories[name]
+            return builder
+
+    def prepare(self, spec: SimulationSpec, *, key: Any) -> PreparedSimulation[Any, Any, Any, Any, Any]:
+        """Dispatch deterministic preparation through the builder selected by a spec."""
+
+        return self.resolve(spec.solver).prepare(spec, key=key)
+
+
+solver_registry = SolverRegistry()
+
+
+__all__ = [
+    "InvalidSolverNameError",
+    "SolverAlreadyRegisteredError",
+    "SolverRegistry",
+    "UnknownSolverError",
+    "solver_registry",
+]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # ADEPT Architecture
 
+ADEPT is incrementally moving toward explicit, logging-free preparation and a pure
+numerical transform boundary. [ADR 0001](adr/0001-explicit-simulation-boundaries.md)
+defines the target contracts and compatibility policy. The existing lifecycle below
+remains the active execution path while solvers migrate behind parity tests.
+
 - ADEPT solvers are packaged into `ADEPTModule`s and run via the `ergoExo`
   Code pointer: `adept/_base_.py`
 - The `ergoExo` manages creation of an MLflow "run" and calls lifecycle methods on the `ADEPTModule` to perform logging of configuration, parameters, and run artifacts.

--- a/docs/adr/0001-explicit-simulation-boundaries.md
+++ b/docs/adr/0001-explicit-simulation-boundaries.md
@@ -1,0 +1,96 @@
+# ADR 0001: Explicit simulation and runtime boundaries
+
+- Status: Accepted
+- Date: 2026-09-02
+- Issues: [#349](https://github.com/ergodicio/adept/issues/349), [#353](https://github.com/ergodicio/adept/issues/353)
+
+## Context
+
+`ergoExo` currently owns solver selection, mutable preparation, JIT compilation,
+MLflow lifecycle, artifact export, and result analysis. Each solver implements those
+steps by subclassing `ADEPTModule`. This public API remains widely used, but the
+bound-method JIT boundary can capture configuration and state invisibly, and merely
+importing ADEPT loads numerical and tracking dependencies.
+
+ADEPT needs a logging-free preparation API and an explicit numerical boundary without
+requiring all existing solvers and downstream projects to migrate at once.
+
+## Decision
+
+ADEPT will use the following vocabulary and ownership boundaries:
+
+- `SimulationSpec` is versioned user intent. It contains a stable solver name and
+  solver configuration, but no tracking configuration, live clients, credentials, or
+  runtime resources.
+- `SolverRegistry` maps stable names to logging-free `SolverBuilder`s. Registrations
+  may be lazy so inspecting specifications does not import numerical implementations.
+- `SolverBuilder.prepare(spec, *, key)` deterministically returns a
+  `PreparedSimulation` and performs no tracking, filesystem writes, or process-global
+  configuration.
+- `PreparedSimulation` explicitly owns a program, initial parameters, state, inputs,
+  manifest, analyzer, and solver capabilities. Changes produce a replaced value rather
+  than mutating closure-captured fields.
+- `JaxProgram(params, state, inputs, key)` is the transformed numerical boundary. A
+  future numerical-core change will define its stable `RawResult` and the distinct
+  continuous `rhs` and discrete `step` contracts.
+- A host-side executor turns a `RawResult` into a materialized `Result`. An `Analyzer`
+  turns that result into a `Report` of metrics and artifact descriptions. Tracking,
+  artifact upload, checkpointing, plotting, scheduling, and external processes remain
+  host-side services.
+
+The dependency direction is:
+
+```text
+serializable spec/run plan
+          |
+          v
+registry -> builder -> prepared simulation -> JAX program -> raw result
+                           |                                |
+                           +-> manifest/capabilities        v
+                                                executor -> result
+                                                             |
+                                                             v
+                                               analyzer -> report
+                                                             |
+                                                             v
+                                              tracker / artifact sink
+```
+
+Specification and registry modules use only the Python standard library. Importing
+them must not import JAX, Equinox, MLflow, solver modules, or initialize a runtime.
+Concrete builders and executors own those imports at their execution boundary.
+
+## Compatibility
+
+This is a strangler migration, not a flag-day replacement:
+
+1. The new contracts and registry land alongside the existing lifecycle.
+2. Representative continuous and discrete solvers gain new builders and numerical
+   entry points with legacy/new parity tests.
+3. Host-side tracker and analyzer services reproduce existing run and artifact
+   behavior.
+4. `ergoExo` and `ADEPTModule` become compatibility façades over migrated paths.
+5. Unmigrated and caller-supplied legacy modules retain an explicit legacy fallback.
+6. Deprecation begins only after downstream pilot migrations and a published removal
+   policy.
+
+During the transition, the façade preserves documented setup, call, gradient, output,
+configuration-snapshot, nested/resumed run, and custom-module behavior. Arbitrary
+mutation inside transformed execution will not be emulated on the new path; callers
+will receive an actionable migration error or use the legacy fallback.
+
+## Error policy
+
+- Invalid specifications fail before builder loading.
+- Unknown solver names report the available registry keys.
+- Registry collisions fail instead of silently replacing a builder.
+- Capability and resource mismatches fail during executor preflight, before a solve.
+- Tracking and artifact failures are host-side and follow an explicit strict or
+  best-effort policy; they never alter numerical results silently.
+
+## Consequences
+
+The initial change is additive and does not reroute simulations. It introduces some
+temporary duplication while solvers migrate, but gives every migration a parity-tested
+rollback path. Keeping the contract layer dependency-free also enables future external
+and scheduler submitters to inspect plans without importing JAX or MLflow.

--- a/tests/test_architecture/test_contracts.py
+++ b/tests/test_architecture/test_contracts.py
@@ -1,0 +1,124 @@
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from adept.core import (
+    ExecutionKind,
+    Placement,
+    Precision,
+    PreparedSimulation,
+    RunManifest,
+    SimulationSpec,
+    SolverCapabilities,
+)
+
+
+def test_legacy_config_adapter_is_defensive_and_excludes_host_settings():
+    legacy = {
+        "solver": "tf-1d",
+        "mlflow": {"experiment": "test", "run": "legacy"},
+        "grid": {"nx": 8},
+        "drivers": ["first"],
+    }
+
+    spec = SimulationSpec.from_legacy_config(legacy)
+
+    legacy["grid"]["nx"] = 16
+    assert spec.solver == "tf-1d"
+    assert spec.config_dict() == {"grid": {"nx": 8}, "drivers": ["first"]}
+    assert "mlflow" not in spec.to_dict()["config"]
+
+
+def test_specification_views_cannot_change_stored_configuration():
+    spec = SimulationSpec("vlasov-1d", {"grid": {"nx": 8}})
+
+    with pytest.raises(TypeError):
+        spec.config["grid"] = {"nx": 32}
+
+    mutable_copy = spec.config_dict()
+    mutable_copy["grid"]["nx"] = 32
+    assert spec.config["grid"]["nx"] == 8
+
+
+@pytest.mark.parametrize("reserved", ["solver", "mlflow"])
+def test_specification_rejects_host_side_reserved_keys(reserved):
+    with pytest.raises(ValueError, match="reserved host-side keys"):
+        SimulationSpec("tf-1d", {reserved: {}})
+
+
+def test_legacy_config_requires_a_solver():
+    with pytest.raises(ValueError, match="missing required 'solver'"):
+        SimulationSpec.from_legacy_config({"grid": {"nx": 8}})
+
+
+def test_capabilities_are_typed_and_serializable():
+    capabilities = SolverCapabilities(
+        execution_kind=ExecutionKind.DISCRETE,
+        precision=Precision.X64,
+        differentiable=True,
+        batchable=False,
+        placements={Placement.SINGLE_DEVICE, Placement.MULTI_DEVICE},
+    )
+
+    assert capabilities.placements == frozenset({Placement.SINGLE_DEVICE, Placement.MULTI_DEVICE})
+    assert capabilities.to_dict() == {
+        "execution_kind": "discrete",
+        "precision": "x64",
+        "differentiable": True,
+        "batchable": False,
+        "placements": ["multi-device", "single-device"],
+    }
+    assert SolverCapabilities.from_dict(capabilities.to_dict()) == capabilities
+
+
+def test_capabilities_require_a_supported_placement():
+    with pytest.raises(ValueError, match="at least one"):
+        SolverCapabilities(ExecutionKind.CONTINUOUS, placements=frozenset())
+
+
+def test_manifest_is_defensive_and_serializable():
+    raw = {"grid": {"nx": 8}}
+    manifest = RunManifest(
+        raw_config=raw,
+        resolved_config={"grid": {"nx": 8, "dx": 0.25}},
+        units={"x0": "1 meter"},
+        seed=42,
+        key_provenance="jax.random.key(42)",
+        code={"adept": "abc123"},
+        dependencies={"jax": "1.2.3"},
+        structural_fingerprint="sha256:example",
+    )
+
+    raw["grid"]["nx"] = 16
+    returned = manifest.to_dict()
+    returned["resolved_config"]["grid"]["nx"] = 32
+
+    assert manifest.raw_config["grid"]["nx"] == 8
+    assert manifest.resolved_config["grid"]["nx"] == 8
+    assert manifest.to_dict()["structural_fingerprint"] == "sha256:example"
+    assert RunManifest.from_dict(manifest.to_dict()) == manifest
+
+
+def test_specification_round_trips_through_json():
+    spec = SimulationSpec("tf-1d", {"grid": {"nx": 8}}, schema_version="2")
+
+    restored = SimulationSpec.from_dict(json.loads(json.dumps(spec.to_dict())))
+
+    assert restored == spec
+
+
+def test_prepared_simulation_container_is_frozen():
+    manifest = RunManifest(raw_config={}, resolved_config={}, structural_fingerprint="sha256:example")
+    prepared = PreparedSimulation(
+        program="program",
+        params={},
+        state={"value": 1},
+        inputs={},
+        manifest=manifest,
+        analyzer="analyzer",
+        capabilities=SolverCapabilities(ExecutionKind.CONTINUOUS),
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        prepared.state = {"value": 2}

--- a/tests/test_architecture/test_import_boundaries.py
+++ b/tests/test_architecture/test_import_boundaries.py
@@ -1,0 +1,65 @@
+import subprocess
+import sys
+import textwrap
+
+
+def run_isolated_python(source: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_importing_adept_contracts_does_not_load_numerical_or_tracking_dependencies():
+    process = run_isolated_python(
+        """
+        import sys
+
+        import adept
+        from adept.core import SimulationSpec, SolverRegistry
+
+        forbidden = ("jax", "equinox", "mlflow", "diffrax")
+        loaded = sorted(
+            name for name in sys.modules
+            if any(name == dependency or name.startswith(dependency + ".") for dependency in forbidden)
+        )
+        assert loaded == [], loaded
+        assert adept.SimulationSpec is SimulationSpec
+        assert adept.SolverRegistry is SolverRegistry
+        """
+    )
+
+    assert process.returncode == 0, process.stderr
+
+
+def test_legacy_public_symbols_still_resolve_lazily():
+    process = run_isolated_python(
+        """
+        import sys
+
+        import adept
+
+        assert "adept._base_" not in sys.modules
+        from adept import ADEPTModule, ergoExo
+        assert "adept._base_" in sys.modules
+        assert ADEPTModule.__name__ == "ADEPTModule"
+        assert ergoExo.__name__ == "ergoExo"
+        """
+    )
+
+    assert process.returncode == 0, process.stderr
+
+
+def test_existing_eager_solver_attributes_remain_available():
+    process = run_isolated_python(
+        """
+        import adept
+
+        assert adept.vlasov1d.__name__ == "adept.vlasov1d"
+        assert adept.vfp2d.__name__ == "adept.vfp2d"
+        """
+    )
+
+    assert process.returncode == 0, process.stderr

--- a/tests/test_architecture/test_registry.py
+++ b/tests/test_architecture/test_registry.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+
+import pytest
+
+from adept.core import (
+    ExecutionKind,
+    InvalidSolverNameError,
+    PreparedSimulation,
+    RunManifest,
+    SimulationSpec,
+    SolverAlreadyRegisteredError,
+    SolverCapabilities,
+    SolverRegistry,
+    UnknownSolverError,
+)
+
+
+@dataclass
+class FakeBuilder:
+    calls: list[tuple[SimulationSpec, object]]
+
+    def prepare(self, spec: SimulationSpec, *, key: object) -> PreparedSimulation:
+        self.calls.append((spec, key))
+        return PreparedSimulation(
+            program="program",
+            params={"scale": 1.0},
+            state={"value": 0.0},
+            inputs=spec.config_dict(),
+            manifest=RunManifest(
+                raw_config=spec.config,
+                resolved_config=spec.config,
+                structural_fingerprint="sha256:fake",
+                key_provenance=str(key),
+            ),
+            analyzer="analyzer",
+            capabilities=SolverCapabilities(ExecutionKind.CONTINUOUS, differentiable=True),
+        )
+
+
+def test_registry_dispatches_preparation_by_stable_solver_name():
+    builder = FakeBuilder([])
+    registry = SolverRegistry()
+    registry.register("tf-1d", builder)
+    spec = SimulationSpec("tf-1d", {"grid": {"nx": 8}})
+
+    prepared = registry.prepare(spec, key="key-42")
+
+    assert builder.calls == [(spec, "key-42")]
+    assert prepared.inputs == {"grid": {"nx": 8}}
+    assert prepared.capabilities.differentiable is True
+
+
+def test_lazy_registration_loads_once_and_names_do_not_trigger_loading():
+    calls = []
+    builder = FakeBuilder([])
+    registry = SolverRegistry()
+
+    def load_builder():
+        calls.append("loaded")
+        return builder
+
+    registry.register_lazy("pic-1d", load_builder)
+
+    assert registry.names() == ("pic-1d",)
+    assert calls == []
+    assert registry.resolve("pic-1d") is builder
+    assert registry.resolve("pic-1d") is builder
+    assert calls == ["loaded"]
+
+
+def test_registration_collision_is_actionable():
+    registry = SolverRegistry()
+    registry.register("tf-1d", FakeBuilder([]))
+
+    with pytest.raises(SolverAlreadyRegisteredError, match="already registered"):
+        registry.register_lazy("tf-1d", lambda: FakeBuilder([]))
+
+
+def test_unknown_solver_lists_available_names():
+    registry = SolverRegistry()
+    registry.register("tf-1d", FakeBuilder([]))
+
+    with pytest.raises(UnknownSolverError, match=r"Unknown solver 'pic-1d'.*tf-1d"):
+        registry.resolve("pic-1d")
+
+
+@pytest.mark.parametrize("name", ["TF-1D", "tf_1d", "tf 1d", "-tf-1d", ""])
+def test_registry_rejects_unstable_names(name):
+    with pytest.raises(InvalidSolverNameError, match="lowercase kebab-case"):
+        SolverRegistry().register(name, FakeBuilder([]))
+
+
+def test_registry_rejects_objects_without_prepare():
+    with pytest.raises(TypeError, match=r"prepare\(spec, \*, key\)"):
+        SolverRegistry().register("tf-1d", object())
+
+
+def test_unregister_requires_an_existing_name():
+    registry = SolverRegistry()
+
+    with pytest.raises(UnknownSolverError, match="Registered solvers: <none>"):
+        registry.unregister("tf-1d")


### PR DESCRIPTION
## Summary

- add standard-library-only contracts for SimulationSpec, PreparedSimulation, RunManifest, JaxProgram, Analyzer, SolverBuilder, and typed capabilities
- add a public solver registry with lazy loading, deterministic name ordering, collision protection, and actionable unknown-solver errors
- preserve the legacy public API through lazy top-level imports so specification and submission processes do not import JAX, Equinox, Diffrax, or MLflow
- record the transform, runtime, compatibility, and error boundaries in ADR 0001
- update contributor guidance to distinguish the active legacy lifecycle from new architecture work

## Compatibility

This PR does not reroute ergoExo, register incomplete built-in adapters, alter solver output shapes, or remove ADEPTModule. Existing legacy symbols and solver module attributes continue to resolve lazily.

## Verification

- `uvx ty check adept/core adept/__init__.py`
- all changed-file pre-commit hooks
- `uv run pytest -q tests/test_architecture tests/test_base/test_ergoExo.py tests/import_test.py` — 26 passed
- broader default-suite smoke run — 102 passed with no failures before manual interruption during a long existing Hermite numerical test

## Follow-up

The next vertical slice should register one genuinely logging-free continuous builder and one discrete builder, then compare their numerical results with the legacy entry points before any façade routing changes.

Part of #349
Part of #353