### PR TITLE
feat(lpse2d): add full TPD/SRS/IAW coupling and 2D HPE feedback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+NOTES.md merge=union
+**/NOTES.md merge=union

--- a/NOTES.md
+++ b/NOTES.md
@@ -27,3 +27,15 @@ Append-only checkpoints for scientific model development and validation.
 - **Evidence or artifacts:** `tests/test_lpse2d/test_tpd_depletion.py`; `tests/test_lpse2d/test_iaw.py`; `configs/envelope-2d/tpd-srs-iaw.yaml`.
 - **Interpretation:** Reciprocal TPD feedback closes the above-threshold fluid energy path. It does not make the existing quasi-1D HPE tracker angle-resolved; 2D kinetic feedback remains a separate model extension.
 - **Next:** Run the full Envelope-2D regression suite, finalize documentation and mirrored notes, then open the PR.
+
+## 2026-09-03 23:09:13 PDT — Envelope-2D parity implementation completed
+
+- **Checkpoint ID:** 20260904T060913Z-1cea910a
+- **State:** COMPLETED
+- **Objective:** Deliver verified IAW evolution and reciprocal TPD pump depletion on top of the merged TPD/SRS/HPE feature set.
+- **Action or change:** Added IAW state/evolution, MATLAB-order damping and boundaries, ponderomotive drive, EPW/pump/Raman density feedback, IAW diagnostics, clean reciprocal TPD pump feedback, TPD-only flux diagnostics, dynamic-light stability setup, a combined 2D example deck, and an explicit TPD/HPE dimensionality guard.
+- **Provenance:** Commit `1cea910`; branch `codex/lpse2d-iaw-parity`; MATLAB IAW reference `m201805_matlabLpse_v11.m` at repository commit `3bf8b0b`.
+- **Observation:** Full non-slow Envelope-2D regression: 53 passed, 1 skipped, 3 deselected in 938.91 s. Final focused IAW/TPD suite: 12 passed in 4.76 s. Ruff and compile checks passed.
+- **Evidence or artifacts:** Pull request https://github.com/ergodicio/adept/pull/363; `adept/_lpse2d/core/iaw.py`; `tests/test_lpse2d/test_iaw.py`; `tests/test_lpse2d/test_tpd_depletion.py`; `configs/envelope-2d/tpd-srs-iaw.yaml`.
+- **Interpretation:** The 2D fluid model now composes TPD, SRS, pump feedback, and IAWs. The existing quasi-1D HPE tracker composes with SRS and IAWs, but a genuinely combined TPD+HPE model remains blocked on a multidimensional particle/feedback formulation and is rejected explicitly.
+- **Next:** Review and merge PR #363; design `(x, y, p_x, p_y)` HPE and an angle-resolved damping estimator as a separate follow-up if TPD kinetic feedback is required.

--- a/NOTES.md
+++ b/NOTES.md
@@ -64,3 +64,30 @@ Append-only checkpoints for scientific model development and validation.
 - **Evidence or artifacts:** `tests/test_lpse2d/test_hpe.py`; `tests/test_lpse2d/test_tpd_depletion.py`; `configs/envelope-2d/tpd-srs-iaw.yaml`; `docs/source/solvers/lpse2d/config.md`.
 - **Interpretation:** The user's box-averaging understanding is correct: positions are retained only for local force gathering, not to form a particle population per mesh point. Directional Landau feedback comes from Radon-like projections of the single global distribution, so histogram state scales as `n_angles * nv`, independent of `nx * ny`. The remaining HPE limitation is Im-only feedback (no trapping-induced nonlinear frequency shift), not transverse dimensionality.
 - **Next:** Push the update to PR #363 and use production TPD runs to converge `n_particles`, `n_angles`, gather refinement, and the damping EMA window on GPU.
+
+## 2026-09-04 09:18:28 PDT — Correct 2D absorbing-wall reinjection
+
+- **Checkpoint ID:** 20260904T161828Z-f10c2eed
+- **State:** PLANNED
+- **Objective:** Remove the review-blocking bias in the 2D HPE thermal-wall sampler before declaring the combined kinetic model ready.
+- **USER (verbatim):** "ok can you fix"
+- **Action or change:** Accepted the review finding on PR #363. The current 2D boundary code draws the radially truncated box distribution isotropically and flips the normal sign; that is not the incoming flux distribution. The replacement will sample wall-frame velocities from `p(r, theta) proportional to r^2 exp(-r^2 / (2 vte^2)) cos(theta)` for `r > v_min`, using an exact truncated-Maxwell inverse CDF and `sin(theta)` uniform on `[-1, 1]`.
+- **Provenance:** Commit `b7787b84321d7391d5d3a1fab7304a0987810ed0`; branch `codex/lpse2d-iaw-parity`; PR https://github.com/ergodicio/adept/pull/363; review state `CHANGES_REQUESTED` by `ergodic-ludwig` at 2026-09-04 08:07:29 PDT.
+- **Observation:** No corrected result yet. The existing sampler preserves inward direction and radial-tail support but omits the normal-velocity flux weighting, so repeated absorbing-wall crossings can bias the global directional histograms.
+- **Evidence or artifacts:** `adept/_lpse2d/core/hpe.py`; PR review on #363; vault mirror `Notes/adept/2026-09-03-222949-codex-lpse2d-iaw-parity-92eb82df.md`.
+- **Interpretation:** For an isotropic 2D Maxwellian at a planar wall, multiplying by inward normal speed and transforming to polar wall coordinates gives a separable radial truncated-Maxwell law and angular `cos(theta)` law. A stationarity/distribution test should lock both factors.
+- **Corrects:** Checkpoint `20260904T150248Z-2d2f0e6d`, which marked the 2D HPE implementation complete before independent boundary-law review.
+- **Next:** Implement the exact flux sampler, test its radial CDF and angular moments plus inward wall mapping, rerun focused/full regressions, and push a review correction.
+
+## 2026-09-04 09:29:09 PDT — Flux-weighted HPE wall correction completed
+
+- **Checkpoint ID:** 20260904T162909Z-cbd107a4
+- **State:** COMPLETED
+- **Objective:** Correct 2D HPE thermal-wall reinjection so absorbing boundaries preserve the intended box-averaged tail distribution.
+- **Action or change:** Replaced isotropic sign-flip reinjection with the exact planar-flux sampler. The radial speed is drawn from the Maxwell law `p(r) proportional to r^2 exp(-r^2/(2 vte^2))` truncated to `[v_min, 0.99c]` by inverse-survival bisection; the wall angle uses `sin(theta)` uniform on `[-1,1]`, equivalent to `p(theta)=cos(theta)/2`. The wall-frame sample is rotated onto all four faces with inward normal velocity. The initial 2D tail loader now also uses the exact doubly truncated Rayleigh inverse rather than clipping an unbounded draw at `0.99c`, and configuration rejects a cutoff at or above that cap.
+- **Provenance:** Based on commit `b7787b84321d7391d5d3a1fab7304a0987810ed0`; branch `codex/lpse2d-iaw-parity`; PR https://github.com/ergodicio/adept/pull/363.
+- **Observation:** The boundary-law test verifies the radial probability-integral transform has uniform mean/variance within tolerances `0.004`/`0.002`, verifies `mean(sin(theta))=0` and `var(sin(theta))=1/3` within `0.005`/`0.004`, enforces radial support, and checks inward mapping on all four faces. Focused HPE/TPD/IAW suite: 22 passed, 3 deselected in 20.05 s. Full non-slow Envelope-2D suite with local MLflow and `MPLBACKEND=Agg`: 61 passed, 1 skipped, 3 deselected in 257.71 s. Ruff lint/format and Python compilation pass.
+- **Evidence or artifacts:** `adept/_lpse2d/core/hpe.py`; `tests/test_lpse2d/test_hpe.py::test_2d_wall_reinjection_is_flux_weighted`; `docs/source/solvers/lpse2d/config.md`.
+- **Interpretation:** The review-blocking distribution bias is removed and its separable radial/angular law is locked by a statistical test. Repeated planar-wall reinjection now samples the flux distribution associated with the same retained 2D Maxwellian tail used at initialization.
+- **Corrects:** Checkpoint `20260904T150248Z-2d2f0e6d`; completes planned correction `20260904T161828Z-f10c2eed`.
+- **Next:** Commit and push the correction to PR #363, report the derivation/test to the reviewer, and wait for re-review.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,29 @@
+# ADEPT Research Notes
+
+Append-only checkpoints for scientific model development and validation.
+
+## 2026-09-03 22:29:49 PDT — Envelope-2D IAW parity scope
+
+- **Checkpoint ID:** 20260904T052949Z-92eb82df
+- **State:** PLANNED
+- **Objective:** Integrate the remaining `lpse-matlab` physics needed for the requested full TPD+SRS workflow, including particle feedback, laser feedback, and ion-acoustic waves.
+- **USER (verbatim):** "can you make a PR to integrate the missing features from ../lpse-matlab into the envelope2d solver? we want the full set of TPD+SRS w/ the particle tracker and laser feedback and IAWs (am i missing anything?)"
+- **Action or change:** Audited ADEPT `origin/main` against `/Users/archis/Dev/code/ergodic/lpse-matlab` at commit `3bf8b0b`. Current ADEPT main already contains TPD, SRS/Raman light, evolved-pump depletion feedback, Follett-style hybrid test-particle evolution with damping feedback, reproducible noise, SRS diagnostics, broadband/speckle drivers, and shifted-band source anti-aliasing. The planned implementation scope is the missing IAW subsystem and its coupling to light/EPW fields, with focused parity tests and an example deck.
+- **Provenance:** ADEPT commit `25719e727ca1fa0d46a00ede1e2054ae3ec105d8`; branch `codex/lpse2d-iaw-parity`; MATLAB source commit `3bf8b0b`.
+- **Observation:** No result yet. MATLAB exposes an IAW density perturbation `Nelf` and velocity-divergence field `W`, split-step evolution, acoustic/convective terms, collisional and Landau damping, boundary damping, and a ponderomotive light-intensity source. Existing ADEPT `origin/main` has no IAW state or solver.
+- **Evidence or artifacts:** Vault mirror `Notes/adept/2026-09-03-222949-codex-lpse2d-iaw-parity-92eb82df.md`.
+- **Interpretation:** The named TPD, SRS, particle, and laser-feedback capabilities do not need to be reimplemented; IAW parity is the substantive missing feature. Additional parity considerations to preserve are source anti-aliasing, reproducible noise, diagnostics, broadband colors, and speckles.
+- **Next:** Port and test the MATLAB IAW split-step path on top of current `origin/main`, then run the LPSE test suite and open a PR.
+
+## 2026-09-03 22:50:18 PDT — Scope expansion: reciprocal TPD pump depletion
+
+- **Checkpoint ID:** 20260904T055018Z-2e66ec98
+- **State:** PLANNED
+- **Objective:** Add TPD pump depletion to the IAW parity work so every enabled parametric instability feeds back on the evolved pump.
+- **USER (verbatim):** "i think we need TPD pump depletion too right?" Follow-up implementation constraint: "no dont use the old stuff, just ditch it and rewrite it"
+- **Action or change:** Expanded `terms.light.pump_depletion` from SRS-only to all active TPD/SRS sources. The TPD term is a clean implementation constructed as the discrete reciprocal of the current potential-form TPD operator; the abandoned `origin/update/lpse/pump` prototype is not incorporated.
+- **Provenance:** Current Envelope-2D TPD operator in `adept/_lpse2d/core/epw.py`; MATLAB TPD source in `m201805_matlabLpse_v11.m`; no TPD pump feedback exists in the MATLAB reference.
+- **Observation:** For coupling terms alone, the new pump RHS and existing EPW RHS conserve `|E0|^2 + (wp0/w0)|E_epw|^2` to floating-point tolerance. Focused TPD-depletion and IAW tests pass (9 tests).
+- **Evidence or artifacts:** `tests/test_lpse2d/test_tpd_depletion.py`; `tests/test_lpse2d/test_iaw.py`; `configs/envelope-2d/tpd-srs-iaw.yaml`.
+- **Interpretation:** Reciprocal TPD feedback closes the above-threshold fluid energy path. It does not make the existing quasi-1D HPE tracker angle-resolved; 2D kinetic feedback remains a separate model extension.
+- **Next:** Run the full Envelope-2D regression suite, finalize documentation and mirrored notes, then open the PR.

--- a/NOTES.md
+++ b/NOTES.md
@@ -39,3 +39,28 @@ Append-only checkpoints for scientific model development and validation.
 - **Evidence or artifacts:** Pull request https://github.com/ergodicio/adept/pull/363; `adept/_lpse2d/core/iaw.py`; `tests/test_lpse2d/test_iaw.py`; `tests/test_lpse2d/test_tpd_depletion.py`; `configs/envelope-2d/tpd-srs-iaw.yaml`.
 - **Interpretation:** The 2D fluid model now composes TPD, SRS, pump feedback, and IAWs. The existing quasi-1D HPE tracker composes with SRS and IAWs, but a genuinely combined TPD+HPE model remains blocked on a multidimensional particle/feedback formulation and is rejected explicitly.
 - **Next:** Review and merge PR #363; design `(x, y, p_x, p_y)` HPE and an angle-resolved damping estimator as a separate follow-up if TPD kinetic feedback is required.
+
+## 2026-09-04 07:32:05 PDT — Expand HPE to a global 2D particle ensemble
+
+- **Checkpoint ID:** 20260904T143205Z-6b54cbe1
+- **State:** PLANNED
+- **Objective:** Extend the HPE tracker on PR #363 from `(x, p_x)` to `(x, y, p_x, p_y)` so TPD and SRS can use kinetic damping feedback in a 2D box.
+- **USER (verbatim):** "let's make the particle tracker 2D. i thought the particles are box averaged and not at each point?"
+- **Action or change:** Reopened the kinetic-model scope. The planned design keeps one global macro-particle ensemble; particle positions exist only for field gathering, while the feedback distribution remains box averaged. Direction-dependent damping will be derived from projections of the global 2D velocity distribution along each retained wavevector rather than from per-cell particle populations.
+- **Provenance:** Commit `8f9ff7690fff915a3146f74e4dd68551b5c5ef37`; branch `codex/lpse2d-iaw-parity`; PR https://github.com/ergodicio/adept/pull/363.
+- **Observation:** No result yet. Current HPE stores one position and momentum component per particle, gathers only `Ex`, and forms one global `f(vx)` histogram that is broadcast across `ky`.
+- **Evidence or artifacts:** `adept/_lpse2d/core/hpe.py`; vault mirror `Notes/adept/2026-09-03-222949-codex-lpse2d-iaw-parity-92eb82df.md`.
+- **Interpretation:** The user's box-averaging point removes the need for a particle population at every spatial point, but oblique TPD modes still require 2D particle orbits and a directional velocity-space projection.
+- **Next:** Design the directional damping estimator and state layout, implement the 2D gather/push/feedback path with quasi-1D compatibility, and validate isotropic initialization plus oblique-mode response.
+
+## 2026-09-04 08:02:48 PDT — Box-averaged 2D2V HPE completed
+
+- **Checkpoint ID:** 20260904T150248Z-2d2f0e6d
+- **State:** COMPLETED
+- **Objective:** Make the HPE particle tracker genuinely 2-D while retaining one spatially averaged ensemble for TPD and SRS damping feedback.
+- **Action or change:** Rewrote the HPE core as a dual 1D1V/2D2V implementation. In a 2-D box each macro-particle carries `(x, y, p_x, p_y)`, gathers spectrally refined `Ex` and `Ey` by bilinear interpolation, and contributes to one bank of box-wide projected velocity histograms. Thirty-two oriented projections over `[0, 2 pi)` are interpolated onto every `(kx, ky)` resonance; opposite directions remain distinct. Removed the HPE+TPD setup rejection, generalized hot-electron/damping diagnostics, and enabled HPE in the full TPD+SRS+IAW example deck.
+- **Provenance:** Branch `codex/lpse2d-iaw-parity`; PR https://github.com/ergodicio/adept/pull/363; implementation in `adept/_lpse2d/core/hpe.py`.
+- **Observation:** The complete non-slow Envelope-2D suite passes with isolated local tracking and a headless plot backend: 60 passed, 1 skipped, 3 deselected in 261.85 s. Focused HPE/TPD/IAW verification passed 20 tests before the final directional test was added; the final full suite includes that test. Ruff lint/format and Python compilation pass. A combined one-step test advances TPD, SRS, reciprocal pump depletion, IAWs, and 2D2V HPE together with finite state and diagnostics.
+- **Evidence or artifacts:** `tests/test_lpse2d/test_hpe.py`; `tests/test_lpse2d/test_tpd_depletion.py`; `configs/envelope-2d/tpd-srs-iaw.yaml`; `docs/source/solvers/lpse2d/config.md`.
+- **Interpretation:** The user's box-averaging understanding is correct: positions are retained only for local force gathering, not to form a particle population per mesh point. Directional Landau feedback comes from Radon-like projections of the single global distribution, so histogram state scales as `n_angles * nv`, independent of `nx * ny`. The remaining HPE limitation is Im-only feedback (no trapping-induced nonlinear frequency shift), not transverse dimensionality.
+- **Next:** Push the update to PR #363 and use production TPD runs to converge `n_particles`, `n_angles`, gather refinement, and the damping EMA window on GPU.

--- a/adept/_lpse2d/core/epw.py
+++ b/adept/_lpse2d/core/epw.py
@@ -137,6 +137,7 @@ class SpectralEPWSolver:
 
         # Density gradient
         self.density_gradient_enabled = cfg["terms"]["epw"]["density_gradient"]
+        self.iaw_enabled = cfg["terms"].get("iaw", {}).get("active", False)
 
         # Landau damping flag (previously ignored -- damping was unconditionally on)
         self.landau_enabled = bool(cfg["terms"]["epw"]["damping"].get("landau", True))
@@ -427,13 +428,17 @@ class SpectralEPWSolver:
             srs_source = self.calc_srs_source(E0, y["E1"])
 
         # ========================================================================
-        # STEP 7: Apply density gradient to E fields (in REAL space)
+        # STEP 7: Apply background and ion-acoustic density detuning (in REAL space)
         # ========================================================================
-        if self.density_gradient_enabled:
+        if self.density_gradient_enabled or self.iaw_enabled:
             # MATLAB line 2081-2082:
-            # Ex = Ex .* exp(-1i * wp0/2 * (n/n0 - 1) * DT)
-            # Ey = Ey .* exp(-1i * wp0/2 * (n/n0 - 1) * DT)
-            density_perturbation = background_density / self.envelope_density - 1.0
+            # Ex = Ex .* exp(-1i * wp0/2 * (n/n0 - 1 + Nelf) * DT)
+            # Ey = Ey .* exp(-1i * wp0/2 * (n/n0 - 1 + Nelf) * DT)
+            density_perturbation = (
+                background_density / self.envelope_density - 1.0 if self.density_gradient_enabled else 0.0
+            )
+            if self.iaw_enabled:
+                density_perturbation = density_perturbation + y["iaw_density"]
             density_phase = jnp.exp(-1j * self.wp0 / 2.0 * density_perturbation * self.dt)
             ex = ex * density_phase
             ey = ey * density_phase

--- a/adept/_lpse2d/core/hpe.py
+++ b/adept/_lpse2d/core/hpe.py
@@ -1,32 +1,20 @@
 """Hybrid particle evolution (HPE) for the envelope-2d solver.
 
-Test-particle Landau-damping feedback following Follett et al., Phys. Plasmas 24,
-102134 (2017): tail electrons are pushed relativistically in the de-enveloped
-electrostatic field, a spatially-averaged velocity distribution is accumulated,
-and the Landau damping rate applied by ``SpectralEPWSolver`` is recomputed from
-that evolving distribution (their Eq. 4). The feedback is Im-only -- the real part
-of the EPW dispersion is untouched -- so this captures trapping-induced damping
-reduction (kinetic inflation) and hot-electron generation, but not the nonlinear
-frequency shift.
+Tail electrons are pushed relativistically in the real, de-enveloped
+electrostatic field. Particle positions are used only to gather that local
+field; the distribution that feeds Landau damping is a *single box-averaged
+ensemble*, following Follett et al., Phys. Plasmas 24, 102134 (2017).
 
-Quasi-1D only for now (``ny == 1``, enforced at config time): the push uses only
-``Ex`` and particles carry a single momentum component.
+The 2-D tracker is 2D2V: particles carry ``(x, y, p_x, p_y)`` and gather both
+components of the EPW field. Rather than storing particles or histograms at
+every mesh point, it accumulates a small bank of global projected distributions
+``f(v . k_hat)``. The projection angle and resonant velocity are interpolated
+for every ``(kx, ky)`` mode when evaluating the damping. The existing ny == 1
+path remains available for inexpensive SRS calculations and for its validation
+suite.
 
-Departures from the paper, chosen for JAX friendliness (see
-docs/dev/lpse2d-hpe-plan.md for the full rationale):
-
-- **Tail-only loading**: particles are drawn from the Maxwellian tail
-  ``|v| > v_min * vte``; modes whose phase velocity falls below the cutoff keep
-  the analytic damping rate (blended per k-mode).
-- **EMA histogram** instead of interval damping updates: the distribution is a
-  state variable updated every field step by an exponential moving average with
-  time constant ``tau_damping``.
-- **Per-k calibration**: the discrete histogram -> gamma_L operator is normalized
-  per k-mode so that the *expected* initial (Maxwellian-tail) histogram
-  reproduces the analytic Landau rate exactly. The evolving rate is therefore
-  ``gamma_analytic(k) * Op[f](k) / Op[f_Maxwell](k)``, and all binning /
-  finite-difference biases cancel.
-- ``gamma_HPE`` is clamped >= 0 (a noisy negative rate would pump the field).
+The feedback is imaginary-part-only: trapping can reduce Landau damping and
+generate hot electrons, but it does not alter the real EPW dispersion.
 """
 
 import jax
@@ -37,73 +25,106 @@ from scipy import special
 
 from adept._lpse2d.core.epw import landau_damping_rate
 
-PARTICLE_KEYS = ("x_e", "u_e", "epw_hist", "gamma_L")
+PARTICLE_KEYS = ("x_e", "y_e", "u_e", "epw_hist", "gamma_L")
 
 
 def _hpe_cfg(cfg: dict) -> dict:
     return cfg["terms"]["hpe"]
 
 
+def _analytic_rate(cfg: dict) -> np.ndarray:
+    derived = cfg["units"]["derived"]
+    kx = np.asarray(cfg["grid"]["kx"])
+    ky = np.asarray(cfg["grid"]["ky"])
+    k_sq = kx[:, None] ** 2 + ky[None, :] ** 2
+    zero_mask = np.where(k_sq > 0.0, 1.0, 0.0)
+    return np.asarray(
+        landau_damping_rate(jnp.asarray(k_sq), derived["wp0"], derived["vte_sq"], jnp.asarray(zero_mask)),
+        dtype=np.float64,
+    )
+
+
 def resonance_arrays(cfg: dict) -> dict:
-    """Static arrays shared by the pusher, the damping extraction, and diagnostics.
+    """Build the velocity grid, resonance map, blend mask, and calibration input.
 
-    Returns a dict with
-
-    - ``v_centers`` (nv,): histogram bin centers, um/ps
-    - ``dv``: bin width
-    - ``v_phi`` (nx,): signed phase velocity of each kx mode (0 where masked)
-    - ``mask_res`` (nx,): True where the particle-based rate is valid (blend mask)
-    - ``gamma_analytic`` (nx, ny): the static analytic Landau rate
-    - ``f_tail_frac``: fraction of the full Maxwellian carried by the loaded tail
-    - ``f0_expected`` (nv,): expected initial histogram (exact per-bin integrals of
-      the truncated Maxwellian, normalized like the sampled histogram)
+    For ``ny == 1``, ``v_phi`` and ``mask_res`` retain their historical ``(nx,)``
+    shape. In 2-D they have shape ``(nx, ny)`` and ``angles`` contains the
+    oriented projection axes spanning ``[0, 2*pi)``. Opposite directions are
+    deliberately distinct: an asymmetric distribution can damp ``+k`` and
+    ``-k`` independently.
     """
     hpe = _hpe_cfg(cfg)
     derived = cfg["units"]["derived"]
     wp0, vte, c = derived["wp0"], np.sqrt(derived["vte_sq"]), derived["c"]
+    nx, ny = int(cfg["grid"]["nx"]), int(cfg["grid"]["ny"])
+    is_2d = ny > 1
 
     nv = int(hpe["nv"])
     v_max = float(hpe["v_max"]) * c
     edges = np.linspace(-v_max, v_max, nv + 1)
     v_centers = 0.5 * (edges[1:] + edges[:-1])
-    dv = edges[1] - edges[0]
+    dv = float(edges[1] - edges[0])
 
-    kx = np.array(cfg["grid"]["kx"])
-    ky = np.array(cfg["grid"]["ky"])
+    kx = np.asarray(cfg["grid"]["kx"])
+    ky = np.asarray(cfg["grid"]["ky"])
     k_sq = kx[:, None] ** 2 + ky[None, :] ** 2
-    zero_mask = np.where(k_sq > 0, 1.0, 0.0)
-    gamma_analytic = np.array(
-        landau_damping_rate(jnp.array(k_sq), wp0, derived["vte_sq"], jnp.array(zero_mask)), dtype=np.float64
-    )
+    k_mag = np.sqrt(k_sq)
+    gamma_analytic = _analytic_rate(cfg)
 
-    # signed phase velocity of each kx mode. The resonance frequency is the
-    # Bohm-Gross frequency by default (this is what the analytic rate the k-blend
-    # hands off to is derived with); "wp0" reproduces Follett's bare-carrier choice.
-    kx_safe = np.where(np.abs(kx) > 0, kx, 1.0)
-    if hpe["omega_res"] == "wp0":
-        omega_res = wp0 * np.ones_like(kx)
-    else:  # bohm_gross
-        omega_res = np.sqrt(wp0**2 + 3.0 * kx**2 * derived["vte_sq"])
-    v_phi = np.where(np.abs(kx) > 0, omega_res / kx_safe, 0.0)
+    if is_2d:
+        theta_k = np.mod(np.arctan2(ky[None, :], kx[:, None]), 2.0 * np.pi)
+        n_angles = int(hpe["n_angles"])
+        angles = 2.0 * np.pi * np.arange(n_angles) / n_angles
+        k_safe = np.where(k_mag > 0.0, k_mag, 1.0)
+        if hpe["omega_res"] == "wp0":
+            omega_res = wp0 * np.ones_like(k_mag)
+        else:
+            omega_res = np.sqrt(wp0**2 + 3.0 * k_sq * derived["vte_sq"])
+        v_phi = np.where(k_mag > 0.0, omega_res / k_safe, 0.0)
+    else:
+        angles = np.asarray([0.0])
+        theta_k = np.zeros((nx, 1))
+        kx_safe = np.where(np.abs(kx) > 0.0, kx, 1.0)
+        if hpe["omega_res"] == "wp0":
+            omega_res = wp0 * np.ones_like(kx)
+        else:
+            omega_res = np.sqrt(wp0**2 + 3.0 * kx**2 * derived["vte_sq"])
+        v_phi = np.where(np.abs(kx) > 0.0, omega_res / kx_safe, 0.0)
 
     v_min = float(hpe["v_min"]) * vte
     buffer = float(hpe["v_blend_buffer"]) * vte
-    mask_res = (np.abs(kx) > 0) & (np.abs(v_phi) > v_min + buffer) & (np.abs(v_phi) < 0.9 * v_max)
+    if is_2d:
+        mask_res = (k_mag > 0.0) & (v_phi > v_min + buffer) & (v_phi < 0.9 * v_max)
+        # Fraction of an isotropic 2-D Maxwellian outside the loaded speed circle.
+        f_tail_frac = float(np.exp(-0.5 * (v_min / vte) ** 2))
 
-    # two-sided Maxwellian tail fraction beyond v_min
-    f_tail_frac = float(special.erfc(v_min / (np.sqrt(2.0) * vte)))
+        # Conditional marginal of a radially truncated 2-D Maxwellian. Above the
+        # cutoff (the only region used by HPE damping), this is the full Gaussian
+        # divided by the radial-tail probability. The inner expression keeps the
+        # complete expected histogram normalized for diagnostics and calibration.
+        abs_v = np.abs(v_centers)
+        perpendicular_cut = np.sqrt(np.maximum(v_min**2 - abs_v**2, 0.0))
+        perpendicular_tail = np.where(
+            abs_v >= v_min,
+            1.0,
+            special.erfc(perpendicular_cut / (np.sqrt(2.0) * vte)),
+        )
+        f0_expected = (
+            np.exp(-0.5 * (v_centers / vte) ** 2) / (np.sqrt(2.0 * np.pi) * vte) * perpendicular_tail / f_tail_frac
+        )
+        f0_expected /= np.sum(f0_expected) * dv
+    else:
+        mask_res = (np.abs(kx) > 0.0) & (np.abs(v_phi) > v_min + buffer) & (np.abs(v_phi) < 0.9 * v_max)
+        f_tail_frac = float(special.erfc(v_min / (np.sqrt(2.0) * vte)))
 
-    # expected histogram of the truncated Maxwellian: exact per-bin integrals so
-    # bins straddling the cutoff carry their correct partial weight
-    def cdf(v):
-        return 0.5 * (1.0 + special.erf(v / (np.sqrt(2.0) * vte)))
+        def cdf(v):
+            return 0.5 * (1.0 + special.erf(v / (np.sqrt(2.0) * vte)))
 
-    lo, hi = edges[:-1], edges[1:]
-    p_bin = np.clip(cdf(hi) - cdf(np.maximum(lo, v_min)), 0.0, None) * (hi > v_min) + np.clip(
-        cdf(np.minimum(hi, -v_min)) - cdf(lo), 0.0, None
-    ) * (lo < -v_min)
-    norm = np.sum(p_bin) * dv
-    f0_expected = p_bin / norm
+        lo, hi = edges[:-1], edges[1:]
+        p_bin = np.clip(cdf(hi) - cdf(np.maximum(lo, v_min)), 0.0, None) * (hi > v_min) + np.clip(
+            cdf(np.minimum(hi, -v_min)) - cdf(lo), 0.0, None
+        ) * (lo < -v_min)
+        f0_expected = p_bin / (np.sum(p_bin) * dv)
 
     return {
         "v_centers": v_centers,
@@ -113,63 +134,76 @@ def resonance_arrays(cfg: dict) -> dict:
         "gamma_analytic": gamma_analytic,
         "f_tail_frac": f_tail_frac,
         "f0_expected": f0_expected,
+        "angles": angles,
+        "theta_k": theta_k,
     }
 
 
 def load_particles(cfg: dict) -> dict:
-    """Sample the initial particle state (numpy, once, at init).
-
-    Positions are drawn proportional to the background density; velocities from
-    the two-sided truncated Maxwellian tail ``|v| > v_min * vte``. Returns the
-    state-dict entries: ``x_e``, ``u_e`` (u = gamma*v), ``epw_hist`` (the sampled
-    histogram, which seeds the EMA), and ``gamma_L`` (the analytic rate array, so
-    the first steps are identical to a fluid run).
-    """
+    """Sample one box-wide tail ensemble and return its initial solver state."""
     from scipy import stats
 
     hpe = _hpe_cfg(cfg)
     derived = cfg["units"]["derived"]
     vte, c = np.sqrt(derived["vte_sq"]), derived["c"]
     n_p = int(hpe["n_particles"])
+    is_2d = int(cfg["grid"]["ny"]) > 1
     rng = np.random.default_rng(int(hpe["seed"]))
 
-    # velocities: |v|/vte ~ truncnorm on [v_min, 0.99c/vte], random sign
-    a, b = float(hpe["v_min"]), 0.99 * c / vte
-    speed = stats.truncnorm.rvs(a, b, loc=0.0, scale=1.0, size=n_p, random_state=rng) * vte
-    sign = rng.choice(np.array([-1.0, 1.0]), size=n_p)
-    v = sign * speed
-    u = v / np.sqrt(1.0 - (v / c) ** 2)
+    if is_2d:
+        # Conditional Rayleigh draw for an isotropic 2-D Maxwellian with
+        # |v| > v_min*vte. The relativistic cap only removes a negligible tail.
+        uni = rng.uniform(np.finfo(float).tiny, 1.0, size=n_p)
+        speed = np.sqrt((float(hpe["v_min"]) * vte) ** 2 - 2.0 * vte**2 * np.log(uni))
+        speed = np.minimum(speed, 0.99 * c)
+        velocity_angle = rng.uniform(0.0, 2.0 * np.pi, size=n_p)
+        velocity = speed[:, None] * np.stack((np.cos(velocity_angle), np.sin(velocity_angle)), axis=-1)
+        gamma_rel = 1.0 / np.sqrt(1.0 - (speed / c) ** 2)
+        u = gamma_rel[:, None] * velocity
+    else:
+        a, b = float(hpe["v_min"]), 0.99 * c / vte
+        speed = stats.truncnorm.rvs(a, b, loc=0.0, scale=1.0, size=n_p, random_state=rng) * vte
+        velocity = rng.choice(np.asarray([-1.0, 1.0]), size=n_p) * speed
+        u = velocity / np.sqrt(1.0 - (velocity / c) ** 2)
 
-    # positions: cell weighted by density, uniform within the cell
-    x_grid = np.array(cfg["grid"]["x"])
-    dx = cfg["grid"]["dx"]
-    density = np.array(cfg["grid"]["background_density"])[:, 0]
-    p_cell = density / np.sum(density)
+    # Draw cells from the complete 2-D density map. This remains one ensemble:
+    # no particle list or velocity distribution is attached to an individual cell.
+    x_grid = np.asarray(cfg["grid"]["x"])
+    y_grid = np.asarray(cfg["grid"]["y"])
+    density = np.asarray(cfg["grid"]["background_density"])
+    p_cell = density.reshape(-1) / np.sum(density)
     cells = rng.choice(density.size, size=n_p, p=p_cell)
-    x = x_grid[cells] + (rng.uniform(size=n_p) - 0.5) * dx
+    ix, iy = np.unravel_index(cells, density.shape)
+    x = x_grid[ix] + (rng.uniform(size=n_p) - 0.5) * cfg["grid"]["dx"]
+    y = y_grid[iy] + (rng.uniform(size=n_p) - 0.5) * cfg["grid"]["dy"]
 
     arrays = resonance_arrays(cfg)
     nv = int(hpe["nv"])
     v_max = float(hpe["v_max"]) * c
-    counts, _ = np.histogram(v, bins=nv, range=(-v_max, v_max))
-    hist = counts.astype(np.float64) / (n_p * arrays["dv"])
+    if is_2d:
+        directions = np.stack((np.cos(arrays["angles"]), np.sin(arrays["angles"])), axis=-1)
+        projected = velocity @ directions.T
+        hist = np.stack(
+            [np.histogram(projected[:, i], bins=nv, range=(-v_max, v_max))[0] for i in range(directions.shape[0])]
+        ).astype(np.float64)
+        hist /= n_p * arrays["dv"]
+    else:
+        counts, _ = np.histogram(velocity, bins=nv, range=(-v_max, v_max))
+        hist = counts.astype(np.float64) / (n_p * arrays["dv"])
 
-    return {
+    state = {
         "x_e": np.asarray(x, dtype=np.float64),
         "u_e": np.asarray(u, dtype=np.float64),
         "epw_hist": hist,
         "gamma_L": arrays["gamma_analytic"].copy(),
     }
+    if is_2d:
+        state["y_e"] = np.asarray(y, dtype=np.float64)
+    return state
 
 
 class HybridParticleEvolution:
-    """One HPE step: subcycled relativistic push + histogram EMA + damping update.
-
-    Called by ``SplitStep.__call__`` after the EPW update; consumes and returns the
-    full state dict (complex-viewed). The damping array it writes into
-    ``y["gamma_L"]`` is consumed by ``SpectralEPWSolver`` on the *next* field step
-    (one-step lag, far tighter than the paper's 100 fs update interval).
-    """
+    """Subcycled 1-D or 2-D particle push plus global damping feedback."""
 
     def __init__(self, cfg: dict):
         hpe = _hpe_cfg(cfg)
@@ -180,169 +214,299 @@ class HybridParticleEvolution:
         self.wp0 = derived["wp0"]
         self.c = derived["c"]
         self.vte = float(np.sqrt(derived["vte_sq"]))
-        self.q_over_m = derived["e"] / derived["me"]  # electron charge magnitude / mass
-
-        self.nx, self.ny = grid["nx"], grid["ny"]
-        self.dx = grid["dx"]
+        self.q_over_m = derived["e"] / derived["me"]
+        self.nx, self.ny = int(grid["nx"]), int(grid["ny"])
+        self.is_2d = self.ny > 1
+        self.dx, self.dy = grid["dx"], grid["dy"]
         self.xmin, self.xmax = grid["xmin"], grid["xmax"]
-        self.Lx = self.xmax - self.xmin
-        self.kx = jnp.array(grid["kx"])
-        self.periodic = cfg["terms"]["epw"]["boundary"]["x"] == "periodic"
+        self.ymin, self.ymax = grid["ymin"], grid["ymax"]
+        self.Lx, self.Ly = self.xmax - self.xmin, self.ymax - self.ymin
+        self.kx, self.ky = jnp.asarray(grid["kx"]), jnp.asarray(grid["ky"])
+        self.periodic_x = cfg["terms"]["epw"]["boundary"]["x"] == "periodic"
+        self.periodic_y = cfg["terms"]["epw"]["boundary"]["y"] == "periodic"
+        # Historical public attribute retained for quasi-1D validation tests.
+        self.periodic = self.periodic_x
 
-        # gather from a spectrally upsampled field: linear interpolation of a wave
-        # sampled at k*dx ~ 1-2 rad/cell attenuates the gathered field by
-        # sinc^2(k dx/2) (~15-30%!); zero-padding ex_k by gather_refine before the
-        # ifft makes that error ~1% for one cheap length-(refine*nx) FFT per step
         self.refine = int(hpe["gather_refine"])
-        self.nx_f = self.refine * self.nx
-        self.dx_f = self.dx / self.refine
-        self.x0 = float(np.array(grid["x"])[0])  # cell-centered origin, shared by both grids
-        self.pad_lo = (self.nx_f - self.nx) // 2
-        self.pad_hi = self.nx_f - self.nx - self.pad_lo
+        self.nx_f, self.ny_f = self.refine * self.nx, self.refine * self.ny
+        self.dx_f, self.dy_f = self.dx / self.refine, self.dy / self.refine
+        self.x0, self.y0 = float(np.asarray(grid["x"])[0]), float(np.asarray(grid["y"])[0])
+        self.pad_x_lo = (self.nx_f - self.nx) // 2
+        self.pad_x_hi = self.nx_f - self.nx - self.pad_x_lo
+        self.pad_y_lo = (self.ny_f - self.ny) // 2
+        self.pad_y_hi = self.ny_f - self.ny - self.pad_y_lo
+        self.pad_lo, self.pad_hi = self.pad_x_lo, self.pad_x_hi
 
         self.n_sub = int(hpe["substeps"])
         self.dtp = self.dt / self.n_sub
-        self.alpha = self.dt / hpe["tau_damping_ps"]  # EMA weight
+        self.alpha = self.dt / hpe["tau_damping_ps"]
         self.t_start = hpe["t_start_ps"]
         self.feedback = bool(hpe["feedback"])
         self.n_p = int(hpe["n_particles"])
         self.nv = int(hpe["nv"])
         self.v_min = float(hpe["v_min"]) * self.vte
-        # wall re-injection stream: a fold_in stream tag decorrelates it from every
-        # other consumer of the HPE seed (the numpy loader) and from the EPW noise
-        # stream regardless of how the two seeds relate -- the old additive +7919
-        # offset overlapped the EPW stream after 7919 steps
         self.wall_key = jax.random.fold_in(jax.random.PRNGKey(int(hpe["seed"])), 314159)
-        # jnp.histogram needs concrete bin edges; keep them (and centers) on-device
+
         arrays = resonance_arrays(cfg)
         self.v_max = float(hpe["v_max"]) * self.c
         self.dv = arrays["dv"]
-        self.v_centers = jnp.array(arrays["v_centers"])
+        self.v_centers = jnp.asarray(arrays["v_centers"])
         self.v_edges = jnp.linspace(-self.v_max, self.v_max, self.nv + 1)
-        self.v_phi = jnp.array(arrays["v_phi"])
-        self.mask_res = jnp.array(arrays["mask_res"])
-        self.gamma_analytic = jnp.array(arrays["gamma_analytic"])
+        self.v_phi = jnp.asarray(arrays["v_phi"])
+        self.mask_res = jnp.asarray(arrays["mask_res"])
+        self.gamma_analytic = jnp.asarray(arrays["gamma_analytic"])
         self.f_tail_frac = arrays["f_tail_frac"]
+        self.angles = jnp.asarray(arrays["angles"])
+        self.directions = jnp.stack((jnp.cos(self.angles), jnp.sin(self.angles)), axis=-1)
+        self.theta_k = jnp.asarray(arrays["theta_k"])
+        self.n_angles = int(self.angles.size)
+        self.dtheta = 2.0 * np.pi / self.n_angles
 
-        # per-k calibration: the discrete operator applied to the expected initial
-        # histogram must return the analytic rate exactly (see module docstring)
-        gamma_raw0 = np.array(self._gamma_raw(jnp.array(arrays["f0_expected"])))
-        gamma_an_1d = np.array(arrays["gamma_analytic"][:, 0])
-        mask = np.array(arrays["mask_res"])
+        if self.is_2d:
+            expected = jnp.broadcast_to(jnp.asarray(arrays["f0_expected"]), (self.n_angles, self.nv))
+            gamma_raw0 = np.asarray(self._gamma_raw_2d(expected))
+            gamma_an = np.asarray(arrays["gamma_analytic"])
+            mask = np.asarray(arrays["mask_res"])
+        else:
+            gamma_raw0 = np.asarray(self._gamma_raw_1d(jnp.asarray(arrays["f0_expected"])))
+            gamma_an = np.asarray(arrays["gamma_analytic"][:, 0])
+            mask = np.asarray(arrays["mask_res"])
         with np.errstate(divide="ignore", invalid="ignore"):
-            calib = np.where(mask & (gamma_raw0 > 0), gamma_an_1d / np.where(gamma_raw0 > 0, gamma_raw0, 1.0), 1.0)
-        self.calibration = jnp.array(calib)
-        if np.any(mask):
-            c_band = calib[mask & (gamma_an_1d > 1.0e-6 * self.wp0)]
-            if c_band.size:
-                print(
-                    f"HPE: {self.n_p} particles, {self.n_sub} substeps/step, "
-                    f"calibration C(k) in [{c_band.min():.3f}, {c_band.max():.3f}] over the resonant band"
-                )
+            calib = np.where(mask & (gamma_raw0 > 0.0), gamma_an / np.where(gamma_raw0 > 0.0, gamma_raw0, 1.0), 1.0)
+        self.calibration = jnp.asarray(calib)
+
+        c_band = calib[mask & (gamma_an > 1.0e-6 * self.wp0)]
+        if c_band.size:
+            dimensionality = f"2D2V/{self.n_angles} angles" if self.is_2d else "1D1V"
+            print(
+                f"HPE: {self.n_p} particles ({dimensionality}), {self.n_sub} substeps/step, "
+                f"calibration C(k) in [{c_band.min():.3f}, {c_band.max():.3f}] over the resonant band"
+            )
+
+    # ---------------------------------------------------------------- fields --
+
+    def refine_ex(self, phi_k: Array) -> Array:
+        """Quasi-1D compatibility helper returning the refined Ex envelope."""
+        ex_k = -1j * self.kx * phi_k[:, 0]
+        ex_k_fine = jnp.fft.ifftshift(jnp.pad(jnp.fft.fftshift(ex_k), (self.pad_x_lo, self.pad_x_hi)))
+        return jnp.fft.ifft(ex_k_fine) * self.refine / self.ny
+
+    def _pad_field_2d(self, field_k: Array) -> Array:
+        shifted = jnp.fft.fftshift(field_k)
+        padded = jnp.pad(shifted, ((self.pad_x_lo, self.pad_x_hi), (self.pad_y_lo, self.pad_y_hi)))
+        return jnp.fft.ifft2(jnp.fft.ifftshift(padded)) * self.refine**2
+
+    def refine_e(self, phi_k: Array) -> Array:
+        """Return refined ``(nx_f, ny_f, 2)`` Ex/Ey envelopes."""
+        ex = self._pad_field_2d(-1j * self.kx[:, None] * phi_k)
+        ey = self._pad_field_2d(-1j * self.ky[None, :] * phi_k)
+        return jnp.stack((ex, ey), axis=-1)
+
+    def _linear_indices(self, position, origin, spacing, count, periodic):
+        index = (position - origin) / spacing
+        raw = jnp.floor(index).astype(jnp.int32)
+        weight = index - raw
+        if periodic:
+            i0 = jnp.mod(raw, count)
+            i1 = jnp.mod(raw + 1, count)
+        else:
+            i0 = jnp.clip(raw, 0, count - 2)
+            i1 = i0 + 1
+            weight = jnp.clip(index - i0, 0.0, 1.0)
+        return i0, i1, weight
+
+    def _accel(self, x: Array, ex_env: Array, t: float) -> Array:
+        """Quasi-1D field gather retained in its historical numerical convention."""
+        i0, i1, weight = self._linear_indices(x, self.x0, self.dx_f, self.nx_f, False)
+        ex_p = ex_env[i0] * (1.0 - weight) + ex_env[i1] * weight
+        return -self.q_over_m * jnp.real(ex_p * jnp.exp(-1j * self.wp0 * t))
+
+    def _accel_2d(self, x: Array, y: Array, e_env: Array, t: float) -> Array:
+        ix0, ix1, wx = self._linear_indices(x, self.x0, self.dx_f, self.nx_f, self.periodic_x)
+        iy0, iy1, wy = self._linear_indices(y, self.y0, self.dy_f, self.ny_f, self.periodic_y)
+        e00, e10 = e_env[ix0, iy0], e_env[ix1, iy0]
+        e01, e11 = e_env[ix0, iy1], e_env[ix1, iy1]
+        e_particle = (
+            (1.0 - wx)[:, None] * (1.0 - wy)[:, None] * e00
+            + wx[:, None] * (1.0 - wy)[:, None] * e10
+            + (1.0 - wx)[:, None] * wy[:, None] * e01
+            + wx[:, None] * wy[:, None] * e11
+        )
+        return -self.q_over_m * jnp.real(e_particle * jnp.exp(-1j * self.wp0 * t))
 
     # ------------------------------------------------------------------ push --
 
-    def refine_ex(self, phi_k: Array) -> Array:
-        """(refine * nx,) complex Ex envelope on the upsampled grid from phi_k."""
-        ex_k = -1j * self.kx * phi_k[:, 0]
-        ex_k_fine = jnp.fft.ifftshift(jnp.pad(jnp.fft.fftshift(ex_k), (self.pad_lo, self.pad_hi)))
-        return jnp.fft.ifft(ex_k_fine) * self.refine / self.ny  # ifft2(phi_k) would carry a 1/ny
-
-    def _accel(self, x: Array, ex_env: Array, t: float) -> Array:
-        """-(e/m) * Re[Ex_envelope(x) * exp(-i wp0 t)] gathered at particle positions
-        (linear interpolation on the upsampled grid, clamped at the walls)."""
-        idx = (x - self.x0) / self.dx_f
-        i0 = jnp.clip(jnp.floor(idx).astype(jnp.int32), 0, self.nx_f - 2)
-        w = jnp.clip(idx - i0, 0.0, 1.0)
-        ex_p = ex_env[i0] * (1.0 - w) + ex_env[i0 + 1] * w
-        carrier = jnp.exp(-1j * self.wp0 * t)
-        return -self.q_over_m * jnp.real(ex_p * carrier)
-
     def _substep(self, i, carry, ex_env, t0):
-        # the leading kick reuses the acceleration carried from the previous substep's
-        # trailing kick (same x, same t -- bitwise identical), so _accel runs once per
-        # substep instead of twice; XLA does not CSE across fori_loop iterations, and
-        # the gather in _accel dominates the GPU cost of this loop
-        x, u, a = carry
+        x, u, acceleration = carry
         t_i = t0 + i * self.dtp
-        u_half = u + 0.5 * self.dtp * a
-        gamma = jnp.sqrt(1.0 + (u_half / self.c) ** 2)
-        x = x + self.dtp * u_half / gamma
-        if self.periodic:
+        u_half = u + 0.5 * self.dtp * acceleration
+        gamma_rel = jnp.sqrt(1.0 + (u_half / self.c) ** 2)
+        x = x + self.dtp * u_half / gamma_rel
+        if self.periodic_x:
             x = jnp.mod(x - self.xmin, self.Lx) + self.xmin
-        a = self._accel(x, ex_env, t_i + self.dtp)
-        u = u_half + 0.5 * self.dtp * a
-        return x, u, a
+        acceleration = self._accel(x, ex_env, t_i + self.dtp)
+        u = u_half + 0.5 * self.dtp * acceleration
+        return x, u, acceleration
+
+    def _substep_2d(self, i, carry, e_env, t0):
+        x, y, u, acceleration = carry
+        t_i = t0 + i * self.dtp
+        u_half = u + 0.5 * self.dtp * acceleration
+        gamma_rel = jnp.sqrt(1.0 + jnp.sum((u_half / self.c) ** 2, axis=-1))
+        x = x + self.dtp * u_half[:, 0] / gamma_rel
+        y = y + self.dtp * u_half[:, 1] / gamma_rel
+        if self.periodic_x:
+            x = jnp.mod(x - self.xmin, self.Lx) + self.xmin
+        if self.periodic_y:
+            y = jnp.mod(y - self.ymin, self.Ly) + self.ymin
+        acceleration = self._accel_2d(x, y, e_env, t_i + self.dtp)
+        u = u_half + 0.5 * self.dtp * acceleration
+        return x, y, u, acceleration
 
     def _apply_boundaries(self, x: Array, u: Array, t: float) -> tuple[Array, Array]:
-        """Thermalizing walls: exiting particles are re-injected at the wall with an
-        inward, flux-weighted tail speed (p(|v|) ~ |v| exp(-v^2/2vte^2), |v| > v_min,
-        analytic inverse CDF), which keeps the loaded tail distribution stationary."""
-        if self.periodic:
+        if self.periodic_x:
             return x, u
-        out_left = x < self.xmin
-        out_right = x > self.xmax
+        out_left, out_right = x < self.xmin, x > self.xmax
         key = jax.random.fold_in(self.wall_key, jnp.asarray(t / self.dt).astype(jnp.int32))
         uni = jax.random.uniform(key, (self.n_p,), minval=1.0e-12, maxval=1.0)
-        speed = jnp.sqrt(self.v_min**2 - 2.0 * self.vte**2 * jnp.log(uni))
-        speed = jnp.minimum(speed, 0.99 * self.c)
+        speed = jnp.minimum(jnp.sqrt(self.v_min**2 - 2.0 * self.vte**2 * jnp.log(uni)), 0.99 * self.c)
         u_new = speed / jnp.sqrt(1.0 - (speed / self.c) ** 2)
         x = jnp.where(out_left, self.xmin, jnp.where(out_right, self.xmax, x))
         u = jnp.where(out_left, u_new, jnp.where(out_right, -u_new, u))
         return x, u
 
+    def _apply_boundaries_2d(self, x, y, u, t):
+        out_left, out_right = x < self.xmin, x > self.xmax
+        out_bottom, out_top = y < self.ymin, y > self.ymax
+        any_out = (out_left | out_right) if self.periodic_y else (out_left | out_right | out_bottom | out_top)
+        if self.periodic_x:
+            any_out = (out_bottom | out_top) if not self.periodic_y else jnp.zeros_like(out_left)
+
+        step_key = jax.random.fold_in(self.wall_key, jnp.asarray(t / self.dt).astype(jnp.int32))
+        radial_key, angle_key = jax.random.split(step_key)
+        uni = jax.random.uniform(radial_key, (self.n_p,), minval=1.0e-12, maxval=1.0)
+        speed = jnp.minimum(jnp.sqrt(self.v_min**2 - 2.0 * self.vte**2 * jnp.log(uni)), 0.99 * self.c)
+        angle = jax.random.uniform(angle_key, (self.n_p,), minval=0.0, maxval=2.0 * np.pi)
+        velocity = speed[:, None] * jnp.stack((jnp.cos(angle), jnp.sin(angle)), axis=-1)
+        velocity = velocity.at[:, 0].set(jnp.where(out_left, jnp.abs(velocity[:, 0]), velocity[:, 0]))
+        velocity = velocity.at[:, 0].set(jnp.where(out_right, -jnp.abs(velocity[:, 0]), velocity[:, 0]))
+        velocity = velocity.at[:, 1].set(jnp.where(out_bottom, jnp.abs(velocity[:, 1]), velocity[:, 1]))
+        velocity = velocity.at[:, 1].set(jnp.where(out_top, -jnp.abs(velocity[:, 1]), velocity[:, 1]))
+        gamma_rel = 1.0 / jnp.sqrt(1.0 - (speed / self.c) ** 2)
+        u_new = gamma_rel[:, None] * velocity
+
+        if not self.periodic_x:
+            x = jnp.where(out_left, self.xmin, jnp.where(out_right, self.xmax, x))
+        if not self.periodic_y:
+            y = jnp.where(out_bottom, self.ymin, jnp.where(out_top, self.ymax, y))
+        u = jnp.where(any_out[:, None], u_new, u)
+        return x, y, u
+
     def push(self, x: Array, u: Array, ex_env: Array, t: float) -> tuple[Array, Array]:
-        """Subcycled relativistic KDK leapfrog across one field step [t, t + dt]."""
-        a0 = self._accel(x, ex_env, t)
-        x, u, _ = jax.lax.fori_loop(0, self.n_sub, lambda i, carry: self._substep(i, carry, ex_env, t), (x, u, a0))
+        """Historical quasi-1D KDK entry point."""
+        acceleration = self._accel(x, ex_env, t)
+        x, u, _ = jax.lax.fori_loop(
+            0, self.n_sub, lambda i, carry: self._substep(i, carry, ex_env, t), (x, u, acceleration)
+        )
         return self._apply_boundaries(x, u, t)
+
+    def push_2d(self, x: Array, y: Array, u: Array, e_env: Array, t: float):
+        """Relativistic KDK push for one ``(x,y,p_x,p_y)`` ensemble."""
+        acceleration = self._accel_2d(x, y, e_env, t)
+        x, y, u, _ = jax.lax.fori_loop(
+            0,
+            self.n_sub,
+            lambda i, carry: self._substep_2d(i, carry, e_env, t),
+            (x, y, u, acceleration),
+        )
+        return self._apply_boundaries_2d(x, y, u, t)
 
     # ------------------------------------------------- histogram and damping --
 
     def histogram(self, u: Array) -> Array:
-        v = u / jnp.sqrt(1.0 + (u / self.c) ** 2)
-        counts, _ = jnp.histogram(v, bins=self.v_edges)
-        # int counts / float promotes to the active float dtype (envelope-2d may run f32)
-        return counts / (self.n_p * self.dv)
+        if not self.is_2d:
+            velocity = u / jnp.sqrt(1.0 + (u / self.c) ** 2)
+            counts, _ = jnp.histogram(velocity, bins=self.v_edges)
+            return counts / (self.n_p * self.dv)
 
-    def _gamma_raw(self, hist: Array) -> Array:
-        """Uncalibrated Follett Eq. 4 in 1D: gamma(kx) = -(pi/2) wp0^3/k^2 sgn(k) f'(v_phi).
+        gamma_rel = jnp.sqrt(1.0 + jnp.sum((u / self.c) ** 2, axis=-1))
+        velocity = u / gamma_rel[:, None]
 
-        The sgn(k) makes the damping even in k for a symmetric distribution: -k modes
-        resonate at v_phi < 0 where the Maxwellian slope is positive -- each
-        propagation direction damps on its own tail."""
+        def projected_histogram(direction):
+            counts, _ = jnp.histogram(velocity @ direction, bins=self.v_edges)
+            return counts / (self.n_p * self.dv)
+
+        return jax.lax.map(projected_histogram, self.directions)
+
+    def _gamma_raw_1d(self, hist: Array) -> Array:
         dfdv = jnp.gradient(hist, self.dv) * self.f_tail_frac
         dfdv_at_vphi = jnp.interp(self.v_phi, self.v_centers, dfdv)
-        kx_safe = jnp.where(jnp.abs(self.kx) > 0, self.kx, 1.0)
+        kx_safe = jnp.where(jnp.abs(self.kx) > 0.0, self.kx, 1.0)
         return jnp.where(
-            jnp.abs(self.kx) > 0, -0.5 * np.pi * self.wp0**3 * jnp.sign(kx_safe) / kx_safe**2 * dfdv_at_vphi, 0.0
+            jnp.abs(self.kx) > 0.0,
+            -0.5 * np.pi * self.wp0**3 * jnp.sign(kx_safe) / kx_safe**2 * dfdv_at_vphi,
+            0.0,
         )
 
+    def _gamma_raw_2d(self, hist: Array) -> Array:
+        """Evaluate the projected Follett operator at every 2-D spectral mode."""
+        dfdv = jnp.gradient(hist, self.dv, axis=-1) * self.f_tail_frac
+
+        angle_coordinate = self.theta_k / self.dtheta
+        ia0_raw = jnp.floor(angle_coordinate).astype(jnp.int32)
+        angle_weight = angle_coordinate - ia0_raw
+        ia0 = jnp.mod(ia0_raw, self.n_angles)
+        ia1 = jnp.mod(ia0_raw + 1, self.n_angles)
+
+        velocity_coordinate = (self.v_phi - self.v_centers[0]) / self.dv
+        iv0 = jnp.clip(jnp.floor(velocity_coordinate).astype(jnp.int32), 0, self.nv - 2)
+        velocity_weight = jnp.clip(velocity_coordinate - iv0, 0.0, 1.0)
+
+        def gather_slope(angle_index):
+            lower = dfdv[angle_index, iv0]
+            upper = dfdv[angle_index, iv0 + 1]
+            return (1.0 - velocity_weight) * lower + velocity_weight * upper
+
+        slope = (1.0 - angle_weight) * gather_slope(ia0) + angle_weight * gather_slope(ia1)
+        k_sq = self.kx[:, None] ** 2 + self.ky[None, :] ** 2
+        k_sq_safe = jnp.where(k_sq > 0.0, k_sq, 1.0)
+        return jnp.where(k_sq > 0.0, -0.5 * np.pi * self.wp0**3 / k_sq_safe * slope, 0.0)
+
+    def _gamma_raw(self, hist: Array) -> Array:
+        return self._gamma_raw_2d(hist) if self.is_2d else self._gamma_raw_1d(hist)
+
     def damping(self, hist: Array) -> Array:
-        """Blended (nx, ny) damping array: calibrated HPE rate on resonant modes
-        (clamped >= 0), analytic rate elsewhere."""
         gamma_hpe = jnp.maximum(self.calibration * self._gamma_raw(hist), 0.0)
+        if self.is_2d:
+            return jnp.where(self.mask_res, gamma_hpe, self.gamma_analytic)
         gamma_1d = jnp.where(self.mask_res, gamma_hpe, self.gamma_analytic[:, 0])
         return jnp.broadcast_to(gamma_1d[:, None], (self.nx, self.ny))
 
     # ---------------------------------------------------------------- driver --
 
     def __call__(self, t: float, y: dict[str, Array]) -> dict[str, Array]:
-        phi_k = y["epw"]
+        if self.is_2d:
 
-        def active(operand):
-            x, u, hist, gamma_L = operand
-            ex_env = self.refine_ex(phi_k)
-            x, u = self.push(x, u, ex_env, t)
+            def active(operand):
+                x, y_position, u, hist, gamma_l = operand
+                x, y_position, u = self.push_2d(x, y_position, u, self.refine_e(y["epw"]), t)
+                hist = (1.0 - self.alpha) * hist + self.alpha * self.histogram(u)
+                if self.feedback:
+                    gamma_l = self.damping(hist)
+                return x, y_position, u, hist, gamma_l
+
+            operand = (y["x_e"], y["y_e"], y["u_e"], y["epw_hist"], y["gamma_L"])
+            x, y_position, u, hist, gamma_l = jax.lax.cond(t >= self.t_start, active, lambda value: value, operand)
+            return {**y, "x_e": x, "y_e": y_position, "u_e": u, "epw_hist": hist, "gamma_L": gamma_l}
+
+        def active_1d(operand):
+            x, u, hist, gamma_l = operand
+            x, u = self.push(x, u, self.refine_ex(y["epw"]), t)
             hist = (1.0 - self.alpha) * hist + self.alpha * self.histogram(u)
             if self.feedback:
-                gamma_L = self.damping(hist)
-            return x, u, hist, gamma_L
+                gamma_l = self.damping(hist)
+            return x, u, hist, gamma_l
 
-        def inactive(operand):
-            return operand
-
-        x, u, hist, gamma_L = jax.lax.cond(
-            t >= self.t_start, active, inactive, (y["x_e"], y["u_e"], y["epw_hist"], y["gamma_L"])
-        )
-        return {**y, "x_e": x, "u_e": u, "epw_hist": hist, "gamma_L": gamma_L}
+        operand = (y["x_e"], y["u_e"], y["epw_hist"], y["gamma_L"])
+        x, u, hist, gamma_l = jax.lax.cond(t >= self.t_start, active_1d, lambda value: value, operand)
+        return {**y, "x_e": x, "u_e": u, "epw_hist": hist, "gamma_L": gamma_l}

--- a/adept/_lpse2d/core/hpe.py
+++ b/adept/_lpse2d/core/hpe.py
@@ -21,6 +21,7 @@ import jax
 import numpy as np
 from jax import Array
 from jax import numpy as jnp
+from jax.scipy import special as jax_special
 from scipy import special
 
 from adept._lpse2d.core.epw import landau_damping_rate
@@ -152,10 +153,14 @@ def load_particles(cfg: dict) -> dict:
 
     if is_2d:
         # Conditional Rayleigh draw for an isotropic 2-D Maxwellian with
-        # |v| > v_min*vte. The relativistic cap only removes a negligible tail.
-        uni = rng.uniform(np.finfo(float).tiny, 1.0, size=n_p)
-        speed = np.sqrt((float(hpe["v_min"]) * vte) ** 2 - 2.0 * vte**2 * np.log(uni))
-        speed = np.minimum(speed, 0.99 * c)
+        # v_min*vte < |v| < 0.99c. Inverting the doubly truncated Rayleigh
+        # survival avoids a point mass at the relativistic cap.
+        v_min = float(hpe["v_min"]) * vte
+        v_max = 0.99 * c
+        survival_min = np.exp(-0.5 * (v_min / vte) ** 2)
+        survival_max = np.exp(-0.5 * (v_max / vte) ** 2)
+        target_survival = survival_min + rng.uniform(size=n_p) * (survival_max - survival_min)
+        speed = np.sqrt(-2.0 * vte**2 * np.log(target_survival))
         velocity_angle = rng.uniform(0.0, 2.0 * np.pi, size=n_p)
         velocity = speed[:, None] * np.stack((np.cos(velocity_angle), np.sin(velocity_angle)), axis=-1)
         gamma_rel = 1.0 / np.sqrt(1.0 - (speed / c) ** 2)
@@ -375,23 +380,70 @@ class HybridParticleEvolution:
         u = jnp.where(out_left, u_new, jnp.where(out_right, -u_new, u))
         return x, u
 
+    def _maxwell_survival(self, speed: Array) -> Array:
+        """Survival function of the 3-D Maxwell speed law with scale ``vte``.
+
+        The extra radial power relative to the loaded 2-D box distribution comes
+        from flux weighting at a planar wall: in wall polar coordinates,
+        ``v_normal * f(v) * r dr dtheta`` is proportional to
+        ``r^2 exp(-r^2 / 2vte^2) cos(theta) dr dtheta``.
+        """
+        scaled = speed / self.vte
+        return jax_special.erfc(scaled / np.sqrt(2.0)) + np.sqrt(2.0 / np.pi) * scaled * jnp.exp(-0.5 * scaled**2)
+
+    def _sample_flux_weighted_tail(self, key: Array) -> tuple[Array, Array]:
+        """Sample inward normal/tangential velocities at a thermalizing wall.
+
+        This is the exact planar-flux law for the retained isotropic 2-D Maxwellian
+        tail ``|v| > v_min``. The radius follows a truncated Maxwell distribution
+        and ``sin(theta)`` is uniform on ``[-1, 1]`` (equivalently,
+        ``p(theta) = cos(theta)/2`` on the inward half-plane).
+        """
+        radial_key, angle_key = jax.random.split(key)
+        uniform_radius = jax.random.uniform(radial_key, (self.n_p,), minval=0.0, maxval=1.0)
+        lower = jnp.full((self.n_p,), self.v_min)
+        upper = jnp.full((self.n_p,), 0.99 * self.c)
+        survival_lower = self._maxwell_survival(lower)
+        survival_upper = self._maxwell_survival(upper)
+        target_survival = survival_lower + uniform_radius * (survival_upper - survival_lower)
+
+        def bisect(_, bracket):
+            lo, hi = bracket
+            midpoint = 0.5 * (lo + hi)
+            move_lower = self._maxwell_survival(midpoint) > target_survival
+            return jnp.where(move_lower, midpoint, lo), jnp.where(move_lower, hi, midpoint)
+
+        lower, upper = jax.lax.fori_loop(0, 32, bisect, (lower, upper))
+        speed = 0.5 * (lower + upper)
+        sin_theta = jax.random.uniform(angle_key, (self.n_p,), minval=-1.0, maxval=1.0)
+        normal_velocity = speed * jnp.sqrt(jnp.maximum(1.0 - sin_theta**2, 0.0))
+        tangential_velocity = speed * sin_theta
+        return normal_velocity, tangential_velocity
+
     def _apply_boundaries_2d(self, x, y, u, t):
+        if self.periodic_x and self.periodic_y:
+            return x, y, u
         out_left, out_right = x < self.xmin, x > self.xmax
         out_bottom, out_top = y < self.ymin, y > self.ymax
-        any_out = (out_left | out_right) if self.periodic_y else (out_left | out_right | out_bottom | out_top)
-        if self.periodic_x:
-            any_out = (out_bottom | out_top) if not self.periodic_y else jnp.zeros_like(out_left)
+        cross_x = (out_left | out_right) if not self.periodic_x else jnp.zeros_like(out_left)
+        cross_y = (out_bottom | out_top) if not self.periodic_y else jnp.zeros_like(out_bottom)
+        any_out = cross_x | cross_y
 
         step_key = jax.random.fold_in(self.wall_key, jnp.asarray(t / self.dt).astype(jnp.int32))
-        radial_key, angle_key = jax.random.split(step_key)
-        uni = jax.random.uniform(radial_key, (self.n_p,), minval=1.0e-12, maxval=1.0)
-        speed = jnp.minimum(jnp.sqrt(self.v_min**2 - 2.0 * self.vte**2 * jnp.log(uni)), 0.99 * self.c)
-        angle = jax.random.uniform(angle_key, (self.n_p,), minval=0.0, maxval=2.0 * np.pi)
-        velocity = speed[:, None] * jnp.stack((jnp.cos(angle), jnp.sin(angle)), axis=-1)
-        velocity = velocity.at[:, 0].set(jnp.where(out_left, jnp.abs(velocity[:, 0]), velocity[:, 0]))
-        velocity = velocity.at[:, 0].set(jnp.where(out_right, -jnp.abs(velocity[:, 0]), velocity[:, 0]))
-        velocity = velocity.at[:, 1].set(jnp.where(out_bottom, jnp.abs(velocity[:, 1]), velocity[:, 1]))
-        velocity = velocity.at[:, 1].set(jnp.where(out_top, -jnp.abs(velocity[:, 1]), velocity[:, 1]))
+        normal_velocity, tangential_velocity = self._sample_flux_weighted_tail(step_key)
+        x_sign = jnp.where(out_left, 1.0, -1.0)
+        y_sign = jnp.where(out_bottom, 1.0, -1.0)
+
+        # For an x wall, x is normal and y tangential; for a y-only crossing the
+        # roles swap. A finite-step corner crossing is mapped into the inward
+        # quadrant without changing the sampled speed.
+        velocity_x = jnp.where(cross_x, x_sign * normal_velocity, tangential_velocity)
+        velocity_y = jnp.where(cross_x, tangential_velocity, y_sign * normal_velocity)
+        corner = cross_x & cross_y
+        velocity_x = jnp.where(corner, x_sign * jnp.abs(velocity_x), velocity_x)
+        velocity_y = jnp.where(corner, y_sign * jnp.abs(velocity_y), velocity_y)
+        velocity = jnp.stack((velocity_x, velocity_y), axis=-1)
+        speed = jnp.sqrt(normal_velocity**2 + tangential_velocity**2)
         gamma_rel = 1.0 / jnp.sqrt(1.0 - (speed / self.c) ** 2)
         u_new = gamma_rel[:, None] * velocity
 

--- a/adept/_lpse2d/core/iaw.py
+++ b/adept/_lpse2d/core/iaw.py
@@ -1,0 +1,102 @@
+"""Ion-acoustic-wave evolution for the Envelope-2D solver.
+
+This ports the ``isEvolveIaw`` split-step path from
+``m201805_matlabLpse_v11.m``. The real state variables are the fractional ion
+density perturbation ``n`` (MATLAB ``Nelf``) and the ion-velocity divergence
+``w`` (MATLAB ``W``):
+
+    d w / dt = -laplacian(PP)
+    d n / dt = -w
+
+where the ponderomotive potential is
+
+    PP = cs^2 n + Z e^2/(4 me mi) [|E_epw|^2/wp0^2
+                                    + |E0|^2/w0^2
+                                    + |E1|^2/w1^2].
+
+The update order matches MATLAB's ``iawSplitStep``: kick ``w`` from the
+potential, apply twice the requested amplitude Landau rate to ``w``, then
+drift ``n``. Boundary damping acts on ``w`` and collisions act on ``n`` after
+the split step, as in the original time loop.
+"""
+
+from jax import Array
+from jax import numpy as jnp
+
+
+class IonAcousticWave:
+    """Advance the ion-acoustic density and velocity-divergence fields."""
+
+    def __init__(self, cfg: dict):
+        grid = cfg["grid"]
+        derived = cfg["units"]["derived"]
+        iaw = cfg["terms"]["iaw"]
+
+        self.dt = grid["dt"]
+        self.dx = grid["dx"]
+        self.dy = grid["dy"]
+        self.ny = grid["ny"]
+        self.kx = grid["kx"]
+        self.ky = grid["ky"]
+        self.k_sq = self.kx[:, None] ** 2 + self.ky[None, :] ** 2
+        self.filter = grid["low_pass_filter_grid"] * grid["zero_mask"]
+        self.boundary = grid["iaw_absorbing_boundaries"]
+
+        self.cs = derived["cs"]
+        self.wp0 = derived["wp0"]
+        self.w0 = derived["w0"]
+        self.w1 = derived["w1"]
+        self.ponderomotive_prefactor = (
+            cfg["units"]["ionization state"] * derived["e"] ** 2 / (4.0 * derived["me"] * derived["mi"])
+        )
+
+        damping = iaw["damping"]
+        self.landau_rate = damping["landau"] * self.cs * jnp.sqrt(self.k_sq)
+        self.collisional_factor = 1.0 - damping["collisions"] * self.dt
+        self.max_density_perturbation = iaw["max_density_perturbation"]
+
+    def laplacian(self, field: Array) -> Array:
+        """Second-order periodic finite-difference Laplacian used by MATLAB."""
+        lap = (jnp.roll(field, -1, axis=0) - 2.0 * field + jnp.roll(field, 1, axis=0)) / self.dx**2
+        if self.ny > 1:
+            lap = lap + (jnp.roll(field, -1, axis=1) - 2.0 * field + jnp.roll(field, 1, axis=1)) / self.dy**2
+        return lap
+
+    def epw_fields(self, phi_k: Array) -> tuple[Array, Array]:
+        """Return the real-space EPW electric-field envelopes from ``phi_k``."""
+        ex = jnp.fft.ifft2(-1j * self.kx[:, None] * phi_k)
+        ey = jnp.fft.ifft2(-1j * self.ky[None, :] * phi_k)
+        return ex, ey
+
+    def ponderomotive_potential(self, phi_k: Array, E0: Array, E1: Array, density: Array) -> Array:
+        """Build the acoustic plus EPW/pump/Raman ponderomotive potential."""
+        ex, ey = self.epw_fields(phi_k)
+        epw_intensity = jnp.abs(ex) ** 2 + jnp.abs(ey) ** 2
+        pump_intensity = jnp.sum(jnp.abs(E0) ** 2, axis=-1)
+        raman_intensity = jnp.sum(jnp.abs(E1) ** 2, axis=-1)
+        return self.cs**2 * density + self.ponderomotive_prefactor * (
+            epw_intensity / self.wp0**2 + pump_intensity / self.w0**2 + raman_intensity / self.w1**2
+        )
+
+    def __call__(self, y: dict[str, Array]) -> dict[str, Array]:
+        """Advance one MATLAB-order IAW split step and return the full state."""
+        potential = self.ponderomotive_potential(y["epw"], y["E0"], y["E1"], y["iaw_density"])
+
+        velocity_divergence = y["iaw_velocity_divergence"] - self.dt * self.laplacian(potential)
+        velocity_k = jnp.fft.fft2(velocity_divergence)
+        velocity_k = velocity_k * jnp.exp(-2.0 * self.landau_rate * self.dt) * self.filter
+        velocity_divergence = jnp.real(jnp.fft.ifft2(velocity_k)) * self.boundary
+
+        density = (y["iaw_density"] - self.dt * velocity_divergence) * self.collisional_factor
+        if self.max_density_perturbation is not None:
+            density = jnp.clip(
+                density,
+                -self.max_density_perturbation,
+                self.max_density_perturbation,
+            )
+
+        return {
+            **y,
+            "iaw_density": density,
+            "iaw_velocity_divergence": velocity_divergence,
+        }

--- a/adept/_lpse2d/core/light.py
+++ b/adept/_lpse2d/core/light.py
@@ -8,7 +8,7 @@ from adept._lpse2d.core.raman import RamanLight
 
 class CoupledLight(RamanLight):
     """
-    Evolves the pump E0 and the Raman scattered light E1 together, with pump depletion.
+    Evolves the pump E0 and, when enabled, the Raman scattered light E1.
 
     This is the `isPumpDepletion` path of m201805_matlabLpse_v11.m: the pump is no longer
     prescribed analytically but advanced with the same staggered explicit scheme as the
@@ -38,8 +38,19 @@ class CoupledLight(RamanLight):
     The E1 half of the solver -- FD stencils, detuning/diffraction coefficients, SRS
     coupling, and the seed injector -- is inherited from ``RamanLight`` (``self.rhs``),
     so any numerics fix there applies to both the prescribed-pump and pump-depletion
-    paths. This class adds only the pump: its coefficients, its boundary injector, and
-    the coupled staggered loop.
+    paths. This class adds the pump: its coefficients, boundary injector, reciprocal
+    TPD/SRS couplings, and the coupled staggered loop.
+
+    The TPD pump term is constructed directly as the discrete reciprocal of
+    ``SpectralEPWSolver.calc_tpd_source`` (rather than using the abandoned historical
+    Pump2D prototype):
+
+        dE0_y/dt |_TPD = i e/(4 w0 me) exp(+i (w0 - 2 wp0)t)
+                          * Ehy * div(Eh)
+
+    The pair conserves ``|E0|^2 + (wp0/w0)|Eh|^2`` for coupling terms alone. Only
+    the y-polarized pump participates because the existing TPD operator is written
+    for that polarization.
 
     The pump injector amplitude is divided by sinc(k0 dx) so the launched amplitude is
     exactly E0_source * sqrt(intensity) / eps^(1/4) despite the two-point discrete
@@ -54,6 +65,10 @@ class CoupledLight(RamanLight):
         derived = cfg["units"]["derived"]
         self.E0_source = derived["E0_source"]
         background_density = cfg["grid"]["background_density"]
+        source_cfg = cfg["terms"]["epw"]["source"]
+        self.srs_enabled = bool(source_cfg.get("srs", False))
+        self.tpd_enabled = bool(source_cfg.get("tpd", False))
+        self.ky = cfg["grid"]["ky"]
 
         # pump detuning/diffraction (MATLAB lines 1616-1626); with wp0^2 = w0^2 * n_env
         # the pump coefficient reduces to i w0/2 (1 - n)
@@ -61,7 +76,8 @@ class CoupledLight(RamanLight):
             1j * self.w0 / 2.0 * (1.0 - self.wp0**2 / self.w0**2 * background_density / self.envelope_density)
         )
         self.diffraction_coeff0 = 1j * self.c**2 / (2.0 * self.w0)
-        self.depletion_coeff0 = -1j * self.e / (4.0 * self.w1 * self.me)  # in dE0/dt, lap phi * E1
+        self.srs_depletion_coeff0 = -1j * self.e / (4.0 * self.w1 * self.me)
+        self.tpd_depletion_coeff0 = 1j * self.e / (4.0 * self.w0 * self.me)
 
         # ---- pump injector (MATLAB lines 1707-1753, mirrored to the left edge) ----
         pump = cfg["drivers"]["E0"]["derived"]
@@ -111,30 +127,79 @@ class CoupledLight(RamanLight):
         row_i0 = jnp.sum(1j * amp * jnp.exp(1j * k0[:, None] * self.x[self.i0 + 1]) * color_phase, axis=0)
         return row_i0, row_i0p1
 
-    def pump_rhs(self, t: float, E0: Array, E1: Array, laplacian_phi: Array, pump_args: dict) -> Array:
+    def pump_rhs(
+        self,
+        t: float,
+        E0: Array,
+        E1: Array,
+        laplacian_phi: Array,
+        pump_args: dict,
+        iaw_density: Array | None = None,
+        phi_k: Array | None = None,
+    ) -> Array:
         """Pump RHS: propagation + detuning (MATLAB lines 1616-1626), pump depletion
         (lines 1640-1646: no conjugate, w1 denominator), and the boundary injector."""
         e0x, e0y = E0[..., 0], E0[..., 1]
         e1x, e1y = E1[..., 0], E1[..., 1]
+        linear_coeff0 = self.linear_coeff0
+        if iaw_density is not None:
+            # MATLAB: i*w0/2 * [1 - wp0^2/w0^2 * (n_b/n_env + Nelf)] E0
+            linear_coeff0 = linear_coeff0 - 1j * self.wp0**2 / (2.0 * self.w0) * iaw_density
 
-        k_e0x = self.diffraction_coeff0 * (self._d2y(e0x) - self._dxdy(e0y)) + self.linear_coeff0 * e0x
-        k_e0y = self.diffraction_coeff0 * (self._d2x(e0y) - self._dxdy(e0x)) + self.linear_coeff0 * e0y
-        k_e0x += self.depletion_coeff0 * laplacian_phi * e1x
-        k_e0y += self.depletion_coeff0 * laplacian_phi * e1y
+        k_e0x = self.diffraction_coeff0 * (self._d2y(e0x) - self._dxdy(e0y)) + linear_coeff0 * e0x
+        k_e0y = self.diffraction_coeff0 * (self._d2x(e0y) - self._dxdy(e0x)) + linear_coeff0 * e0y
+        if self.srs_enabled:
+            k_e0x += self.srs_depletion_coeff0 * laplacian_phi * e1x
+            k_e0y += self.srs_depletion_coeff0 * laplacian_phi * e1y
+        if self.tpd_enabled:
+            if phi_k is None:
+                raise ValueError("phi_k is required for TPD pump depletion")
+            k_e0y += self.calc_tpd_depletion(t, phi_k)
         row_i0, row_i0p1 = self.calc_pump_source(t, pump_args)
         k_e0y = k_e0y.at[self.i0, :].add(row_i0)
         k_e0y = k_e0y.at[self.i0 + 1, :].add(row_i0p1)
 
         return jnp.stack([k_e0x, k_e0y], axis=-1)
 
+    def calc_tpd_depletion(self, t: float, phi_k: Array) -> Array:
+        """Return the clean reciprocal TPD source for the y-polarized pump.
+
+        ``div_e`` uses the same potential convention as the EPW TPD source:
+        ``div_e = ifft2(k^2 phi_k)``.
+        """
+        ey = jnp.fft.ifft2(-1j * self.ky[None, :] * phi_k)
+        div_e = jnp.fft.ifft2(self.k_sq * phi_k)
+        phase = jnp.exp(1j * (self.w0 - 2.0 * self.wp0) * t)
+        return self.tpd_depletion_coeff0 * phase * ey * div_e
+
     def coupled_rhs(
-        self, t: float, E0: Array, E1: Array, laplacian_phi: Array, pump_args: dict, seed_args: dict | None
+        self,
+        t: float,
+        E0: Array,
+        E1: Array,
+        laplacian_phi: Array,
+        pump_args: dict,
+        seed_args: dict | None,
+        iaw_density: Array | None = None,
+        phi_k: Array | None = None,
     ) -> tuple[Array, Array]:
         # the E1 RHS (propagation + detuning + SRS coupling + seed rows) is exactly
         # the RamanLight one
-        return self.pump_rhs(t, E0, E1, laplacian_phi, pump_args), self.rhs(t, E1, E0, laplacian_phi, seed_args)
+        pump_rhs = self.pump_rhs(t, E0, E1, laplacian_phi, pump_args, iaw_density, phi_k)
+        if not self.srs_enabled:
+            return pump_rhs, jnp.zeros_like(E1)
+        return pump_rhs, self.rhs(t, E1, E0, laplacian_phi, seed_args, iaw_density)
 
-    def __call__(self, t: float, E0: Array, E1: Array, phi_k: Array, pump_args: dict, seed_args: dict | None):
+    def __call__(
+        self,
+        t: float,
+        E0: Array,
+        E1: Array,
+        phi_k: Array,
+        pump_args: dict,
+        seed_args: dict | None,
+        iaw_density: Array | None = None,
+    ):
         """
         Advance (E0, E1) over one EPW step: self.n_sub staggered light sub-steps.
 
@@ -148,10 +213,19 @@ class CoupledLight(RamanLight):
         def substep(i, fields):
             E0, E1 = fields
             t_i = t + i * self.dt_l
-            k_e0, k_e1 = self.coupled_rhs(t_i, E0, E1, laplacian_phi, pump_args, seed_args)
+            k_e0, k_e1 = self.coupled_rhs(t_i, E0, E1, laplacian_phi, pump_args, seed_args, iaw_density, phi_k)
             E0 = E0 + self.dt_l * jnp.real(k_e0)
             E1 = E1 + self.dt_l * jnp.real(k_e1)
-            k_e0, k_e1 = self.coupled_rhs(t_i + self.dt_l / 2.0, E0, E1, laplacian_phi, pump_args, seed_args)
+            k_e0, k_e1 = self.coupled_rhs(
+                t_i + self.dt_l / 2.0,
+                E0,
+                E1,
+                laplacian_phi,
+                pump_args,
+                seed_args,
+                iaw_density,
+                phi_k,
+            )
             E0 = E0 + 1j * self.dt_l * jnp.imag(k_e0)
             E1 = E1 + 1j * self.dt_l * jnp.imag(k_e1)
             E0 = E0 * self.sub_boundary[..., None]

--- a/adept/_lpse2d/core/raman.py
+++ b/adept/_lpse2d/core/raman.py
@@ -117,12 +117,24 @@ class RamanLight:
         row_i1p1 = 1j * amp * envelope_y * jnp.exp(-1j * k1 * self.x[self.i1] - 1j * self.w1 * dw1 * t)
         return row_i1, row_i1p1
 
-    def rhs(self, t: float, E1: Array, E0: Array, laplacian_phi: Array, seed_args: dict | None) -> Array:
+    def rhs(
+        self,
+        t: float,
+        E1: Array,
+        E0: Array,
+        laplacian_phi: Array,
+        seed_args: dict | None,
+        iaw_density: Array | None = None,
+    ) -> Array:
         e1x, e1y = E1[..., 0], E1[..., 1]
+        linear_coeff = self.linear_coeff
+        if iaw_density is not None:
+            # MATLAB: i*w1/2 * [1 - wp0^2/w1^2 * (n_b/n_env + Nelf)] E1
+            linear_coeff = linear_coeff - 1j * self.wp0**2 / (2.0 * self.w1) * iaw_density
 
         # paraxial propagation with cross-derivative terms (MATLAB lines 1663-1671)
-        k_e1x = self.diffraction_coeff * (self._d2y(e1x) - self._dxdy(e1y)) + self.linear_coeff * e1x
-        k_e1y = self.diffraction_coeff * (self._d2x(e1y) - self._dxdy(e1x)) + self.linear_coeff * e1y
+        k_e1x = self.diffraction_coeff * (self._d2y(e1x) - self._dxdy(e1y)) + linear_coeff * e1x
+        k_e1y = self.diffraction_coeff * (self._d2x(e1y) - self._dxdy(e1x)) + linear_coeff * e1y
 
         # SRS coupling to the EPW (MATLAB lines 1684-1689, potential formulation)
         k_e1x += self.srs_coeff * jnp.conj(laplacian_phi) * E0[..., 0]
@@ -135,7 +147,15 @@ class RamanLight:
 
         return jnp.stack([k_e1x, k_e1y], axis=-1)
 
-    def __call__(self, t: float, E1: Array, E0_fn, phi_k: Array, seed_args: dict | None) -> Array:
+    def __call__(
+        self,
+        t: float,
+        E1: Array,
+        E0_fn,
+        phi_k: Array,
+        seed_args: dict | None,
+        iaw_density: Array | None = None,
+    ) -> Array:
         """
         Advance E1 over one EPW step (self.n_sub staggered light sub-steps).
 
@@ -151,10 +171,17 @@ class RamanLight:
         def substep(i, E1):
             t_i = t + i * self.dt_l
             # real-part update with the RHS at t_i (MATLAB lines 1380-1397)
-            k1 = self.rhs(t_i, E1, E0_fn(t_i), laplacian_phi, seed_args)
+            k1 = self.rhs(t_i, E1, E0_fn(t_i), laplacian_phi, seed_args, iaw_density)
             E1 = E1 + self.dt_l * jnp.real(k1)
             # imaginary-part update with the RHS at t_i + dt/2 (MATLAB lines 1400-1421)
-            k2 = self.rhs(t_i + self.dt_l / 2.0, E1, E0_fn(t_i + self.dt_l / 2.0), laplacian_phi, seed_args)
+            k2 = self.rhs(
+                t_i + self.dt_l / 2.0,
+                E1,
+                E0_fn(t_i + self.dt_l / 2.0),
+                laplacian_phi,
+                seed_args,
+                iaw_density,
+            )
             E1 = E1 + 1j * self.dt_l * jnp.imag(k2)
             # absorbing boundaries (MATLAB lines 977-983)
             E1 = E1 * self.sub_boundary[..., None]

--- a/adept/_lpse2d/core/vector_field.py
+++ b/adept/_lpse2d/core/vector_field.py
@@ -46,7 +46,7 @@ class SplitStep:
             self.iaw = IonAcousticWave(cfg)
         else:
             self.iaw = None
-        # the HPE keys (x_e, u_e, epw_hist, gamma_L) are real and stay out of this list
+        # HPE particle/histogram keys are real and stay out of this list
         self.complex_state_vars = ["E0", "epw", "E1"]
         self.boundary_envelope = cfg["grid"]["absorbing_boundaries"]
         self.one_over_ksq = cfg["grid"]["one_over_ksq"]

--- a/adept/_lpse2d/core/vector_field.py
+++ b/adept/_lpse2d/core/vector_field.py
@@ -40,6 +40,12 @@ class SplitStep:
             self.hpe = HybridParticleEvolution(cfg)
         else:
             self.hpe = None
+        if cfg["terms"].get("iaw", {}).get("active", False):
+            from adept._lpse2d.core.iaw import IonAcousticWave
+
+            self.iaw = IonAcousticWave(cfg)
+        else:
+            self.iaw = None
         # the HPE keys (x_e, u_e, epw_hist, gamma_L) are real and stay out of this list
         self.complex_state_vars = ["E0", "epw", "E1"]
         self.boundary_envelope = cfg["grid"]["absorbing_boundaries"]
@@ -82,11 +88,18 @@ class SplitStep:
         )
 
     def light_split_step(self, t, y, driver_args):
+        iaw_density = y.get("iaw_density")
         if self.pump_depletion:
             # the pump is a dynamic field sourced by its boundary injector; both light
             # waves advance inside one staggered update (absorbers applied per sub-step)
             y["E0"], y["E1"] = self.coupled_light(
-                t, y["E0"], y["E1"], y["epw"], driver_args["E0"], driver_args.get("E1")
+                t,
+                y["E0"],
+                y["E1"],
+                y["epw"],
+                driver_args["E0"],
+                driver_args.get("E1"),
+                iaw_density,
             )
             return y
 
@@ -105,7 +118,7 @@ class SplitStep:
 
         if self.raman is not None:
             # evolve the Raman light; absorbing boundaries are applied per light sub-step inside
-            y["E1"] = self.raman(t, y["E1"], E0_fn, y["epw"], driver_args.get("E1"))
+            y["E1"] = self.raman(t, y["E1"], E0_fn, y["epw"], driver_args.get("E1"), iaw_density)
         else:
             y["E1"] *= self.boundary_envelope[..., None]
 
@@ -122,6 +135,11 @@ class SplitStep:
             new_y["epw"] += jnp.fft.fft2(self.dt * self.epw.driver(args["drivers"]["E2"], t))
         # epw split step
         new_y["epw"] = self.epw(t, new_y, args)
+
+        # ion-acoustic split step: the updated density is seen by the light and EPW
+        # detuning terms on the next outer step, matching the MATLAB ordering
+        if self.iaw is not None:
+            new_y = self.iaw(new_y)
 
         # particle push + Landau-damping feedback; the gamma_L written here is the
         # rate the EPW update applies on the next step (one-step lag)

--- a/adept/_lpse2d/datamodel.py
+++ b/adept/_lpse2d/datamodel.py
@@ -209,8 +209,9 @@ class IAWModel(BaseModel):
 class HPEModel(BaseModel):
     """Hybrid particle evolution (Follett et al. 2017): test electrons pushed in the
     de-enveloped EPW field feed an evolving Landau damping rate back to the wave
-    solver (kinetic inflation + hot electrons). Quasi-1D (ny == 1) only, and
-    requires terms.epw.damping.landau: true."""
+    solver (kinetic inflation + hot electrons). The tracker is 1D1V for ny == 1
+    and 2D2V otherwise; both use one box-averaged ensemble. Requires
+    terms.epw.damping.landau: true."""
 
     active: bool = False
     n_particles: int = 500000
@@ -218,7 +219,8 @@ class HPEModel(BaseModel):
     v_max: float = 1.0  # histogram half-span, units of c
     v_blend_buffer: float = 0.5  # analytic/HPE blend buffer above v_min, units of vte
     nv: int = 512  # velocity bins spanning (-v_max, v_max)
-    gather_refine: int = 4  # spectral upsampling of Ex before the particle gather
+    n_angles: int = 32  # oriented velocity projections spanning 2pi in 2-D
+    gather_refine: int = 4  # spectral upsampling of Ex/Ey before the particle gather
     substep_courant: float = 0.05  # wp0 * particle substep
     tau_damping: str = "100fs"  # EMA window for the velocity histogram
     t_start: str = "0ps"  # push/feedback disabled before this time

--- a/adept/_lpse2d/datamodel.py
+++ b/adept/_lpse2d/datamodel.py
@@ -132,8 +132,8 @@ class GridModel(BaseModel):
     tmin: str
     ymax: str
     ymin: str
-    # number of Raman-light sub-steps per EPW step (SRS only); computed from the
-    # stability limit if omitted
+    # number of dynamic-light sub-steps per EPW step; computed from the tightest
+    # evolved-carrier stability limit if omitted
     light_substeps: int | None = None
 
 
@@ -185,9 +185,25 @@ class EPWModel(BaseModel):
 
 class LightModel(BaseModel):
     """Light-wave evolution options. pump_depletion evolves E0 with the FD envelope
-    solver (boundary injector + EPW coupling) instead of prescribing it analytically."""
+    solver and reciprocal coupling from every active TPD/SRS source."""
 
     pump_depletion: bool = False
+
+
+class IAWDampingModel(BaseModel):
+    """Ion-acoustic damping parameters from the MATLAB LPSE model."""
+
+    collisions: float = 1.0e-5  # density damping rate, 1/ps
+    landau: float = 0.1  # gamma_iaw = landau * cs * |k|
+
+
+class IAWModel(BaseModel):
+    """Ion-acoustic density/velocity-divergence evolution and ponderomotive drive."""
+
+    active: bool = False
+    boundary: BoundaryModel | None = None  # defaults to terms.epw.boundary
+    damping: IAWDampingModel = IAWDampingModel()
+    max_density_perturbation: float | None = None
 
 
 class HPEModel(BaseModel):
@@ -214,6 +230,7 @@ class HPEModel(BaseModel):
 class TermsModel(BaseModel):
     epw: EPWModel
     light: LightModel = LightModel()
+    iaw: IAWModel | None = None
     hpe: HPEModel | None = None
     zero_mask: bool
 

--- a/adept/_lpse2d/diagnostics.py
+++ b/adept/_lpse2d/diagnostics.py
@@ -1,4 +1,4 @@
-"""Scalar diagnostics for lpse2d SRS runs, mirroring the OSIRIS scan2 metrics.
+"""Scalar diagnostics for lpse2d dynamic-light runs, mirroring OSIRIS scan2 metrics.
 
 The point of this module is one-to-one MLflow comparability with the OSIRIS PIC
 post-processing in the ``osiris-lpi`` repo: metric *names and definitions* here

--- a/adept/_lpse2d/helpers.py
+++ b/adept/_lpse2d/helpers.py
@@ -217,7 +217,7 @@ def get_derived_quantities(cfg: dict) -> dict:
     # Explicit nulls mean "absent". The datamodel advertises `X | None = None` for these
     # fields, so normalize them here -- before anything reads them -- to keep every
     # spelling of "not set" (missing key, or `key: null` in the YAML) equivalent.
-    for term_key in ("hpe", "light"):
+    for term_key in ("hpe", "iaw", "light"):
         if term_key in cfg["terms"] and cfg["terms"][term_key] is None:
             cfg["terms"][term_key] = {}
     if "light_substeps" in cfg_grid and cfg_grid["light_substeps"] is None:
@@ -298,10 +298,46 @@ def get_derived_quantities(cfg: dict) -> dict:
         if epw_source.get("noise_seed") is None:
             epw_source["noise_seed"] = int(np.random.randint(2**20))
 
+    # Ion-acoustic waves: resolve defaults before parameter logging. The MATLAB
+    # split step is a symplectic-Euler update of (div u_i, delta n_i/n0), whose
+    # acoustic branch is stable for omega_max * dt < 2.
+    iaw = cfg["terms"].get("iaw", {})
+    if iaw.get("active", False):
+        from adept._lpse2d.datamodel import IAWModel
+
+        iaw = {**iaw, **IAWModel(**iaw).model_dump()}
+        if iaw["boundary"] is None:
+            iaw["boundary"] = dict(cfg["terms"]["epw"]["boundary"])
+        if iaw["damping"]["collisions"] < 0.0:
+            raise ValueError("terms.iaw.damping.collisions must be non-negative")
+        if iaw["damping"]["landau"] < 0.0:
+            raise ValueError("terms.iaw.damping.landau must be non-negative")
+        max_dn = iaw["max_density_perturbation"]
+        if max_dn is not None and max_dn <= 0.0:
+            raise ValueError("terms.iaw.max_density_perturbation must be positive or null")
+
+        inv_dy_sq = 0.0 if cfg_grid["ny"] == 1 else 1.0 / cfg_grid["dy"] ** 2
+        omega_max = 2.0 * cfg["units"]["derived"]["cs"] * np.sqrt(1.0 / cfg_grid["dx"] ** 2 + inv_dy_sq)
+        if omega_max * cfg_grid["dt"] >= 2.0:
+            raise ValueError(
+                "The ion-acoustic update is unstable: omega_iaw,max * grid.dt must be < 2 "
+                f"(got {omega_max * cfg_grid['dt']:.3g}). Reduce grid.dt or increase grid.dx."
+            )
+        cfg["terms"]["iaw"] = iaw
+        print(
+            "IAWs are on -- evolving density and velocity divergence with "
+            f"omega_iaw,max * dt = {omega_max * cfg_grid['dt']:.3g}"
+        )
+
     # HPE (Follett-style test-particle Landau damping): resolve defaults, convert
     # units, and derive the substep count here so everything lands in MLflow params
     hpe = cfg["terms"].get("hpe", {})
     if hpe.get("active", False):
+        if cfg["terms"]["epw"]["source"].get("tpd", False):
+            raise NotImplementedError(
+                "terms.hpe cannot be combined with TPD yet: TPD requires transverse modes, "
+                "while the current particle tracker evolves only (x, p_x) in a ny == 1 box"
+            )
         if cfg_grid["ny"] != 1:
             raise NotImplementedError("terms.hpe requires a quasi-1D box (ny == 1); shrink the y extent")
         if not cfg["terms"]["epw"]["damping"].get("landau", True):
@@ -324,9 +360,12 @@ def get_derived_quantities(cfg: dict) -> dict:
         )
 
     pump_depletion = cfg["terms"].get("light", {}).get("pump_depletion", False)
+    source_terms = cfg["terms"]["epw"]["source"]
+    srs_on = bool(source_terms.get("srs", False))
+    tpd_on = bool(source_terms.get("tpd", False))
     if pump_depletion:
-        if not cfg["terms"]["epw"]["source"].get("srs", False):
-            raise ValueError("terms.light.pump_depletion requires terms.epw.source.srs: true")
+        if not (srs_on or tpd_on):
+            raise ValueError("terms.light.pump_depletion requires at least one of terms.epw.source.srs/tpd")
         if "E0" not in cfg["drivers"]:
             raise ValueError(
                 "terms.light.pump_depletion requires drivers.E0 (the evolved pump is launched "
@@ -340,7 +379,7 @@ def get_derived_quantities(cfg: dict) -> dict:
                 "(the pump is launched by a boundary injector and must exit the box)"
             )
 
-    if cfg["terms"]["epw"]["source"].get("srs", False):
+    if srs_on:
         derived = cfg["units"]["derived"]
 
         # The SRS source filter only passes wavenumbers up to the local Raman light
@@ -364,10 +403,11 @@ def get_derived_quantities(cfg: dict) -> dict:
                 "(or the envelope density) if you want SRS."
             )
 
-        # The detuning term's operator norm is set by the density endpoint FARTHEST
-        # from each carrier's critical density, not the largest density -- and uniform
-        # boxes carry their density in `val`, which the old max(max, min) fallback
-        # silently replaced with 1.0 (an underestimate at low envelope density).
+    if srs_on or pump_depletion:
+        derived = cfg["units"]["derived"]
+
+        # The detuning term's operator norm is set by the density endpoint farthest
+        # from each evolved carrier's critical density, not the largest density.
         if cfg["density"]["basis"] == "uniform":
             n_endpoints = [float(cfg["density"].get("val", 1.0))]
         else:
@@ -376,29 +416,39 @@ def get_derived_quantities(cfg: dict) -> dict:
         def _worst_detuning_sq(w_carrier: float) -> float:
             return max(abs(w_carrier**2 - derived["w0"] ** 2 * n) for n in n_endpoints)
 
-        dt_max = 1.0 / (
-            2.0 * derived["c"] ** 2 / (cfg_grid["dx"] ** 2 * derived["w1"])
-            + _worst_detuning_sq(derived["w1"]) / (4.0 * derived["w1"])
-        )
-        if pump_depletion:
-            # the evolved pump has its own (looser, but not guaranteed) stability limit;
-            # sub-cycle to the tighter of the two carriers
-            dt_max_pump = 1.0 / (
-                2.0 * derived["c"] ** 2 / (cfg_grid["dx"] ** 2 * derived["w0"])
-                + _worst_detuning_sq(derived["w0"]) / (4.0 * derived["w0"])
+        dt_limits = []
+        evolved_carriers = []
+        if srs_on:
+            dt_limits.append(
+                1.0
+                / (
+                    2.0 * derived["c"] ** 2 / (cfg_grid["dx"] ** 2 * derived["w1"])
+                    + _worst_detuning_sq(derived["w1"]) / (4.0 * derived["w1"])
+                )
             )
-            dt_max = min(dt_max, dt_max_pump)
+            evolved_carriers.append("Raman")
+        if pump_depletion:
+            dt_limits.append(
+                1.0
+                / (
+                    2.0 * derived["c"] ** 2 / (cfg_grid["dx"] ** 2 * derived["w0"])
+                    + _worst_detuning_sq(derived["w0"]) / (4.0 * derived["w0"])
+                )
+            )
+            evolved_carriers.append("pump")
+        dt_max = min(dt_limits)
         if "light_substeps" in cfg_grid:
             n_sub = int(cfg_grid["light_substeps"])
             if cfg_grid["dt"] / n_sub > dt_max:
                 raise ValueError(
                     f"grid.light_substeps = {n_sub} gives a light step of {cfg_grid['dt'] / n_sub:.2e} ps "
-                    f"which exceeds the Raman stability limit of {dt_max:.2e} ps"
+                    f"which exceeds the dynamic-light stability limit of {dt_max:.2e} ps"
                 )
         else:
             n_sub = int(np.ceil(cfg_grid["dt"] / (0.9 * dt_max)))
         cfg_grid["light_substeps"] = n_sub
-        print(f"SRS is on -- the Raman light is sub-cycled {n_sub}x per EPW step (dt_light limit {dt_max:.2e} ps)")
+        carriers = " + ".join(evolved_carriers)
+        print(f"{carriers} light is sub-cycled {n_sub}x per EPW step (dt_light limit {dt_max:.2e} ps)")
 
     # change driver parameters to the right units
     for k in cfg["drivers"].keys():
@@ -556,24 +606,27 @@ def get_solver_quantities(cfg: dict) -> dict:
     boundary_width = _Q(cfg_grid["boundary_width"]).to("um").value
     rise = boundary_width / 5
 
-    if cfg["terms"]["epw"]["boundary"]["x"] == "absorbing":
-        left = cfg["grid"]["xmin"] + boundary_width
-        right = cfg["grid"]["xmax"] - boundary_width
+    def absorbing_boundary(boundary):
+        if boundary["x"] == "absorbing":
+            left = cfg_grid["xmin"] + boundary_width
+            right = cfg_grid["xmax"] - boundary_width
+            envelope_x = get_envelope(rise, rise, left, right, cfg_grid["x"])[:, None]
+        else:
+            envelope_x = np.ones((cfg_grid["nx"], cfg_grid["ny"]))
 
-        envelope_x = get_envelope(rise, rise, left, right, cfg_grid["x"])[:, None]
-    else:
-        envelope_x = np.ones((cfg_grid["nx"], cfg_grid["ny"]))
+        if boundary["y"] == "absorbing":
+            left = cfg_grid["ymin"] + boundary_width
+            right = cfg_grid["ymax"] - boundary_width
+            envelope_y = get_envelope(rise, rise, left, right, cfg_grid["y"])[None, :]
+        else:
+            envelope_y = np.ones((cfg_grid["nx"], cfg_grid["ny"]))
 
-    if cfg["terms"]["epw"]["boundary"]["y"] == "absorbing":
-        left = cfg["grid"]["ymin"] + boundary_width
-        right = cfg["grid"]["ymax"] - boundary_width
-        envelope_y = get_envelope(rise, rise, left, right, cfg_grid["y"])[None, :]
-    else:
-        envelope_y = np.ones((cfg_grid["nx"], cfg_grid["ny"]))
+        return np.exp(-float(cfg_grid["boundary_abs_coeff"]) * cfg_grid["dt"] * (1.0 - envelope_x * envelope_y))
 
-    cfg_grid["absorbing_boundaries"] = np.exp(
-        -float(cfg_grid["boundary_abs_coeff"]) * cfg_grid["dt"] * (1.0 - envelope_x * envelope_y)
-    )
+    cfg_grid["absorbing_boundaries"] = absorbing_boundary(cfg["terms"]["epw"]["boundary"])
+    iaw = cfg["terms"].get("iaw", {})
+    if iaw.get("active", False):
+        cfg_grid["iaw_absorbing_boundaries"] = absorbing_boundary(iaw["boundary"])
 
     cfg_grid["zero_mask"] = (
         np.where(np.sqrt(cfg_grid["kx"][:, None] ** 2 + cfg_grid["ky"][None, :] ** 2) == 0, 0, 1)
@@ -1044,19 +1097,36 @@ def make_field_xarrays(cfg, this_t, state, td):
         coords=(tax_tuple, xax_tuple, yax_tuple),
     )
 
-    kfields = xr.Dataset({"phi": phi_k, "ex": ex_k, "ey": ey_k})
-    fields = xr.Dataset(
-        {
-            "phi": phi_x,
-            "ex": ex,
-            "ey": ey,
-            "e0_x": e0x,
-            "e0_y": e0y,
-            "e1_x": e1x,
-            "e1_y": e1y,
-            "background_density": background_density,
-        }
-    )
+    kfield_data = {"phi": phi_k, "ex": ex_k, "ey": ey_k}
+    field_data = {
+        "phi": phi_x,
+        "ex": ex,
+        "ey": ey,
+        "e0_x": e0x,
+        "e0_y": e0y,
+        "e1_x": e1x,
+        "e1_y": e1y,
+        "background_density": background_density,
+    }
+    if "iaw_density" in state:
+        iaw_density_np = np.asarray(state["iaw_density"])
+        iaw_velocity_np = np.asarray(state["iaw_velocity_divergence"])
+        field_data["iaw_density"] = xr.DataArray(iaw_density_np, coords=(tax_tuple, xax_tuple, yax_tuple))
+        field_data["iaw_velocity_divergence"] = xr.DataArray(iaw_velocity_np, coords=(tax_tuple, xax_tuple, yax_tuple))
+        k_coords = (
+            tax_tuple,
+            (r"kx ($kc\omega_0^{-1}$)", shift_kx),
+            (r"ky ($kc\omega_0^{-1}$)", shift_ky),
+        )
+        kfield_data["iaw_density"] = xr.DataArray(
+            np.fft.fftshift(np.fft.fft2(iaw_density_np, axes=(1, 2)), axes=(1, 2)), coords=k_coords
+        )
+        kfield_data["iaw_velocity_divergence"] = xr.DataArray(
+            np.fft.fftshift(np.fft.fft2(iaw_velocity_np, axes=(1, 2)), axes=(1, 2)), coords=k_coords
+        )
+
+    kfields = xr.Dataset(kfield_data)
+    fields = xr.Dataset(field_data)
     kfields.to_netcdf(os.path.join(td, "binary", "k-fields.xr"), engine="h5netcdf", invalid_netcdf=True)
     fields.to_netcdf(os.path.join(td, "binary", "fields.xr"), engine="h5netcdf", invalid_netcdf=True)
 
@@ -1168,6 +1238,8 @@ def get_default_save_func(cfg):
     from adept._lpse2d.core.epw import landau_damping_rate
 
     srs_on = cfg["terms"]["epw"]["source"].get("srs", False)
+    pump_evolved = cfg["terms"].get("light", {}).get("pump_depletion", False)
+    iaw_on = cfg["terms"].get("iaw", {}).get("active", False)
     derived = cfg["units"]["derived"]
     dt = cfg["grid"]["dt"]
     nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
@@ -1221,17 +1293,16 @@ def get_default_save_func(cfg):
         have_ratio_band = bool(np.any(ratio_band))
         gamma_an_safe = np.where(ratio_band, gamma_an_1d, 1.0)
 
-    if srs_on:
-        # Legacy reflectivity probe: sample |E1_y|^2 on the low-density side, just inside
-        # the absorber. R = sqrt(eps1) * <|E1_y|^2>_y / E0_source^2. Kept unchanged for
-        # backward comparability; it sits in the absorber's tanh skirt and reads ~10% low.
+    if srs_on or pump_evolved:
+        # Flux probes for the dynamic-light laser budget. They are also retained for
+        # prescribed-pump SRS so the legacy one-way Raman reflectivity remains available.
         boundary_width = _Q(cfg["grid"]["boundary_width"]).to("um").value
         x_probe = cfg["grid"]["xmin"] + 1.6 * boundary_width
         ix_probe = int(np.argmin(np.abs(np.array(cfg["grid"]["x"]) - x_probe)))
         w0 = derived["w0"]
         w1 = derived["w1"]
         n_probe = float(np.mean(np.array(cfg["grid"]["background_density"])[ix_probe, :]))
-        sqrt_eps1 = np.sqrt(max(1.0 - n_probe * w0**2 / w1**2, 0.0))
+        sqrt_eps1 = np.sqrt(max(1.0 - n_probe * w0**2 / w1**2, 0.0)) if srs_on else 0.0
         E0_source_sq = derived["E0_source"] ** 2
 
         # Flux probes for the OSIRIS-style laser budget. F_j = c^2/(w dx) * Im(E_j* E_j+1)
@@ -1249,7 +1320,7 @@ def get_default_save_func(cfg):
         # with an evolved pump, the incident probe must sit downstream (+x) of the pump
         # injector rows or it reads the near-field of the two-point source
         ix_left_e0 = ix_left
-        if cfg["terms"].get("light", {}).get("pump_depletion", False):
+        if pump_evolved:
             pump_offset = cfg["drivers"]["E0"]["derived"]["offset"]
             ix_inject = int(np.argmin(np.abs(x_grid - (cfg["grid"]["xmin"] + pump_offset))))
             ix_left_e0 = max(ix_left, ix_inject + 4)
@@ -1318,6 +1389,11 @@ def get_default_save_func(cfg):
             jnp.mean(energy_total_factor * e_sq * boundary_sq_loss, axis=1)
         )
 
+        if iaw_on:
+            iaw_density = y["iaw_density"]
+            out["iaw_density_sq"] = jnp.mean(iaw_density**2)
+            out["iaw_density_abs_max"] = jnp.max(jnp.abs(iaw_density))
+
         if hpe_on:
             u = y["u_e"]
             gamma_rel = jnp.sqrt(1.0 + (u / c_light) ** 2)
@@ -1339,17 +1415,21 @@ def get_default_save_func(cfg):
                 # emit NaN so the reduction metrics (nanmin / windowed means) skip it
                 out["hpe_gamma_ratio_kpeak"] = jnp.where(jnp.any(phi_amp > 0.0), ratio[jnp.argmax(phi_amp)], jnp.nan)
 
-        if srs_on:
-            e1 = y["E1"].view(jnp.complex128)
+        if srs_on or pump_evolved:
             e0 = y["E0"].view(jnp.complex128)
-            out["e1_sq"] = jnp.mean(jnp.sum(jnp.abs(e1) ** 2, axis=-1))
-            out["reflectivity"] = sqrt_eps1 * jnp.mean(jnp.abs(e1[ix_probe, :, 1]) ** 2) / E0_source_sq
-            # laser budget channels: physical fluxes (discrete fluxes converted via the
-            # local group-velocity factor), normalized to the nominal incident flux
             out["incident_flux"] = discrete_flux(e0, ix_left_e0, flux_coeff_w0) / corr_e0_left / I0_code
             out["transmitted_flux"] = discrete_flux(e0, ix_right, flux_coeff_w0) / corr_e0_right / I0_code
-            out["reflected_flux"] = -discrete_flux(e1, ix_left, flux_coeff_w1) / corr_e1_left / I0_code
-            out["backrefl_flux"] = discrete_flux(e1, ix_right, flux_coeff_w1) / corr_e1_right / I0_code
+            if srs_on:
+                e1 = y["E1"].view(jnp.complex128)
+                out["e1_sq"] = jnp.mean(jnp.sum(jnp.abs(e1) ** 2, axis=-1))
+                out["reflectivity"] = sqrt_eps1 * jnp.mean(jnp.abs(e1[ix_probe, :, 1]) ** 2) / E0_source_sq
+                out["reflected_flux"] = -discrete_flux(e1, ix_left, flux_coeff_w1) / corr_e1_left / I0_code
+                out["backrefl_flux"] = discrete_flux(e1, ix_right, flux_coeff_w1) / corr_e1_right / I0_code
+            else:
+                # TPD-only: any backward pump content is already included in the signed
+                # net E0 flux. Keep the four-channel budget schema with zero Raman flux.
+                out["reflected_flux"] = jnp.asarray(0.0)
+                out["backrefl_flux"] = jnp.asarray(0.0)
 
         return out
 

--- a/adept/_lpse2d/helpers.py
+++ b/adept/_lpse2d/helpers.py
@@ -333,13 +333,6 @@ def get_derived_quantities(cfg: dict) -> dict:
     # units, and derive the substep count here so everything lands in MLflow params
     hpe = cfg["terms"].get("hpe", {})
     if hpe.get("active", False):
-        if cfg["terms"]["epw"]["source"].get("tpd", False):
-            raise NotImplementedError(
-                "terms.hpe cannot be combined with TPD yet: TPD requires transverse modes, "
-                "while the current particle tracker evolves only (x, p_x) in a ny == 1 box"
-            )
-        if cfg_grid["ny"] != 1:
-            raise NotImplementedError("terms.hpe requires a quasi-1D box (ny == 1); shrink the y extent")
         if not cfg["terms"]["epw"]["damping"].get("landau", True):
             raise ValueError("terms.hpe requires terms.epw.damping.landau: true (it replaces the static rate)")
         # defaults and type coercion come from the datamodel's HPEModel so they are
@@ -349,13 +342,17 @@ def get_derived_quantities(cfg: dict) -> dict:
         hpe = {**hpe, **HPEModel(**hpe).model_dump()}
         if hpe["omega_res"] not in ("bohm_gross", "wp0"):
             raise ValueError("terms.hpe.omega_res must be 'bohm_gross' or 'wp0'")
+        if hpe["n_angles"] < 4:
+            raise ValueError("terms.hpe.n_angles must be at least 4")
         hpe["tau_damping_ps"] = _Q(hpe["tau_damping"]).to("ps").value
         hpe["t_start_ps"] = _Q(hpe["t_start"]).to("ps").value
         wp0 = cfg["units"]["derived"]["wp0"]
         hpe["substeps"] = int(np.ceil(wp0 * cfg_grid["dt"] / float(hpe["substep_courant"])))
         cfg["terms"]["hpe"] = hpe
+        dimensionality = f"2D2V with {hpe['n_angles']} projections" if cfg_grid["ny"] > 1 else "1D1V"
         print(
-            f"HPE is on -- {hpe['n_particles']} tail particles (|v| > {hpe['v_min']} vte), "
+            f"HPE is on -- {hpe['n_particles']} box-averaged tail particles ({dimensionality}, "
+            f"|v| > {hpe['v_min']} vte), "
             f"{hpe['substeps']} particle substeps per EPW step"
         )
 
@@ -956,8 +953,11 @@ def plot_srs_diagnostics(series, metrics, cfg, td):
 
     if "hpe_hist" in series:
         # tail distribution vs time: flattening at the resonant v_phi and a growing
-        # high-energy shoulder are the HPE signatures
+        # high-energy shoulder are the HPE signatures. The 2-D tracker stores one
+        # projected histogram per angle; show their box-wide angular mean here.
         hist = np.asarray(series["hpe_hist"].values, dtype=float)
+        if hist.ndim == 3:
+            hist = np.mean(hist, axis=1)
         v = np.asarray(series["v (c)"].values, dtype=float)
         fig, ax = plt.subplots(1, 2, figsize=(10, 3.5))
         with np.errstate(divide="ignore"):
@@ -1002,12 +1002,19 @@ def make_series_xarrays(cfg, this_t, state, td):
     for k, v in state.items():
         v = np.asarray(v)
         if k == "hpe_hist":
-            # (nt, nv) velocity histogram from the HPE module; the axis is v/c
-            # (a slash in a coord name is illegal in netCDF)
+            # Quasi-1D stores (nt, nv). The 2-D tracker stores the same global
+            # projected distribution at n_angles oriented axes: (nt, angle, nv).
             hpe = cfg["terms"]["hpe"]
             edges = np.linspace(-hpe["v_max"], hpe["v_max"], hpe["nv"] + 1)
             centers = 0.5 * (edges[1:] + edges[:-1])
-            data[k] = xr.DataArray(v, coords=(("t (ps)", this_t), ("v (c)", centers)))
+            if v.ndim == 3:
+                angles = 2.0 * np.pi * np.arange(hpe["n_angles"]) / hpe["n_angles"]
+                data[k] = xr.DataArray(
+                    v,
+                    coords=(("t (ps)", this_t), ("projection angle (rad)", angles), ("v (c)", centers)),
+                )
+            else:
+                data[k] = xr.DataArray(v, coords=(("t (ps)", this_t), ("v (c)", centers)))
         else:
             data[k] = xr.DataArray(v, coords=(("t (ps)", this_t),))
     series_xr = xr.Dataset(data)
@@ -1287,11 +1294,14 @@ def get_default_save_func(cfg):
         w_tail = hpe_arrays["f_tail_frac"] / n_p  # fraction of all electrons per particle
         c_light = derived["c"]
         nu_coll_arr = derived.get("nu_coll", 0.0) * zero_mask
-        gamma_an_1d = np.array(hpe_arrays["gamma_analytic"][:, 0])
+        gamma_an = np.array(hpe_arrays["gamma_analytic"])
+        mask_res = np.array(hpe_arrays["mask_res"])
+        if mask_res.ndim == 1:
+            mask_res = mask_res[:, None]
         # damping-reduction band: resonant modes where the analytic rate is non-negligible
-        ratio_band = np.array(hpe_arrays["mask_res"]) & (gamma_an_1d > 1.0e-4 * derived["wp0"])
+        ratio_band = mask_res & (gamma_an > 1.0e-4 * derived["wp0"])
         have_ratio_band = bool(np.any(ratio_band))
-        gamma_an_safe = np.where(ratio_band, gamma_an_1d, 1.0)
+        gamma_an_safe = np.where(ratio_band, gamma_an, 1.0)
 
     if srs_on or pump_evolved:
         # Flux probes for the dynamic-light laser budget. They are also retained for
@@ -1396,24 +1406,28 @@ def get_default_save_func(cfg):
 
         if hpe_on:
             u = y["u_e"]
-            gamma_rel = jnp.sqrt(1.0 + (u / c_light) ** 2)
+            if u.ndim == 2:
+                gamma_rel = jnp.sqrt(1.0 + jnp.sum((u / c_light) ** 2, axis=-1))
+            else:
+                gamma_rel = jnp.sqrt(1.0 + (u / c_light) ** 2)
             ke_kev = 510.999 * (gamma_rel - 1.0)
             out["fhot_50keV"] = w_tail * jnp.sum(ke_kev > 50.0)
             out["fhot_100keV"] = w_tail * jnp.sum(ke_kev > 100.0)
             out["hpe_mean_energy_keV"] = jnp.mean(ke_kev)
             out["hpe_hist"] = y["epw_hist"]
             if have_ratio_band:
-                ratio = y["gamma_L"][:, 0] / gamma_an_safe
+                ratio = y["gamma_L"] / gamma_an_safe
                 # inflation-o-meters: worst-case reduction across the resonant band
                 # (noisy at low n_particles -- one clamped mode reads 0), and the
                 # reduction at the band mode carrying the most EPW energy (robust,
                 # and the physically relevant one)
                 out["hpe_gamma_ratio_min"] = jnp.min(jnp.where(ratio_band, ratio, jnp.inf))
-                phi_amp = jnp.where(ratio_band, jnp.abs(phi_k[:, 0]), 0.0)
+                phi_amp = jnp.where(ratio_band, jnp.abs(phi_k), 0.0)
                 # before the EPW has any energy in the band (e.g. the zero-initialized
                 # first steps) argmax lands on index 0 where the ratio is meaningless;
                 # emit NaN so the reduction metrics (nanmin / windowed means) skip it
-                out["hpe_gamma_ratio_kpeak"] = jnp.where(jnp.any(phi_amp > 0.0), ratio[jnp.argmax(phi_amp)], jnp.nan)
+                peak_index = jnp.argmax(jnp.ravel(phi_amp))
+                out["hpe_gamma_ratio_kpeak"] = jnp.where(jnp.any(phi_amp > 0.0), jnp.ravel(ratio)[peak_index], jnp.nan)
 
         if srs_on or pump_evolved:
             e0 = y["E0"].view(jnp.complex128)

--- a/adept/_lpse2d/helpers.py
+++ b/adept/_lpse2d/helpers.py
@@ -344,6 +344,11 @@ def get_derived_quantities(cfg: dict) -> dict:
             raise ValueError("terms.hpe.omega_res must be 'bohm_gross' or 'wp0'")
         if hpe["n_angles"] < 4:
             raise ValueError("terms.hpe.n_angles must be at least 4")
+        if hpe["v_min"] < 0.0:
+            raise ValueError("terms.hpe.v_min must be non-negative")
+        vte = np.sqrt(cfg["units"]["derived"]["vte_sq"])
+        if hpe["v_min"] * vte >= 0.99 * cfg["units"]["derived"]["c"]:
+            raise ValueError("terms.hpe.v_min * vte must be below the 0.99c particle-speed cap")
         hpe["tau_damping_ps"] = _Q(hpe["tau_damping"]).to("ps").value
         hpe["t_start_ps"] = _Q(hpe["t_start"]).to("ps").value
         wp0 = cfg["units"]["derived"]["wp0"]

--- a/adept/_lpse2d/modules/base.py
+++ b/adept/_lpse2d/modules/base.py
@@ -94,7 +94,8 @@ class BaseLPSE2D(ADEPTModule):
         if self.cfg["terms"].get("hpe", {}).get("active", False):
             from adept._lpse2d.core.hpe import load_particles
 
-            # x_e/u_e/epw_hist/gamma_L are real float64, so the .view below is a no-op
+            # particle positions/momenta and histogram/damping state are real float64,
+            # so the .view below is a no-op
             state = state | load_particles(self.cfg)
 
         self.state = {k: v.view(dtype=np.float64) for k, v in state.items()}

--- a/adept/_lpse2d/modules/base.py
+++ b/adept/_lpse2d/modules/base.py
@@ -86,6 +86,11 @@ class BaseLPSE2D(ADEPTModule):
         E1 = np.zeros((self.cfg["grid"]["nx"], self.cfg["grid"]["ny"], 2), dtype=np.complex128)
         state = {"epw": epw, "E0": E0, "E1": E1}
 
+        if self.cfg["terms"].get("iaw", {}).get("active", False):
+            iaw_shape = (self.cfg["grid"]["nx"], self.cfg["grid"]["ny"])
+            state["iaw_density"] = np.zeros(iaw_shape, dtype=np.float64)
+            state["iaw_velocity_divergence"] = np.zeros(iaw_shape, dtype=np.float64)
+
         if self.cfg["terms"].get("hpe", {}).get("active", False):
             from adept._lpse2d.core.hpe import load_particles
 

--- a/configs/envelope-2d/tpd-srs-iaw.yaml
+++ b/configs/envelope-2d/tpd-srs-iaw.yaml
@@ -1,9 +1,6 @@
-# Coupled 2D fluid LPI: TPD + backward SRS, reciprocal pump depletion, and
-# ion-acoustic ponderomotive response. This is the maximal genuinely 2D deck.
-#
-# HPE is intentionally absent: the current particle tracker is quasi-1D and
-# cannot represent the oblique resonances of TPD. See srs-hpe.yaml for the
-# kinetic-feedback path.
+# Full coupled 2D LPI: TPD + backward SRS, reciprocal pump depletion,
+# ion-acoustic ponderomotive response, and one box-averaged 2D2V tail-particle
+# ensemble feeding angle-resolved Landau damping back to every EPW mode.
 density:
   basis: linear
   gradient scale length: 200um
@@ -78,6 +75,14 @@ terms:
       collisions: 1.0e-5
       landau: 0.1
     max_density_perturbation: 0.1
+  hpe:
+    active: true
+    n_particles: 500000
+    n_angles: 32
+    v_min: 2.5
+    substep_courant: 0.05
+    tau_damping: 100fs
+    t_start: 0ps
   light:
     pump_depletion: true
   zero_mask: true

--- a/configs/envelope-2d/tpd-srs-iaw.yaml
+++ b/configs/envelope-2d/tpd-srs-iaw.yaml
@@ -1,0 +1,91 @@
+# Coupled 2D fluid LPI: TPD + backward SRS, reciprocal pump depletion, and
+# ion-acoustic ponderomotive response. This is the maximal genuinely 2D deck.
+#
+# HPE is intentionally absent: the current particle tracker is quasi-1D and
+# cannot represent the oblique resonances of TPD. See srs-hpe.yaml for the
+# kinetic-feedback path.
+density:
+  basis: linear
+  gradient scale length: 200um
+  max: 0.28
+  min: 0.18
+  noise:
+    max: 1.0e-09
+    min: 1.0e-10
+    type: uniform
+drivers:
+  E0:
+    delta_omega_max: 0.015
+    envelope:
+      tc: 200.25ps
+      tr: 0.1ps
+      tw: 400ps
+      xc: 50um
+      xr: 0.2um
+      xw: 1000um
+      yc: 50um
+      yr: 0.2um
+      yw: 1000um
+    num_colors: 1
+    shape: uniform
+    params:
+      phases:
+        seed: 42
+grid:
+  boundary_abs_coeff: 1.0e4
+  boundary_width: 1.5um
+  dealias: shifted-band
+  low_pass_filter: 0.6
+  dt: 1fs
+  dx: 66.3nm
+  tmax: 5ps
+  tmin: 0ps
+  ymax: 6um
+  ymin: -6um
+mlflow:
+  experiment: tpd-srs-iaw
+  run: tpd-srs-iaw
+save:
+  fields:
+    t:
+      dt: 0.2ps
+      tmax: 5ps
+      tmin: 0ps
+    x:
+      dx: 80nm
+    y:
+      dy: 80nm
+solver: envelope-2d
+terms:
+  epw:
+    boundary:
+      x: absorbing
+      y: periodic
+    damping:
+      collisions: 1.0
+      landau: true
+    density_gradient: true
+    linear: true
+    source:
+      noise: true
+      noise_seed: 42
+      tpd: true
+      srs: true
+  iaw:
+    active: true
+    boundary: null
+    damping:
+      collisions: 1.0e-5
+      landau: 0.1
+    max_density_perturbation: 0.1
+  light:
+    pump_depletion: true
+  zero_mask: true
+units:
+  atomic number: 40
+  envelope density: 0.25
+  ionization state: 6
+  laser intensity: 3.5e+14W/cm^2
+  laser_wavelength: 351nm
+  reference electron temperature: 2000eV
+  reference ion temperature: 1000eV

--- a/docs/dev/lpse2d-hpe-plan.md
+++ b/docs/dev/lpse2d-hpe-plan.md
@@ -1,6 +1,6 @@
 # Plan: Follett-style Hybrid Particle Evolution (HPE) for lpse2d
 
-> **Status update (2026-07-30): implemented** through M3 in `adept/_lpse2d/core/hpe.py`
+> **Status update (2026-09-04): implemented in 1D1V and 2D2V** through M3 in `adept/_lpse2d/core/hpe.py`
 > (+ integration per Sec. 3). Notable deviations/findings from implementation:
 >
 > 1. **Signed-k damping formula**: Eq. in Sec. 2.2 needs a $\mathrm{sgn}(k_x)$:
@@ -29,10 +29,15 @@
 >    frequency/carrier sign, M1 calibration, M3a linear closure, M3b O'Neil
 >    flattening, end-to-end SRS smoke). Production config:
 >    `configs/envelope-2d/srs-hpe.yaml`.
+> 8. **2-D extension**: one box-wide `(x,y,p_x,p_y)` ensemble gathers both EPW
+>    field components. Its spatially averaged distribution is retained as 32
+>    oriented projections `f(v . k_hat)`, then interpolated in angle and resonant
+>    velocity for every `(kx,ky)` mode. This composes with oblique TPD in
+>    `configs/envelope-2d/tpd-srs-iaw.yaml`; there is no per-cell particle ensemble.
 
 **Goal:** add the test-particle / self-consistent Landau damping module of Follett et al., *Phys. Plasmas* **24**, 102134 (2017) to the JAX lpse2d SRS solver, so that kinetic inflation (trapping-induced damping reduction) and hot-electron generation are captured. This targets the one remaining fluid-vs-PIC gap in the scan2 replication: all 63 LPSE-dead-but-OSIRIS-active points sit in the marginal-threshold / high-$T_e$ band where trapping physics decides the outcome (`srs-campaign/sims/lpse-srs-scan-test/NOTES.md`).
 
-Status: **plan only — nothing implemented.** Branch context: `lpse2d/srs` @ `d3f8321` (clean).
+Historical planning context follows; the status block above records the implemented result.
 
 ---
 

--- a/docs/source/solvers/lpse2d/config.md
+++ b/docs/source/solvers/lpse2d/config.md
@@ -432,19 +432,20 @@ terms:
 
 ### hpe (optional)
 
-Hybrid particle evolution, following Follett et al., *Phys. Plasmas* **24**, 102134 (2017): test electrons drawn from the Maxwellian tail are pushed relativistically in the de-enveloped electrostatic field $\tilde{E}_x = \mathrm{Re}[E_x e^{-i\omega_{p0}t}]$, their spatially-averaged velocity distribution is accumulated by exponential moving average, and the Landau damping rate applied by the EPW solver is recomputed from that evolving distribution every step (kinetic inflation + hot-electron generation; Im-only feedback, no nonlinear frequency shift). Quasi-1D only (`ny == 1`), and requires `terms.epw.damping.landau: true`. Because TPD requires transverse modes, setup explicitly rejects `hpe.active: true` together with `source.tpd: true`; angle-resolved TPD kinetic feedback needs a future multidimensional tracker. The particle push dominates the runtime, so HPE runs want a GPU.
+Hybrid particle evolution, following Follett et al., *Phys. Plasmas* **24**, 102134 (2017): test electrons drawn from the Maxwellian tail are pushed relativistically in the de-enveloped electrostatic field, their spatially averaged velocity distribution is accumulated by exponential moving average, and the Landau damping rate applied by the EPW solver is recomputed from that evolving distribution every step (kinetic inflation + hot-electron generation; Im-only feedback, no nonlinear frequency shift). For `ny == 1` the tracker uses `(x, p_x)`; in a 2-D box it uses `(x, y, p_x, p_y)` and gathers both $E_x$ and $E_y$. In both cases there is one box-wide ensemble, not a particle population at each grid point. HPE requires `terms.epw.damping.landau: true`. The particle push dominates runtime, so HPE runs want a GPU.
 
-The damping extraction is calibrated per k-mode so that the freshly loaded Maxwellian tail reproduces the analytic Landau rate exactly; modes whose phase velocity lies below the tail cutoff keep the analytic rate. The default time series gains `fhot_50keV`, `fhot_100keV`, `hpe_mean_energy_keV`, `hpe_gamma_ratio_kpeak` (applied-to-analytic damping ratio at the resonant-band mode carrying the most EPW energy), `hpe_gamma_ratio_min` (band minimum; shot-noise-limited at low `n_particles`), and the tail histogram `hpe_hist`; MLflow metrics gain `fhot_50keV`, `t_first_hot_e_50keV`, and `hpe_damping_reduction_final`, named for one-to-one comparison with the OSIRIS scan2 runs.
+In 2-D the box-wide distribution is represented by `n_angles` oriented projections $f(\mathbf{v}\cdot\hat{\mathbf{k}})$ over $[0,2\pi)$. Opposite directions remain distinct, and the two neighboring angular histograms are interpolated for every `(kx, ky)` mode. This is the Radon-projection form of the resonance integral: its memory is `n_angles * nv`, independent of the spatial mesh. The damping extraction is calibrated per k-mode so that a freshly loaded isotropic Maxwellian tail reproduces the analytic Landau rate exactly; modes whose phase velocity lies below the tail cutoff keep the analytic rate. The default time series gains `fhot_50keV`, `fhot_100keV`, `hpe_mean_energy_keV`, `hpe_gamma_ratio_kpeak` (applied-to-analytic damping ratio at the resonant-band mode carrying the most EPW energy), `hpe_gamma_ratio_min` (band minimum; shot-noise-limited at low `n_particles`), and `hpe_hist` (one velocity histogram in 1-D or an angle-by-velocity array in 2-D); MLflow metrics gain `fhot_50keV`, `t_first_hot_e_50keV`, and `hpe_damping_reduction_final`.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `active` | bool | Enable HPE (default `false`) |
 | `n_particles` | int | Number of tail test particles (default `500000`) |
-| `v_min` | float | Tail cutoff in units of `vte` (default `2.5`); only `~erfc(v_min/sqrt(2))` of a Maxwellian is simulated |
+| `v_min` | float | Tail cutoff in units of `vte` (default `2.5`); the retained fraction is `erfc(v_min/sqrt(2))` in 1D1V and `exp(-v_min^2/2)` for the radial 2D2V tail |
 | `v_max` | float | Histogram half-span in units of `c` (default `1.0`) |
 | `nv` | int | Velocity bins spanning `(-v_max, v_max)` (default `512`) |
+| `n_angles` | int | Number of oriented global velocity projections spanning $2\pi$ in 2-D (default `32`; ignored for `ny == 1`) |
 | `v_blend_buffer` | float | Buffer above `v_min` (units of `vte`) below which modes keep the analytic rate (default `0.5`) |
-| `gather_refine` | int | Spectral upsampling factor for `Ex` before the particle gather (default `4`). Linear interpolation of a wave with `k dx ~ 1-2` rad/cell attenuates the gathered field by `sinc^2(k dx / 2)` (15-30%); upsampling makes this ~1% |
+| `gather_refine` | int | Spectral upsampling factor for `Ex` and `Ey` before the particle gather (default `4`). Linear interpolation of a wave with `k dx ~ 1-2` rad/cell attenuates the gathered field by `sinc^2(k dx / 2)` (15-30%); upsampling makes this ~1% |
 | `substep_courant` | float | `wp0 * dt_particle` for the sub-cycled push (default `0.05`; Follett used 0.035) |
 | `tau_damping` | string | EMA time constant for the velocity histogram (default `"100fs"`, Follett's update interval) |
 | `t_start` | string | Push/feedback disabled before this time (default `"0ps"`); use to let the fluid run reach steady state first |
@@ -608,7 +609,7 @@ with kinetic corrections.
 
 ### Coupled TPD + SRS + IAW
 
-See `configs/envelope-2d/tpd-srs-iaw.yaml` for the maximal 2D fluid model: both
-parametric instabilities, reciprocal pump depletion, ion-acoustic evolution, and
-shifted-band de-aliasing. See `configs/envelope-2d/srs-hpe.yaml` for the quasi-1D
-particle-feedback model; HPE cannot yet represent transverse TPD modes.
+See `configs/envelope-2d/tpd-srs-iaw.yaml` for the full 2-D model: both parametric
+instabilities, reciprocal pump depletion, ion-acoustic evolution, 2D2V particle
+feedback, and shifted-band de-aliasing. See `configs/envelope-2d/srs-hpe.yaml` for
+the less expensive quasi-1D particle-feedback model.

--- a/docs/source/solvers/lpse2d/config.md
+++ b/docs/source/solvers/lpse2d/config.md
@@ -112,7 +112,7 @@ Simulation grid parameters. Note: Grid values use physical units as strings.
 | `tmin` | string | Start time with unit |
 | `ymax` | string | Domain maximum y with unit |
 | `ymin` | string | Domain minimum y with unit |
-| `light_substeps` | int | (SRS only, optional) Raman-light sub-steps per EPW step. Computed from the explicit-scheme stability limit `dt_light < 1 / (2c^2/(dx^2 w1) + \|w1^2 - wpe_max^2\|/(4 w1))` if omitted (with `terms.light.pump_depletion` the limit is the tighter of the `w0` and `w1` carriers); a `ValueError` is raised if a user-supplied value violates it |
+| `light_substeps` | int | (dynamic light only, optional) Light-wave sub-steps per EPW step. Computed from the explicit-scheme stability limit for every evolved carrier (`w1` when SRS is on, `w0` when pump depletion is on); a `ValueError` is raised if a user-supplied value violates the tightest limit |
 | `probe_offset` | string | (SRS only, optional) Distance of the laser-budget flux probes from each box edge, with unit. Default `2 * boundary_width`, which is clear of the absorber's tanh skirt (the legacy `reflectivity` probe at `1.6 * boundary_width` sits inside it and reads ~10% low) |
 
 Note: `nx` and `ny` are computed automatically from the grid parameters. The grid is optimized for FFT performance (sizes with small prime factors).
@@ -352,6 +352,7 @@ Physics terms configuration.
 |-------|------|-------------|
 | `epw` | object | Electron plasma wave configuration |
 | `light` | object | (optional) Light-wave evolution configuration |
+| `iaw` | object | (optional) Ion-acoustic density evolution and ponderomotive feedback |
 | `hpe` | object | (optional) Hybrid particle evolution: test-particle Landau damping feedback (Follett et al. 2017) |
 | `zero_mask` | bool | Whether to zero out k=0 mode |
 
@@ -359,7 +360,7 @@ Physics terms configuration.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `pump_depletion` | bool | (default `false`) Evolve the pump `E0` with the same staggered FD envelope solver as the Raman light instead of prescribing it analytically. The pump is launched by a two-point boundary injector at `x = xmin + drivers.E0.offset` and is depleted by the EPW through `-i e/(4 w1 me) (laplacian phi) E1`. Requires `terms.epw.source.srs: true` and `terms.epw.boundary.x: absorbing`; incompatible with `drivers.E0.speckle`. Enables the true net-flux `laser_reflectivity` / `laser_transmissivity` / `laser_absorbed_frac` metrics and lets above-threshold runs saturate |
+| `pump_depletion` | bool | (default `false`) Evolve the pump `E0` with the staggered FD envelope solver instead of prescribing it analytically. The pump is launched at `x = xmin + drivers.E0.offset`; active SRS and TPD terms each add their reciprocal pump coupling, and both act when both instabilities are enabled. Requires at least one of `terms.epw.source.srs`/`tpd` and `terms.epw.boundary.x: absorbing`; incompatible with `drivers.E0.speckle`. Enables true net-flux `laser_reflectivity` / `laser_transmissivity` / `laser_absorbed_frac` metrics and above-threshold saturation |
 
 ### epw
 
@@ -394,7 +395,7 @@ Physics terms configuration.
 | `noise` | bool | Add random noise source |
 | `noise_amplitude` | float | (optional) Amplitude of the per-step EPW noise source. Default `1.0e-10` (the MATLAB `noiseAmp`) |
 | `noise_seed` | int | (optional) Seed for the EPW noise source. Default `null`, which draws a random seed once and pins it into the config before parameters are logged, so every run is exactly reproducible from its logged `noise_seed` |
-| `tpd` | bool | Include two-plasmon decay source |
+| `tpd` | bool | Include the two-plasmon-decay source. With `terms.light.pump_depletion`, also include its energy-reciprocal feedback on the y-polarized pump |
 | `srs` | bool | Include stimulated Raman scattering (optional, default false). Turning this on also evolves the Raman scattered-light field `E1` with a finite-difference paraxial solver, sub-cycled `grid.light_substeps` times per EPW step, and adds the SRS source `i e wp0/(4 me w0 w1) (n/n_env) E0 . conj(E1)` to the EPW potential. The default time series then also records `e1_sq` and `reflectivity` (Poynting-corrected `|E1_y|^2/E0^2` at a probe on the low-density side, `x = 1.6 * boundary_width`) |
 
 #### hyperviscosity (optional)
@@ -404,9 +405,34 @@ Physics terms configuration.
 | `coeff` | float | Hyperviscosity coefficient |
 | `order` | int | Order of hyperviscosity (must be even) |
 
+### iaw (optional)
+
+The IAW state follows the MATLAB LPSE split update for fractional ion-density perturbation `Nelf` and ion-velocity divergence `W`. Its pressure combines the acoustic restoring term with ponderomotive drive from the EPW, pump, and Raman fields. `Nelf` feeds back into the EPW, pump, and Raman detuning terms on the next outer step.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `active` | bool | Enable ion-acoustic evolution (default `false`) |
+| `boundary` | object or null | Per-axis `x`/`y` boundary modes. Defaults to `terms.epw.boundary` |
+| `damping.collisions` | float | Density damping rate in `1/ps` (default `1.0e-5`) |
+| `damping.landau` | float | Dimensionless coefficient in `gamma_iaw(k) = landau * cs * |k|` (default `0.1`); the velocity-divergence equation is damped at `2 gamma_iaw` |
+| `max_density_perturbation` | float or null | Optional symmetric limiter on `|delta n_i/n_0|`; unlimited by default |
+
+The setup validates the explicit acoustic stability condition `omega_iaw,max * grid.dt < 2`.
+
+```yaml
+terms:
+  iaw:
+    active: true
+    boundary: null
+    damping:
+      collisions: 1.0e-5
+      landau: 0.1
+    max_density_perturbation: 0.1
+```
+
 ### hpe (optional)
 
-Hybrid particle evolution, following Follett et al., *Phys. Plasmas* **24**, 102134 (2017): test electrons drawn from the Maxwellian tail are pushed relativistically in the de-enveloped electrostatic field $\tilde{E}_x = \mathrm{Re}[E_x e^{-i\omega_{p0}t}]$, their spatially-averaged velocity distribution is accumulated by exponential moving average, and the Landau damping rate applied by the EPW solver is recomputed from that evolving distribution every step (kinetic inflation + hot-electron generation; Im-only feedback, no nonlinear frequency shift). Quasi-1D only (`ny == 1`), and requires `terms.epw.damping.landau: true`. The particle push dominates the runtime, so HPE runs want a GPU.
+Hybrid particle evolution, following Follett et al., *Phys. Plasmas* **24**, 102134 (2017): test electrons drawn from the Maxwellian tail are pushed relativistically in the de-enveloped electrostatic field $\tilde{E}_x = \mathrm{Re}[E_x e^{-i\omega_{p0}t}]$, their spatially-averaged velocity distribution is accumulated by exponential moving average, and the Landau damping rate applied by the EPW solver is recomputed from that evolving distribution every step (kinetic inflation + hot-electron generation; Im-only feedback, no nonlinear frequency shift). Quasi-1D only (`ny == 1`), and requires `terms.epw.damping.landau: true`. Because TPD requires transverse modes, setup explicitly rejects `hpe.active: true` together with `source.tpd: true`; angle-resolved TPD kinetic feedback needs a future multidimensional tracker. The particle push dominates the runtime, so HPE runs want a GPU.
 
 The damping extraction is calibrated per k-mode so that the freshly loaded Maxwellian tail reproduces the analytic Landau rate exactly; modes whose phase velocity lies below the tail cutoff keep the analytic rate. The default time series gains `fhot_50keV`, `fhot_100keV`, `hpe_mean_energy_keV`, `hpe_gamma_ratio_kpeak` (applied-to-analytic damping ratio at the resonant-band mode carrying the most EPW energy), `hpe_gamma_ratio_min` (band minimum; shot-noise-limited at low `n_particles`), and the tail histogram `hpe_hist`; MLflow metrics gain `fhot_50keV`, `t_first_hot_e_50keV`, and `hpe_damping_reduction_final`, named for one-to-one comparison with the OSIRIS scan2 runs.
 
@@ -579,3 +605,10 @@ See `configs/envelope-2d/srs.yaml` - Noise-seeded backward SRS on a linear densi
 (the lpse-matlab `srs_1D` case), with a reflectivity time series recorded at a probe on
 the low-density side. Also see `configs/envelope-2d/reflection.yaml` - SRS simulation
 with kinetic corrections.
+
+### Coupled TPD + SRS + IAW
+
+See `configs/envelope-2d/tpd-srs-iaw.yaml` for the maximal 2D fluid model: both
+parametric instabilities, reciprocal pump depletion, ion-acoustic evolution, and
+shifted-band de-aliasing. See `configs/envelope-2d/srs-hpe.yaml` for the quasi-1D
+particle-feedback model; HPE cannot yet represent transverse TPD modes.

--- a/docs/source/solvers/lpse2d/config.md
+++ b/docs/source/solvers/lpse2d/config.md
@@ -436,6 +436,8 @@ Hybrid particle evolution, following Follett et al., *Phys. Plasmas* **24**, 102
 
 In 2-D the box-wide distribution is represented by `n_angles` oriented projections $f(\mathbf{v}\cdot\hat{\mathbf{k}})$ over $[0,2\pi)$. Opposite directions remain distinct, and the two neighboring angular histograms are interpolated for every `(kx, ky)` mode. This is the Radon-projection form of the resonance integral: its memory is `n_angles * nv`, independent of the spatial mesh. The damping extraction is calibrated per k-mode so that a freshly loaded isotropic Maxwellian tail reproduces the analytic Landau rate exactly; modes whose phase velocity lies below the tail cutoff keep the analytic rate. The default time series gains `fhot_50keV`, `fhot_100keV`, `hpe_mean_energy_keV`, `hpe_gamma_ratio_kpeak` (applied-to-analytic damping ratio at the resonant-band mode carrying the most EPW energy), `hpe_gamma_ratio_min` (band minimum; shot-noise-limited at low `n_particles`), and `hpe_hist` (one velocity histogram in 1-D or an angle-by-velocity array in 2-D); MLflow metrics gain `fhot_50keV`, `t_first_hot_e_50keV`, and `hpe_damping_reduction_final`.
 
+At an absorbing particle wall, outgoing particles are thermalized and reinjected from the flux-weighted retained-tail law. In 2-D wall coordinates this is $p(r,\theta) \propto r^2\exp[-r^2/(2v_{te}^2)]\cos\theta$ for $r > v_{\min}$ and inward $-\pi/2 < \theta < \pi/2$. This distinction is required to keep repeated wall crossings from biasing the global directional distribution.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `active` | bool | Enable HPE (default `false`) |

--- a/docs/source/solvers/lpse2d/overview.md
+++ b/docs/source/solvers/lpse2d/overview.md
@@ -87,7 +87,7 @@ box and receives the reciprocal TPD and/or SRS feedback described above.
 
 ### Hybrid particles and the 2D boundary
 
-The HPE particle tracker supplies self-consistent Landau-damping feedback and hot-electron diagnostics for quasi-1D runs (`ny == 1`). It can be combined with SRS, pump depletion, and IAWs. It is not yet a 2D kinetic model: angle-resolved TPD feedback would require particles carrying at least `(x, y, p_x, p_y)` and a multidimensional resonant-distribution estimator. Consequently, `configs/envelope-2d/tpd-srs-iaw.yaml` demonstrates the complete 2D fluid coupling, while `srs-hpe.yaml` remains the kinetic-feedback example.
+The HPE particle tracker supplies self-consistent Landau-damping feedback and hot-electron diagnostics in both quasi-1D and 2D runs. For `ny > 1`, a single box-wide ensemble carries `(x, y, p_x, p_y)` and samples both electric-field components; angle-resolved projected-velocity histograms provide the resonant distribution for every `(k_x, k_y)` mode without assigning particles to individual grid cells. Periodic boundaries wrap particles, while reservoir walls use flux-weighted thermal-tail reinjection. HPE can be combined with TPD, SRS, pump depletion, and IAWs, as demonstrated by `configs/envelope-2d/tpd-srs-iaw.yaml`; `srs-hpe.yaml` remains the smaller quasi-1D example.
 
 ## What Gets Saved
 

--- a/docs/source/solvers/lpse2d/overview.md
+++ b/docs/source/solvers/lpse2d/overview.md
@@ -14,7 +14,12 @@ These equations model the evolution and interaction of the complex envelopes of 
 
 One can solve these equations with or without "pump depletion". "Pump depletion" is the effect of the plasma waves on the light waves. By default the pump is prescribed analytically (an external driver for the plasma waves), which is adequate below the absolute instability threshold; above it the plasma-wave and Raman fields grow without bound because nothing depletes the pump.
 
-For SRS, setting `terms.light.pump_depletion: true` evolves the pump `E0` with the same finite-difference envelope solver as the Raman light, sourced by a two-point boundary injector at the low-density side and coupled to the EPW through $-i e/(4 \omega_1 m_e) (\nabla^2 \phi) \mathbf{E}_1$ (the conjugate partner of the Raman coupling; the pair conserves $\int |E_0|^2 + |E_1|^2 + |\nabla\phi|^2$ together with the EPW source). This enables true transmission/absorption diagnostics and saturation of above-threshold runs.
+Setting `terms.light.pump_depletion: true` evolves the pump `E0` with the finite-difference envelope solver and a two-point boundary injector at the low-density side. Every active instability contributes its reciprocal pump term:
+
+- SRS contributes $-i e/(4 \omega_1 m_e) (\nabla^2 \phi) \mathbf{E}_1$.
+- TPD contributes $i e/(4 \omega_0 m_e) e^{i(\omega_0-2\omega_{p0})t} E_{h,y}\nabla\!\cdot\!\mathbf{E}_h$ to the y-polarized pump. This is the discrete reciprocal of the existing TPD source and conserves $\int[|E_0|^2+(\omega_{p0}/\omega_0)|\mathbf{E}_h|^2]$ for the coupling terms alone.
+
+Both terms are included when TPD and SRS are enabled together. Dynamic pump evolution enables true transmission/absorption diagnostics and provides the physical saturation channel needed above threshold.
 
 ### SRS diagnostics
 
@@ -65,9 +70,9 @@ density gradient, periodic transverse to it. The $k=0$ mode is masked out of the
 
 ## Forcing and Drivers
 
-Because pump depletion is not implemented, **the laser is pure forcing** — it drives the plasma waves
-and is never itself depleted. That is the central approximation of this solver and the reason it is
-only valid below the absolute instability threshold.
+With `terms.light.pump_depletion: false`, the laser is prescribed forcing and is therefore appropriate
+only while depletion is negligible. With depletion enabled, the injected pump propagates through the
+box and receives the reciprocal TPD and/or SRS feedback described above.
 
 | Term | Role |
 |---|---|
@@ -75,6 +80,14 @@ only valid below the absolute instability threshold.
 | $S_\text{TPD}$ | The two-plasmon-decay source coupling $E_0$ to the plasma-wave envelope. |
 | $S_h$ | A noise/seed source for the plasma waves. |
 | $\nu_e^\circ$ | Landau damping of the plasma-wave envelope. |
+
+### Ion-acoustic waves
+
+`terms.iaw.active: true` evolves the fractional ion-density perturbation and ion-velocity divergence using the MATLAB LPSE split step. The pressure contains acoustic restoring force plus ponderomotive drive from the EPW, pump, and Raman fields. The resulting density perturbation feeds back into the detuning of all three envelope equations. IAW boundary damping defaults to the EPW boundary configuration; collisional and Landau damping are independently configurable.
+
+### Hybrid particles and the 2D boundary
+
+The HPE particle tracker supplies self-consistent Landau-damping feedback and hot-electron diagnostics for quasi-1D runs (`ny == 1`). It can be combined with SRS, pump depletion, and IAWs. It is not yet a 2D kinetic model: angle-resolved TPD feedback would require particles carrying at least `(x, y, p_x, p_y)` and a multidimensional resonant-distribution estimator. Consequently, `configs/envelope-2d/tpd-srs-iaw.yaml` demonstrates the complete 2D fluid coupling, while `srs-hpe.yaml` remains the kinetic-feedback example.
 
 ## What Gets Saved
 
@@ -85,6 +98,8 @@ only valid below the absolute instability threshold.
 | `fields.xr` | The real-space envelope fields over time |
 | `k-fields.xr` | The same in wavenumber space — this is where TPD growth is measured |
 | `series.xr` | Scalar time series |
+
+When IAWs are active, `fields.xr` and `k-fields.xr` also contain `iaw_density` and `iaw_velocity_divergence`; `series.xr` includes `iaw_density_sq` and `iaw_density_abs_max`.
 
 **`plots/`**, per field `k`:
 

--- a/tests/test_lpse2d/test_hpe.py
+++ b/tests/test_lpse2d/test_hpe.py
@@ -60,6 +60,20 @@ def _make_cfg(hpe_overrides=None, cfg_overrides=None):
     return cfg
 
 
+def _make_cfg_2d(hpe_overrides=None):
+    """Small periodic 2-D box using the same plasma parameters as the 1-D tests."""
+    overrides = {"n_particles": 20000, "n_angles": 16, "gather_refine": 2}
+    if hpe_overrides:
+        overrides.update(hpe_overrides)
+    return _make_cfg(
+        overrides,
+        {
+            "grid.ymin": "-0.4um",
+            "grid.ymax": "0.4um",
+        },
+    )
+
+
 def _single_mode_phi_k(cfg, k_target, e_amp):
     """phi_k with one +k mode such that ex_envelope(x) = e_amp * exp(i k x).
 
@@ -98,6 +112,38 @@ def test_free_streaming():
 
     np.testing.assert_allclose(np.array(u_new), np.array(u), rtol=0, atol=1e-12)
     np.testing.assert_allclose(np.array(x_new), x_expected, rtol=0, atol=1e-9)
+
+
+def test_2d_free_streaming_and_both_field_components():
+    """The 2D2V pusher advances both coordinates and gathers the full grad(phi)."""
+    from adept._lpse2d.core.hpe import HybridParticleEvolution
+
+    cfg = _make_cfg_2d({"n_particles": 256})
+    hpe = HybridParticleEvolution(cfg)
+    rng = np.random.default_rng(7402)
+    x = jnp.asarray(rng.uniform(cfg["grid"]["xmin"], cfg["grid"]["xmax"], hpe.n_p))
+    y = jnp.asarray(rng.uniform(cfg["grid"]["ymin"], cfg["grid"]["ymax"], hpe.n_p))
+    u = jnp.asarray(rng.normal(0.0, 100.0, (hpe.n_p, 2)))
+    zero_field = jnp.zeros((hpe.nx_f, hpe.ny_f, 2), dtype=jnp.complex128)
+
+    x_new, y_new, u_new = hpe.push_2d(x, y, u, zero_field, 0.0)
+    gamma = np.sqrt(1.0 + np.sum((np.asarray(u) / hpe.c) ** 2, axis=-1))
+    x_expected = np.mod(np.asarray(x) + hpe.dt * np.asarray(u)[:, 0] / gamma - hpe.xmin, hpe.Lx) + hpe.xmin
+    y_expected = np.mod(np.asarray(y) + hpe.dt * np.asarray(u)[:, 1] / gamma - hpe.ymin, hpe.Ly) + hpe.ymin
+    np.testing.assert_allclose(u_new, u, rtol=0.0, atol=1.0e-12)
+    np.testing.assert_allclose(x_new, x_expected, rtol=0.0, atol=1.0e-9)
+    np.testing.assert_allclose(y_new, y_expected, rtol=0.0, atol=1.0e-9)
+
+    # A single oblique potential mode has Ey/Ex = ky/kx everywhere. This pins the
+    # transverse spectral reconstruction and the bilinear gather convention.
+    phi_k = np.zeros((hpe.nx, hpe.ny), dtype=np.complex128)
+    mx, my = 3, 2
+    phi_k[mx, my] = 1.0e-4 * hpe.nx * hpe.ny
+    e_env = hpe.refine_e(jnp.asarray(phi_k))
+    acceleration = np.asarray(hpe._accel_2d(x, y, e_env, 0.0))
+    k_ratio = float(np.asarray(hpe.ky)[my] / np.asarray(hpe.kx)[mx])
+    active = np.abs(acceleration[:, 0]) > 1.0e-12 * np.max(np.abs(acceleration[:, 0]))
+    np.testing.assert_allclose(acceleration[active, 1], k_ratio * acceleration[active, 0], rtol=2.0e-6, atol=1.0e-8)
 
 
 def test_bounce_frequency_and_carrier_sign():
@@ -199,6 +245,65 @@ def test_loading_and_histogram_normalization():
 
     # initial gamma_L is exactly the analytic array
     np.testing.assert_allclose(state["gamma_L"], np.array(arrays["gamma_analytic"]), rtol=1e-12)
+
+
+def test_2d_loading_is_one_box_averaged_ensemble():
+    from adept._lpse2d.core.hpe import load_particles, resonance_arrays
+
+    cfg = _make_cfg_2d({"n_particles": 50000})
+    state = load_particles(cfg)
+    arrays = resonance_arrays(cfg)
+
+    assert state["x_e"].shape == (50000,)
+    assert state["y_e"].shape == (50000,)
+    assert state["u_e"].shape == (50000, 2)
+    assert state["epw_hist"].shape == (16, cfg["terms"]["hpe"]["nv"])
+    np.testing.assert_allclose(np.sum(state["epw_hist"], axis=1) * arrays["dv"], 1.0, rtol=2.0e-4)
+
+    c = cfg["units"]["derived"]["c"]
+    vte = np.sqrt(cfg["units"]["derived"]["vte_sq"])
+    gamma = np.sqrt(1.0 + np.sum((state["u_e"] / c) ** 2, axis=-1))
+    speed = np.linalg.norm(state["u_e"] / gamma[:, None], axis=-1)
+    assert np.all(speed > cfg["terms"]["hpe"]["v_min"] * vte - 1.0e-9)
+    assert np.all(speed < c)
+    assert arrays["mask_res"].shape == (cfg["grid"]["nx"], cfg["grid"]["ny"])
+    assert np.any(arrays["mask_res"] & (np.abs(np.asarray(cfg["grid"]["ky"]))[None, :] > 0.0))
+
+
+def test_2d_expected_tail_calibrates_every_oblique_mode():
+    """The global directional marginals reproduce analytic damping over the 2-D band."""
+    from adept._lpse2d.core.hpe import HybridParticleEvolution, resonance_arrays
+
+    cfg = _make_cfg_2d({"n_particles": 64})
+    hpe = HybridParticleEvolution(cfg)
+    arrays = resonance_arrays(cfg)
+    expected = jnp.broadcast_to(jnp.asarray(arrays["f0_expected"]), (hpe.n_angles, hpe.nv))
+    gamma = np.asarray(hpe.damping(expected))
+    analytic = np.asarray(hpe.gamma_analytic)
+    mask = np.asarray(hpe.mask_res)
+    assert np.any(mask)
+    np.testing.assert_allclose(gamma[mask], analytic[mask], rtol=2.0e-6, atol=1.0e-10)
+
+
+def test_2d_damping_is_directional_not_broadcast_over_ky():
+    """Flattening one global projection only undamps modes in that direction."""
+    from adept._lpse2d.core.hpe import HybridParticleEvolution, resonance_arrays
+
+    cfg = _make_cfg_2d({"n_particles": 64})
+    hpe = HybridParticleEvolution(cfg)
+    arrays = resonance_arrays(cfg)
+    expected = jnp.broadcast_to(jnp.asarray(arrays["f0_expected"]), (hpe.n_angles, hpe.nv))
+    flat = jnp.full((hpe.nv,), 1.0 / (hpe.nv * hpe.dv))
+    gamma = np.asarray(hpe.damping(expected.at[0].set(flat)))
+    analytic = np.asarray(hpe.gamma_analytic)
+    mask = np.asarray(hpe.mask_res)
+    kx, ky = np.asarray(cfg["grid"]["kx"]), np.asarray(cfg["grid"]["ky"])
+
+    plus_x = mask[:, 0] & (kx > 0.0)
+    plus_y = mask[0, :] & (ky > 0.0)
+    assert np.any(plus_x) and np.any(plus_y)
+    assert np.all(gamma[plus_x, 0] < 1.0e-10 * analytic[plus_x, 0])
+    np.testing.assert_allclose(gamma[0, plus_y], analytic[0, plus_y], rtol=2.0e-6, atol=1.0e-10)
 
 
 def test_damping_calibration():

--- a/tests/test_lpse2d/test_hpe.py
+++ b/tests/test_lpse2d/test_hpe.py
@@ -60,17 +60,20 @@ def _make_cfg(hpe_overrides=None, cfg_overrides=None):
     return cfg
 
 
-def _make_cfg_2d(hpe_overrides=None):
+def _make_cfg_2d(hpe_overrides=None, cfg_overrides=None):
     """Small periodic 2-D box using the same plasma parameters as the 1-D tests."""
     overrides = {"n_particles": 20000, "n_angles": 16, "gather_refine": 2}
     if hpe_overrides:
         overrides.update(hpe_overrides)
+    config = {
+        "grid.ymin": "-0.4um",
+        "grid.ymax": "0.4um",
+    }
+    if cfg_overrides:
+        config.update(cfg_overrides)
     return _make_cfg(
         overrides,
-        {
-            "grid.ymin": "-0.4um",
-            "grid.ymax": "0.4um",
-        },
+        config,
     )
 
 
@@ -144,6 +147,66 @@ def test_2d_free_streaming_and_both_field_components():
     k_ratio = float(np.asarray(hpe.ky)[my] / np.asarray(hpe.kx)[mx])
     active = np.abs(acceleration[:, 0]) > 1.0e-12 * np.max(np.abs(acceleration[:, 0]))
     np.testing.assert_allclose(acceleration[active, 1], k_ratio * acceleration[active, 0], rtol=2.0e-6, atol=1.0e-8)
+
+
+def test_2d_wall_reinjection_is_flux_weighted():
+    """Incoming wall particles follow the truncated Maxwell-flux radial/angular law."""
+    import jax
+    from scipy import stats
+
+    from adept._lpse2d.core.hpe import HybridParticleEvolution
+
+    n_particles = 100000
+    cfg = _make_cfg_2d(
+        {"n_particles": n_particles},
+        {
+            "terms.epw.boundary.x": "absorbing",
+            "terms.epw.boundary.y": "absorbing",
+        },
+    )
+    hpe = HybridParticleEvolution(cfg)
+    normal, tangent = hpe._sample_flux_weighted_tail(jax.random.PRNGKey(7403))
+    normal, tangent = np.asarray(normal), np.asarray(tangent)
+    speed = np.sqrt(normal**2 + tangent**2)
+
+    assert np.all(normal >= 0.0)
+    assert np.all(speed >= hpe.v_min)
+    assert np.all(speed <= 0.99 * hpe.c)
+
+    # Radial probability integral transform for the Maxwell speed law truncated
+    # to [v_min, 0.99c] must be uniform.
+    cdf_min = stats.maxwell.cdf(hpe.v_min, scale=hpe.vte)
+    cdf_max = stats.maxwell.cdf(0.99 * hpe.c, scale=hpe.vte)
+    radial_quantile = (stats.maxwell.cdf(speed, scale=hpe.vte) - cdf_min) / (cdf_max - cdf_min)
+    np.testing.assert_allclose(np.mean(radial_quantile), 0.5, atol=4.0e-3)
+    np.testing.assert_allclose(np.var(radial_quantile), 1.0 / 12.0, atol=2.0e-3)
+
+    # p(theta)=cos(theta)/2 is equivalent to sin(theta) uniform on [-1,1].
+    sin_theta = tangent / speed
+    np.testing.assert_allclose(np.mean(sin_theta), 0.0, atol=5.0e-3)
+    np.testing.assert_allclose(np.var(sin_theta), 1.0 / 3.0, atol=4.0e-3)
+
+    # The boundary mapping rotates the sampled wall frame correctly for all four
+    # faces. Each quarter of the ensemble exits through a different wall.
+    quarter = n_particles // 4
+    x = np.full(n_particles, 0.5 * (hpe.xmin + hpe.xmax))
+    y = np.full(n_particles, 0.5 * (hpe.ymin + hpe.ymax))
+    x[:quarter] = hpe.xmin - hpe.dx
+    x[quarter : 2 * quarter] = hpe.xmax + hpe.dx
+    y[2 * quarter : 3 * quarter] = hpe.ymin - hpe.dy
+    y[3 * quarter :] = hpe.ymax + hpe.dy
+    u = jnp.zeros((n_particles, 2))
+    x_new, y_new, u_new = hpe._apply_boundaries_2d(jnp.asarray(x), jnp.asarray(y), u, 0.0)
+    gamma_rel = np.sqrt(1.0 + np.sum((np.asarray(u_new) / hpe.c) ** 2, axis=-1))
+    velocity = np.asarray(u_new) / gamma_rel[:, None]
+    np.testing.assert_allclose(x_new[:quarter], hpe.xmin, rtol=0.0, atol=0.0)
+    np.testing.assert_allclose(x_new[quarter : 2 * quarter], hpe.xmax, rtol=0.0, atol=0.0)
+    np.testing.assert_allclose(y_new[2 * quarter : 3 * quarter], hpe.ymin, rtol=0.0, atol=0.0)
+    np.testing.assert_allclose(y_new[3 * quarter :], hpe.ymax, rtol=0.0, atol=0.0)
+    assert np.all(velocity[:quarter, 0] > 0.0)
+    assert np.all(velocity[quarter : 2 * quarter, 0] < 0.0)
+    assert np.all(velocity[2 * quarter : 3 * quarter, 1] > 0.0)
+    assert np.all(velocity[3 * quarter :, 1] < 0.0)
 
 
 def test_bounce_frequency_and_carrier_sign():

--- a/tests/test_lpse2d/test_iaw.py
+++ b/tests/test_lpse2d/test_iaw.py
@@ -1,0 +1,224 @@
+"""Tests for the ion-acoustic-wave path ported from lpse-matlab."""
+
+import numpy as np
+import yaml
+from jax import numpy as jnp
+
+
+def _make_cfg(*, landau=0.0, collisions=0.0, max_density_perturbation=None, with_pump=False):
+    from adept._lpse2d.helpers import get_density_profile, get_derived_quantities, get_solver_quantities, write_units
+
+    with open("tests/test_lpse2d/configs/epw.yaml") as fi:
+        cfg = yaml.safe_load(fi)
+    if with_pump:
+        with open("tests/test_lpse2d/configs/tpd.yaml") as fi:
+            cfg["drivers"]["E0"] = yaml.safe_load(fi)["drivers"]["E0"]
+
+    cfg["density"] = {"basis": "uniform", "val": 0.25}
+    cfg["grid"].update(
+        {
+            "boundary_width": "0.2um",
+            "dt": "2fs",
+            "dx": "0.1um",
+            "xmax": "6.4um",
+            "tmax": "20fs",
+            "ymax": "0.05um",
+            "ymin": "-0.05um",
+            "light_substeps": 1,
+        }
+    )
+    cfg["terms"]["zero_mask"] = True
+    cfg["terms"]["epw"]["boundary"] = {"x": "periodic", "y": "periodic"}
+    cfg["terms"]["epw"]["source"] = {"noise": False, "tpd": False, "srs": False}
+    cfg["terms"]["epw"]["density_gradient"] = False
+    cfg["terms"]["iaw"] = {
+        "active": True,
+        "boundary": {"x": "periodic", "y": "periodic"},
+        "damping": {"collisions": collisions, "landau": landau},
+        "max_density_perturbation": max_density_perturbation,
+    }
+
+    write_units(cfg)
+    cfg = get_derived_quantities(cfg)
+    cfg["grid"] = get_solver_quantities(cfg)
+    cfg["grid"]["background_density"] = get_density_profile(cfg)
+    return cfg
+
+
+def _zero_fields(cfg):
+    nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
+    return {
+        "epw": jnp.zeros((nx, ny), dtype=jnp.complex128),
+        "E0": jnp.zeros((nx, ny, 2), dtype=jnp.complex128),
+        "E1": jnp.zeros((nx, ny, 2), dtype=jnp.complex128),
+    }
+
+
+def test_iaw_split_step_matches_matlab_order():
+    """W is kicked by -laplacian(PP) before Nelf is drifted by the new W."""
+    from adept._lpse2d.core.iaw import IonAcousticWave
+
+    cfg = _make_cfg()
+    solver = IonAcousticWave(cfg)
+    x = np.asarray(cfg["grid"]["x"])
+    k = np.asarray(cfg["grid"]["kx"])[3]
+    density = jnp.asarray(0.02 * np.cos(k * (x - x[0])))[:, None]
+    state = {
+        **_zero_fields(cfg),
+        "iaw_density": density,
+        "iaw_velocity_divergence": jnp.zeros_like(density),
+    }
+
+    expected_w = -solver.dt * solver.laplacian(solver.cs**2 * density)
+    expected_n = density - solver.dt * expected_w
+    out = solver(state)
+
+    np.testing.assert_allclose(out["iaw_velocity_divergence"], expected_w, rtol=1e-11, atol=1e-13)
+    np.testing.assert_allclose(out["iaw_density"], expected_n, rtol=1e-11, atol=1e-13)
+
+
+def test_iaw_landau_damps_velocity_at_twice_the_amplitude_rate():
+    """Damping W at 2*gamma makes the coupled acoustic-mode amplitude decay at gamma."""
+    from adept._lpse2d.core.iaw import IonAcousticWave
+
+    landau_factor = 0.2
+    cfg = _make_cfg(landau=landau_factor)
+    solver = IonAcousticWave(cfg)
+    x = np.asarray(cfg["grid"]["x"])
+    k = np.asarray(cfg["grid"]["kx"])[4]
+    velocity = jnp.asarray(np.cos(k * (x - x[0])))[:, None]
+    state = {
+        **_zero_fields(cfg),
+        "iaw_density": jnp.zeros_like(velocity),
+        "iaw_velocity_divergence": velocity,
+    }
+
+    out = solver(state)
+    expected = velocity * np.exp(-2.0 * landau_factor * solver.cs * abs(k) * solver.dt)
+    np.testing.assert_allclose(out["iaw_velocity_divergence"], expected, rtol=1e-11, atol=1e-13)
+
+
+def test_light_intensity_drives_iaw_and_density_limiter():
+    """The pump ponderomotive pressure drives W; the optional Nelf limiter is applied last."""
+    from adept._lpse2d.core.iaw import IonAcousticWave
+
+    cfg = _make_cfg(max_density_perturbation=1.0e-8)
+    solver = IonAcousticWave(cfg)
+    x = np.asarray(cfg["grid"]["x"])
+    k = np.asarray(cfg["grid"]["kx"])[2]
+    E0 = jnp.zeros_like(_zero_fields(cfg)["E0"])
+    E0 = E0.at[..., 1].set(jnp.asarray(1.0 + 0.25 * np.cos(k * (x - x[0])))[:, None])
+    density = jnp.zeros(E0.shape[:2])
+    state = {
+        **_zero_fields(cfg),
+        "E0": E0,
+        "iaw_density": density,
+        "iaw_velocity_divergence": jnp.zeros_like(density),
+    }
+
+    potential = solver.ponderomotive_prefactor * jnp.sum(jnp.abs(E0) ** 2, axis=-1) / solver.w0**2
+    expected_w = -solver.dt * solver.laplacian(potential)
+    out = solver(state)
+
+    np.testing.assert_allclose(out["iaw_velocity_divergence"], expected_w, rtol=1e-11, atol=1e-13)
+    assert np.max(np.abs(np.asarray(out["iaw_density"]))) <= 1.0e-8
+
+
+def test_iaw_density_detunes_epw_by_matlab_phase():
+    """A uniform Nelf multiplies the EPW envelope by exp(-i wp0 Nelf dt / 2)."""
+    from adept._lpse2d.core.epw import SpectralEPWSolver
+
+    cfg = _make_cfg()
+    solver = SpectralEPWSolver(cfg)
+    nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
+    phi_k = jnp.zeros((nx, ny), dtype=jnp.complex128).at[3, 0].set(1.0 + 0.5j)
+    common = {
+        "epw": phi_k,
+        "E0": jnp.zeros((nx, ny, 2), dtype=jnp.complex128),
+        "E1": jnp.zeros((nx, ny, 2), dtype=jnp.complex128),
+    }
+    dn = 0.03
+    out_zero = solver(jnp.asarray(0.0), {**common, "iaw_density": jnp.zeros((nx, ny))}, None)
+    out_dn = solver(jnp.asarray(0.0), {**common, "iaw_density": jnp.full((nx, ny), dn)}, None)
+
+    phase = np.exp(-1j * solver.wp0 * dn * solver.dt / 2.0)
+    np.testing.assert_allclose(out_dn[3, 0], out_zero[3, 0] * phase, rtol=1e-11, atol=1e-13)
+
+
+def test_iaw_density_detunes_raman_rhs():
+    """The Raman light sees the same Nelf addition to n/n_env as the MATLAB solver."""
+    from adept._lpse2d.core.raman import RamanLight
+
+    cfg = _make_cfg()
+    solver = RamanLight(cfg)
+    nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
+    E1 = jnp.ones((nx, ny, 2), dtype=jnp.complex128)
+    E0 = jnp.zeros_like(E1)
+    laplacian_phi = jnp.zeros((nx, ny), dtype=jnp.complex128)
+    dn = jnp.full((nx, ny), 0.04)
+
+    base = solver.rhs(0.0, E1, E0, laplacian_phi, None)
+    with_iaw = solver.rhs(0.0, E1, E0, laplacian_phi, None, dn)
+    expected = -1j * solver.wp0**2 / (2.0 * solver.w1) * dn[..., None] * E1
+    np.testing.assert_allclose(with_iaw - base, expected, rtol=1e-11, atol=1e-13)
+
+
+def test_iaw_density_detunes_evolved_pump_rhs():
+    """The dynamic pump sees Nelf in the same density detuning as MATLAB."""
+    from adept._lpse2d.core.light import CoupledLight
+
+    cfg = _make_cfg(with_pump=True)
+    cfg["drivers"]["E0"]["derived"].update({"offset": 0.4, "turn_on_time": 0.01})
+    solver = CoupledLight(cfg)
+    nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
+    E0 = jnp.ones((nx, ny, 2), dtype=jnp.complex128)
+    E1 = jnp.zeros_like(E0)
+    laplacian_phi = jnp.zeros((nx, ny), dtype=jnp.complex128)
+    pump_args = {
+        **cfg["drivers"]["E0"]["derived"],
+        "delta_omega": jnp.zeros(1),
+        "intensities": jnp.ones((1, ny)),
+        "phases": jnp.zeros((1, ny)),
+    }
+    dn = jnp.full((nx, ny), 0.04)
+
+    base = solver.pump_rhs(0.0, E0, E1, laplacian_phi, pump_args)
+    with_iaw = solver.pump_rhs(0.0, E0, E1, laplacian_phi, pump_args, dn)
+    expected = -1j * solver.wp0**2 / (2.0 * solver.w0) * dn[..., None] * E0
+    np.testing.assert_allclose(with_iaw - base, expected, rtol=1e-11, atol=1e-13)
+
+
+def test_iaw_configuration_defaults_to_epw_boundaries():
+    # Re-run only the pre-array derivation from a fresh raw deck because the helper
+    # converts unit strings in place.
+    with open("tests/test_lpse2d/configs/epw.yaml") as fi:
+        fresh = yaml.safe_load(fi)
+    fresh["density"] = {"basis": "uniform", "val": 0.25}
+    fresh["grid"]["ymax"] = "0.02um"
+    fresh["grid"]["ymin"] = "-0.02um"
+    fresh["terms"]["iaw"] = {"active": True, "boundary": None}
+
+    from adept._lpse2d.helpers import get_derived_quantities, write_units
+
+    write_units(fresh)
+    fresh = get_derived_quantities(fresh)
+    assert fresh["terms"]["iaw"]["boundary"] == fresh["terms"]["epw"]["boundary"]
+
+
+def test_iaw_composes_with_quasi_1d_particle_feedback():
+    """The existing HPE tracker and the new IAW state can run in the same 1D model."""
+    from adept._lpse2d.core.vector_field import SplitStep
+    from adept._lpse2d.helpers import get_density_profile, get_derived_quantities, get_solver_quantities, write_units
+
+    with open("configs/envelope-2d/srs-hpe.yaml") as fi:
+        cfg = yaml.safe_load(fi)
+    cfg["terms"]["hpe"]["n_particles"] = 64
+    cfg["terms"]["iaw"] = {"active": True}
+
+    write_units(cfg)
+    cfg = get_derived_quantities(cfg)
+    cfg["grid"] = get_solver_quantities(cfg)
+    cfg["grid"]["background_density"] = get_density_profile(cfg)
+    step = SplitStep(cfg)
+
+    assert step.hpe is not None and step.iaw is not None

--- a/tests/test_lpse2d/test_tpd_depletion.py
+++ b/tests/test_lpse2d/test_tpd_depletion.py
@@ -3,13 +3,17 @@
 from copy import deepcopy
 
 import numpy as np
-import pytest
 import yaml
 from jax import numpy as jnp
 
 
 def _make_cfg():
-    from adept._lpse2d.helpers import get_density_profile, get_derived_quantities, get_solver_quantities, write_units
+    from adept._lpse2d.helpers import (
+        get_density_profile,
+        get_derived_quantities,
+        get_solver_quantities,
+        write_units,
+    )
 
     with open("tests/test_lpse2d/configs/tpd.yaml") as fi:
         cfg = yaml.safe_load(fi)
@@ -76,7 +80,12 @@ def test_tpd_only_pump_depletion_configuration_is_supported():
 def test_combined_tpd_srs_iaw_deck_builds_all_fluid_couplings():
     """The production example composes both instabilities, pump feedback, and IAWs."""
     from adept._lpse2d.core.vector_field import SplitStep
-    from adept._lpse2d.helpers import get_density_profile, get_derived_quantities, get_solver_quantities, write_units
+    from adept._lpse2d.helpers import (
+        get_density_profile,
+        get_derived_quantities,
+        get_solver_quantities,
+        write_units,
+    )
 
     with open("configs/envelope-2d/tpd-srs-iaw.yaml") as fi:
         cfg = yaml.safe_load(fi)
@@ -89,19 +98,59 @@ def test_combined_tpd_srs_iaw_deck_builds_all_fluid_couplings():
     assert step.epw.tpd_enabled and step.epw.srs_enabled
     assert step.pump_depletion and step.coupled_light.tpd_enabled and step.coupled_light.srs_enabled
     assert step.iaw is not None
+    assert step.hpe is not None and step.hpe.is_2d
 
 
-def test_tpd_rejects_quasi_1d_particle_feedback_with_clear_error():
-    """Do not silently advertise the x-only HPE tracker as a 2D TPD model."""
-    from adept._lpse2d.helpers import get_derived_quantities, write_units
+def test_tpd_accepts_box_averaged_2d_particle_feedback():
+    """TPD uses one 2D2V ensemble and angle-resolved damping for oblique modes."""
+    from adept._lpse2d.core.hpe import HybridParticleEvolution, load_particles
+    from adept._lpse2d.core.vector_field import SplitStep
+    from adept._lpse2d.helpers import (
+        get_default_save_func,
+        get_density_profile,
+        get_derived_quantities,
+        get_solver_quantities,
+        write_units,
+    )
 
     with open("configs/envelope-2d/tpd-srs-iaw.yaml") as fi:
         cfg = yaml.safe_load(fi)
-    cfg["terms"]["hpe"] = {"active": True}
+    cfg["grid"].update({"dx": "0.1um", "ymin": "-0.8um", "ymax": "0.8um"})
+    cfg["terms"]["hpe"].update({"n_particles": 128, "n_angles": 8, "gather_refine": 1})
     write_units(cfg)
+    cfg = get_derived_quantities(cfg)
+    cfg["grid"] = get_solver_quantities(cfg)
+    cfg["grid"]["background_density"] = get_density_profile(cfg)
 
-    with pytest.raises(NotImplementedError, match="TPD requires transverse modes"):
-        get_derived_quantities(cfg)
+    state = load_particles(cfg)
+    hpe = HybridParticleEvolution(cfg)
+    assert hpe.is_2d
+    assert state["u_e"].shape == (128, 2)
+    assert state["epw_hist"].shape == (8, cfg["terms"]["hpe"]["nv"])
+    assert hpe.mask_res.shape == (cfg["grid"]["nx"], cfg["grid"]["ny"])
+
+    nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
+    state.update(
+        {
+            "epw": np.zeros((nx, ny), dtype=np.complex128),
+            "E0": np.zeros((nx, ny, 2), dtype=np.complex128),
+            "E1": np.zeros((nx, ny, 2), dtype=np.complex128),
+            "iaw_density": np.zeros((nx, ny), dtype=np.float64),
+            "iaw_velocity_divergence": np.zeros((nx, ny), dtype=np.float64),
+        }
+    )
+    packed_state = {key: value.view(np.float64) for key, value in state.items()}
+    pump_args = {
+        **cfg["drivers"]["E0"]["derived"],
+        "delta_omega": jnp.zeros(1),
+        "intensities": jnp.ones((1, ny)),
+        "phases": jnp.zeros((1, ny)),
+    }
+    advanced = SplitStep(cfg)(jnp.asarray(0.0), packed_state, {"drivers": {"E0": pump_args}})
+    assert all(bool(jnp.all(jnp.isfinite(value))) for value in advanced.values())
+    diagnostics = get_default_save_func(cfg)["func"](jnp.asarray(0.0), advanced, None)
+    assert diagnostics["hpe_hist"].shape == (8, cfg["terms"]["hpe"]["nv"])
+    assert bool(jnp.isfinite(diagnostics["hpe_mean_energy_keV"]))
 
 
 def test_tpd_reciprocal_coupling_conserves_wave_energy():

--- a/tests/test_lpse2d/test_tpd_depletion.py
+++ b/tests/test_lpse2d/test_tpd_depletion.py
@@ -1,0 +1,139 @@
+"""Tests for the reciprocal TPD pump-depletion coupling."""
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+import yaml
+from jax import numpy as jnp
+
+
+def _make_cfg():
+    from adept._lpse2d.helpers import get_density_profile, get_derived_quantities, get_solver_quantities, write_units
+
+    with open("tests/test_lpse2d/configs/tpd.yaml") as fi:
+        cfg = yaml.safe_load(fi)
+
+    cfg = deepcopy(cfg)
+    cfg["density"] = {"basis": "uniform", "val": 0.25}
+    cfg["grid"].update(
+        {
+            "boundary_width": "0.4um",
+            "dt": "1fs",
+            "dx": "0.1um",
+            "xmax": "6.4um",
+            "tmax": "10fs",
+            "ymax": "1.6um",
+            "ymin": "-1.6um",
+        }
+    )
+    cfg["terms"]["light"] = {"pump_depletion": True}
+    cfg["terms"]["epw"]["source"].update({"noise": False, "tpd": True, "srs": False})
+    cfg["terms"]["epw"]["density_gradient"] = False
+
+    write_units(cfg)
+    cfg = get_derived_quantities(cfg)
+    cfg["grid"] = get_solver_quantities(cfg)
+    cfg["grid"]["background_density"] = get_density_profile(cfg)
+    return cfg
+
+
+def test_tpd_only_pump_depletion_configuration_is_supported():
+    """TPD does not need SRS merely to select the evolved-pump path."""
+    from adept._lpse2d.core.light import CoupledLight
+    from adept._lpse2d.core.vector_field import SplitStep
+    from adept._lpse2d.helpers import get_default_save_func
+
+    cfg = _make_cfg()
+    solver = CoupledLight(cfg)
+
+    assert solver.tpd_enabled
+    assert not solver.srs_enabled
+    assert cfg["grid"]["light_substeps"] >= 1
+
+    # A TPD-only evolved pump still exposes the same four-channel net-flux budget
+    # used by post-processing; the Raman channels are identically zero.
+    nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
+    state = {
+        "epw": jnp.zeros((nx, ny), dtype=jnp.complex128).view(jnp.float64),
+        "E0": jnp.zeros((nx, ny, 2), dtype=jnp.complex128).view(jnp.float64),
+        "E1": jnp.zeros((nx, ny, 2), dtype=jnp.complex128).view(jnp.float64),
+    }
+    out = get_default_save_func(cfg)["func"](0.0, state, None)
+    assert all(k in out for k in ("incident_flux", "transmitted_flux", "reflected_flux", "backrefl_flux"))
+    assert out["reflected_flux"] == 0.0 and out["backrefl_flux"] == 0.0
+
+    pump_args = {
+        **cfg["drivers"]["E0"]["derived"],
+        "delta_omega": jnp.zeros(1),
+        "intensities": jnp.ones((1, ny)),
+        "phases": jnp.zeros((1, ny)),
+    }
+    advanced = SplitStep(cfg)(jnp.asarray(0.0), state, {"drivers": {"E0": pump_args}})
+    assert all(bool(jnp.all(jnp.isfinite(value))) for value in advanced.values())
+
+
+def test_combined_tpd_srs_iaw_deck_builds_all_fluid_couplings():
+    """The production example composes both instabilities, pump feedback, and IAWs."""
+    from adept._lpse2d.core.vector_field import SplitStep
+    from adept._lpse2d.helpers import get_density_profile, get_derived_quantities, get_solver_quantities, write_units
+
+    with open("configs/envelope-2d/tpd-srs-iaw.yaml") as fi:
+        cfg = yaml.safe_load(fi)
+    write_units(cfg)
+    cfg = get_derived_quantities(cfg)
+    cfg["grid"] = get_solver_quantities(cfg)
+    cfg["grid"]["background_density"] = get_density_profile(cfg)
+
+    step = SplitStep(cfg)
+    assert step.epw.tpd_enabled and step.epw.srs_enabled
+    assert step.pump_depletion and step.coupled_light.tpd_enabled and step.coupled_light.srs_enabled
+    assert step.iaw is not None
+
+
+def test_tpd_rejects_quasi_1d_particle_feedback_with_clear_error():
+    """Do not silently advertise the x-only HPE tracker as a 2D TPD model."""
+    from adept._lpse2d.helpers import get_derived_quantities, write_units
+
+    with open("configs/envelope-2d/tpd-srs-iaw.yaml") as fi:
+        cfg = yaml.safe_load(fi)
+    cfg["terms"]["hpe"] = {"active": True}
+    write_units(cfg)
+
+    with pytest.raises(NotImplementedError, match="TPD requires transverse modes"):
+        get_derived_quantities(cfg)
+
+
+def test_tpd_reciprocal_coupling_conserves_wave_energy():
+    """The new pump term is the exact discrete reciprocal of the existing TPD term.
+
+    For coupling terms alone, d/dt [|E0|^2 + (wp0/w0)|E_epw|^2] = 0.
+    This locks the coefficient, complex-conjugation convention, and carrier phase.
+    """
+    from adept._lpse2d.core.epw import SpectralEPWSolver
+    from adept._lpse2d.core.light import CoupledLight
+
+    cfg = _make_cfg()
+    pump = CoupledLight(cfg)
+    epw = SpectralEPWSolver(cfg)
+    nx, ny = cfg["grid"]["nx"], cfg["grid"]["ny"]
+
+    rng = np.random.default_rng(7401)
+    phi_k = rng.normal(size=(nx, ny)) + 1j * rng.normal(size=(nx, ny))
+    # The EPW state is projected into this band every step. Keeping the synthetic
+    # state in the same band makes the filtered source operator self-adjoint.
+    phi_k *= np.asarray(cfg["grid"]["low_pass_filter_grid"] * cfg["grid"]["zero_mask"])
+    phi_k = jnp.asarray(phi_k)
+    E0_y = jnp.asarray(rng.normal(size=(nx, ny)) + 1j * rng.normal(size=(nx, ny)))
+    t = 0.037
+
+    _, ey = epw.phi_k_to_e_fields(phi_k)
+    tpd_epw_rhs = epw.calc_tpd_source(t, phi_k, ey, E0_y)
+    tpd_pump_rhs = pump.calc_tpd_depletion(t, phi_k)
+
+    pump_energy_rate = 2.0 * jnp.real(jnp.mean(jnp.conj(E0_y) * tpd_pump_rhs))
+    epw_energy_rate = 2.0 * jnp.real(jnp.vdot(phi_k * epw.k_sq, tpd_epw_rhs)) / (nx * ny) ** 2
+    total_rate = pump_energy_rate + epw.wp0 / epw.w0 * epw_energy_rate
+
+    scale = max(abs(float(pump_energy_rate)), abs(float(epw.wp0 / epw.w0 * epw_energy_rate)))
+    assert abs(float(total_rate)) < 1.0e-7 * scale


### PR DESCRIPTION
## Summary

- add the MATLAB-order ion-acoustic split step, including acoustic restoring pressure, EPW/pump/Raman ponderomotive drive, damping/boundaries, density limiting, and density feedback into EPW and both light-wave detuning terms
- extend evolved-pump feedback to all active TPD/SRS couplings; the new TPD pump term is the clean discrete reciprocal of the current potential-form TPD source and is locked by a wave-energy conservation test
- rewrite HPE as a dual 1D1V/2D2V particle tracker: 2-D particles carry `(x, y, p_x, p_y)`, gather both spectrally refined EPW field components, and feed direction-dependent Landau damping back to every `(kx, ky)` mode
- add generalized hot-electron/damping diagnostics, TPD-only laser flux budgets, and a full `tpd-srs-iaw.yaml` example with TPD + SRS + pump depletion + IAWs + 2D HPE

## Particle-model semantics

HPE uses **one box-averaged macro-particle ensemble**, not a particle population at each mesh point. Particle positions exist only to gather the local force. In 2-D, the evolving global velocity distribution is retained as `n_angles` oriented projections `f(v . k_hat)` over `[0, 2 pi)`; neighboring projections and resonant velocities are interpolated for each spectral mode. Opposite directions remain distinct, and histogram memory scales as `n_angles * nv`, independent of `nx * ny`.

The `ny == 1` path retains the existing `(x, p_x)` implementation and validation behavior for inexpensive SRS runs.

Absorbing particle walls use the exact incoming flux law for the retained tail: in wall polar coordinates, `p(r, theta) proportional to r^2 exp(-r^2 / (2 vte^2)) cos(theta)`. The truncated-Maxwell radius is sampled by inverse-survival bisection and `sin(theta)` is uniform on `[-1, 1]`; a statistical test locks the radial transform, angular moments, support, and all four inward face mappings.

## Physics notes

For coupling terms alone, the reciprocal TPD pair conserves

`|E0|^2 + (wp0 / w0) |E_epw|^2`.

The TPD pump term is newly derived from the active Envelope-2D operator. No code from the abandoned historical Pump2D prototype is used. The IAW equations and split ordering follow `m201805_matlabLpse_v11.m`.

The 2-D HPE extension is 2D2V and retains Follett's box-averaged, imaginary-part-only feedback. It captures trapping-induced damping reduction and hot-electron generation but not a trapping-induced nonlinear frequency shift. Production TPD studies should converge `n_particles`, `n_angles`, gather refinement, and the damping EMA window on GPU.

## Validation

- isolated local tracking + `MPLBACKEND=Agg`, `pytest -q tests/test_lpse2d -m 'not slow'`: **61 passed, 1 skipped, 3 deselected**
- focused HPE/TPD/IAW tests: **22 passed, 3 deselected**
- the combined one-step integration test advances TPD, SRS, reciprocal pump depletion, IAWs, and 2D2V HPE together with finite state and diagnostics
- Ruff lint and format checks pass for all changed Python files
- Python compile check passes for `adept/_lpse2d` and the changed tests
