### PR TITLE
Add Strang splitting and degree-7 velocity remapping to Vlasov-1D

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -91,3 +91,30 @@ Append-only checkpoints for scientific model development and validation.
 - **Interpretation:** The review-blocking distribution bias is removed and its separable radial/angular law is locked by a statistical test. Repeated planar-wall reinjection now samples the flux distribution associated with the same retained 2D Maxwellian tail used at initialization.
 - **Corrects:** Checkpoint `20260904T150248Z-2d2f0e6d`; completes planned correction `20260904T161828Z-f10c2eed`.
 - **Next:** Commit and push the correction to PR #363, report the derivation/test to the reviewer, and wait for re-review.
+
+## 2026-09-05 21:48:02 PDT — Vlasov-1D Strang and degree-7 remap
+
+- **Checkpoint ID:** 20260906T044802Z-79ad3623
+- **State:** PLANNED
+- **Objective:** Add opt-in `time: strang` and `edfdv: lagrange7` to upstream Vlasov-1D and open a PR.
+- **USER (verbatim):** "okay can you make a PR for bullet 1. im not too worried about bullet 2 or 3. we dont need to get into the weeds of the numerics. i'm trying to improve the modeling of the turbulence problem"
+- **USER (verbatim), scope clarification:** "dont need to address turbulence in this repo at all. i menat in the ../vp-turbulence project, but that is downstream and this is upstream and you dont need to worry about it"
+- **Action or change:** Implement spectral half-streaming, midpoint-field full velocity push, and spectral half-streaming; add an eight-point degree-7 Lagrange velocity interpolation with nonperiodic boundaries, multispecies support, and the existing sharding interface. Keep legacy options and all production configs unchanged.
+- **Provenance:** Base `origin/main` commit `4c49e93`; branch `codex/vlasov1d-strang-lagrange7`; isolated worktree `/private/tmp/adept-strang-lagrange7`.
+- **Observation:** No implementation result yet. Validation will cover interpolation, midpoint forcing, field diagnostics, and solver integration; no turbulence campaign or broad convergence study is in scope.
+- **Evidence or artifacts:** Vault mirror `Notes/adept/2026-09-05-214802-codex-strang-lagrange7-79ad3623.md`.
+- **Interpretation:** The requested modeling outcome remains unmeasured; this task delivers upstream capabilities only.
+- **Next:** Implement, run focused tests and formatting checks, and open the PR.
+
+## 2026-09-05 21:56:51 PDT — Upstream Strang and degree-7 implementation verified
+
+- **Checkpoint ID:** 20260906T045651Z-7a5c55d3
+- **State:** COMPLETED
+- **Objective:** Deliver opt-in upstream Vlasov-1D time stepping and velocity remapping.
+- **Action or change:** Added `time: strang` for Poisson/Poisson-Boltzmann with midpoint forcing, one velocity remap, and endpoint field diagnostics. Added `edfdv: lagrange7` using an eight-point stencil, floor-filled nonperiodic boundaries, per-species grids/forces, and shared interpolation-pusher sharding. Added focused tests and API documentation. Existing production configs and downstream projects were not changed.
+- **Provenance:** Base `4c49e93`; branch `codex/vlasov1d-strang-lagrange7`; Python 3.14 / JAX 0.9.0.1 on local CPU with `XLA_FLAGS=--xla_force_host_platform_device_count=4`.
+- **Observation:** 35 tests passed across `test_velocity_lagrange7.py`, `test_strang.py`, `test_velocity_cubic_spline.py`, `test_multispecies_pushers.py`, and `test_asymmetric_velocity_grid.py`. Checks include interpolation/boundaries, gradients, multispecies forces, midpoint impulse, final-field synchronization, all three velocity pushers with both Strang field solvers, and combined x/v sharding. Pre-commit hooks and `git diff --check` passed before final notebook update.
+- **Material commands:** `python -m pytest tests/test_vlasov1d/test_velocity_lagrange7.py tests/test_vlasov1d/test_strang.py tests/test_vlasov1d/test_velocity_cubic_spline.py -q` (26 passed); `python -m pytest tests/test_vlasov1d/test_multispecies_pushers.py tests/test_vlasov1d/test_asymmetric_velocity_grid.py -q` (8 passed); after adding the combined sharding check, `python -m pytest tests/test_vlasov1d/test_strang.py::test_strang_sharded_matches_serial -q` (1 passed). All used the shared ADEPT development environment, `MPLBACKEND=Agg`, and the four-device setting above.
+- **Evidence or artifacts:** `tests/test_vlasov1d/test_velocity_lagrange7.py`; `tests/test_vlasov1d/test_strang.py`; vault mirror `Notes/adept/2026-09-05-214802-codex-strang-lagrange7-79ad3623.md`.
+- **Interpretation:** These are implementation checks, not a turbulence result or an extensive convergence study. The new interpolation is unlimited and does not renormalize boundary losses. Strang's second-order scope is the collisionless electrostatic update; existing collision/filter/transverse coupling is unchanged.
+- **Next:** Publish the branch and open the requested upstream PR. Downstream adoption is outside this task.

--- a/adept/_vlasov1d/solvers/pushers/vlasov.py
+++ b/adept/_vlasov1d/solvers/pushers/vlasov.py
@@ -148,11 +148,46 @@ def _uniform_cubic_interp(f: jnp.ndarray, shift: jnp.ndarray, dv: float) -> jnp.
     return jnp.where(outside, jnp.asarray(1.0e-30, dtype=f.dtype), interpolated)
 
 
-class VelocityCubicSpline:
-    """Cubic-spline velocity-space advection under electric and ponderomotive forces."""
+def _uniform_lagrange7_interp(f: jnp.ndarray, shift: jnp.ndarray, dv: float) -> jnp.ndarray:
+    """Translate uniform-grid rows with an eight-point, degree-7 Lagrange stencil.
+
+    Weights depend only on the row's fractional displacement. The stencil is
+    centered around the departure cell, with exterior samples and exterior
+    queries set to 1e-30 (no velocity wraparound). This is an unlimited
+    interpolant: it does not enforce positivity or renormalize escaped mass.
+    """
+    _, nv = f.shape
+    if nv < 8:
+        raise ValueError("lagrange7 interpolation requires at least eight velocity cells")
+
+    # Once a displacement exceeds the domain plus the stencil width, every
+    # query is exterior. Bound it before conversion to avoid integer overflow.
+    displacement = jnp.clip(-shift / jnp.asarray(dv, dtype=f.dtype), -nv - 8, nv + 8)
+    offset = jnp.floor(displacement).astype(jnp.int32)
+    fraction = displacement - offset
+    cell = jnp.arange(nv, dtype=jnp.int32)[None, :] + offset[:, None]
+    floor = jnp.asarray(1.0e-30, dtype=f.dtype)
+    interpolated = jnp.zeros_like(f)
+
+    for node in range(-3, 5):
+        weight = jnp.ones_like(fraction)
+        for other in range(-3, 5):
+            if other != node:
+                weight = weight * (fraction - other) / (node - other)
+        index = cell + node
+        samples = jnp.take_along_axis(f, jnp.clip(index, 0, nv - 1), axis=1)
+        samples = jnp.where((index >= 0) & (index < nv), samples, floor)
+        interpolated = interpolated + weight[:, None] * samples
+
+    query = cell + fraction[:, None]
+    return jnp.where((query >= 0) & (query <= nv - 1), interpolated, floor)
+
+
+class _VelocityInterpolation:
+    """Shared force calculation and sharding for velocity interpolation pushers."""
 
     def __init__(self, species_grids, species_params, parallel=False):
-        """Store per-species velocity grids, interpolation kernel, and sharding metadata."""
+        """Store per-species velocity grids and optional sharding metadata."""
         self.species_grids = species_grids
         self.species_params = species_params
         self.parallel = parallel
@@ -160,7 +195,7 @@ class VelocityCubicSpline:
             self.mesh = Mesh(np.array(jax.devices()), ("device",))
 
     def push(self, f_dict, e, pond, dt):
-        """Apply the unsharded cubic-spline velocity push to each species."""
+        """Apply the unsharded interpolation push to each species."""
         result = {}
         for species_name, f in f_dict.items():
             dv = self.species_grids[species_name]["dv"]
@@ -168,11 +203,11 @@ class VelocityCubicSpline:
             m = self.species_params[species_name]["mass"]
             force = q * e + (q**2 / m) * pond
             accel = force / m
-            result[species_name] = _uniform_cubic_interp(f, accel * dt, dv)
+            result[species_name] = self.interpolate(f, accel * dt, dv)
         return result
 
     def __call__(self, f_dict, e, pond, dt):
-        """Dispatch the cubic-spline velocity push, optionally through shard_map."""
+        """Dispatch the velocity push, optionally through shard_map."""
         if self.parallel:
             return shard_map(
                 self.push,
@@ -182,6 +217,18 @@ class VelocityCubicSpline:
             )(f_dict, e, pond, dt)
         else:
             return self.push(f_dict, e, pond, dt)
+
+
+class VelocityCubicSpline(_VelocityInterpolation):
+    """Local cubic-spline velocity advection under electric and ponderomotive forces."""
+
+    interpolate = staticmethod(_uniform_cubic_interp)
+
+
+class VelocityLagrange7(_VelocityInterpolation):
+    """Degree-7 Lagrange velocity advection under electric and ponderomotive forces."""
+
+    interpolate = staticmethod(_uniform_lagrange7_interp)
 
 
 class HouLiFilter:

--- a/adept/_vlasov1d/solvers/vector_field.py
+++ b/adept/_vlasov1d/solvers/vector_field.py
@@ -21,7 +21,7 @@ class TimeIntegrator:
     This is the base class for all time integrators. This makes it so that we dont have to
     load the electric field solver and the Vlasov pushers in every time integrator
 
-    The available solvers for E df/dv are "exponential" and "cubic-spline"
+    The available solvers for E df/dv are "exponential", "cubic-spline", and "lagrange7"
     The only solver for v df/dx is "exponential"
 
     :param cfg: Dict
@@ -46,6 +46,10 @@ class TimeIntegrator:
             )
         elif cfg["terms"]["edfdv"] == "cubic-spline":
             return vlasov.VelocityCubicSpline(
+                self.species_grids, self.species_params, parallel=_is_parallel(parallel, "x")
+            )
+        elif cfg["terms"]["edfdv"] == "lagrange7":
+            return vlasov.VelocityLagrange7(
                 self.species_grids, self.species_params, parallel=_is_parallel(parallel, "x")
             )
         else:
@@ -93,6 +97,34 @@ class LeapfrogIntegrator(TimeIntegrator):
         f_dict = self.edfdv(f_after_v, e=e + dex_array[0], pond=pond, dt=self.dt)
 
         return e, f_dict
+
+
+class StrangIntegrator(TimeIntegrator):
+    """Explicit x-half / v-full / x-half splitting for electrostatic field solves.
+
+    The velocity kick uses the field from the intermediate distribution and
+    external forcing at the midpoint. Returned distributions and self-consistent
+    fields are synchronized at the end of the step.
+    """
+
+    def __init__(self, cfg: dict, grid: Grid):
+        """Build a Strang step for Poisson or Poisson-Boltzmann fields."""
+        if cfg["terms"]["field"] not in {"poisson", "poisson-boltzmann"}:
+            raise NotImplementedError("time: strang requires field: poisson or poisson-boltzmann")
+        super().__init__(cfg, grid)
+        self.dt = grid.dt
+        # The kick uses the midpoint; saved driver diagnostics use the endpoint.
+        # Entry 1 also retains the wrapper's endpoint transverse-driver timing.
+        self.dt_array = self.dt * jnp.array([0.5, 1.0])
+
+    def __call__(self, f_dict: dict, a: Array, dex_array: Array, prev_ex: Array) -> tuple[Array, dict]:
+        """Advance every species with one velocity interpolation per full step."""
+        f_half = self.vdfdx(f_dict, dt=0.5 * self.dt)
+        pond, e_half = self.field_solve(f_dict=f_half, a=a, prev_ex=None, dt=None)
+        f_kicked = self.edfdv(f_half, e=e_half + dex_array[0], pond=pond, dt=self.dt)
+        f_new = self.vdfdx(f_kicked, dt=0.5 * self.dt)
+        _, e_new = self.field_solve(f_dict=f_new, a=a, prev_ex=None, dt=None)
+        return e_new, f_new
 
 
 class SixthOrderHamIntegrator(TimeIntegrator):
@@ -189,7 +221,7 @@ class SixthOrderHamIntegrator(TimeIntegrator):
 class VlasovPoissonFokkerPlanck:
     """Vlasov-Poisson + Fokker-Planck timestep for multi-species simulations.
 
-    Combines a Vlasov-Poisson integrator (leapfrog or 6th-order Hamiltonian)
+    Combines a Vlasov-Poisson integrator (leapfrog, Strang, or 6th-order Hamiltonian)
     with optional Fokker-Planck collisions. Handles dict-based multi-species
     distributions where each species evolves under the same self-consistent
     electric field.
@@ -211,6 +243,9 @@ class VlasovPoissonFokkerPlanck:
         elif cfg["terms"]["time"] == "leapfrog":
             self.vlasov_poisson = LeapfrogIntegrator(cfg, grid)
             self.dex_save = 0
+        elif cfg["terms"]["time"] == "strang":
+            self.vlasov_poisson = StrangIntegrator(cfg, grid)
+            self.dex_save = 1
         else:
             raise NotImplementedError
         self.fp = fokker_planck.Collisions(cfg=cfg)

--- a/docs/source/solvers/vlasov1d/config.md
+++ b/docs/source/solvers/vlasov1d/config.md
@@ -486,13 +486,47 @@ Solver algorithm configuration.
 | Field | Type | Description |
 |-------|------|-------------|
 | `field` | string | Electric field solver: `"poisson"`, `"poisson-boltzmann"`, `"ampere"`, or `"hampere"` |
-| `edfdv` | string | Velocity advection scheme: `"exponential"` or `"cubic-spline"` |
-| `time` | string | Time integrator: `"sixth"` (6th order Hamiltonian) or `"leapfrog"` |
+| `edfdv` | string | Velocity advection scheme: `"exponential"`, `"cubic-spline"`, or `"lagrange7"` |
+| `time` | string | Time integrator: `"sixth"` (6th order Hamiltonian), `"leapfrog"`, or `"strang"` (explicit second-order electrostatic splitting) |
 | `fokker_planck` | object | Fokker-Planck collision operator configuration |
 | `krook` | object | Krook collision operator configuration |
 | `hou_li_filter` | object | Hou-Li spectral filter (optional, default off) |
 | `species` | list | (Optional) List of species configurations for multispecies simulations |
 | `boltzmann_electrons` | object | (Optional) Linearized Boltzmann electron closure parameters, used with `field: poisson-boltzmann` |
+
+### Strang splitting with degree-7 velocity interpolation
+
+Select these options in an existing Vlasov-1D configuration:
+
+```yaml
+terms:
+  field: poisson  # poisson-boltzmann is also supported
+  time: strang
+  edfdv: lagrange7
+  # Retain the configuration's species, collision, and other term settings.
+```
+
+`strang` streams in space for half a timestep, evaluates the self-consistent field,
+pushes velocity for a full timestep using midpoint external forcing, then streams
+for the remaining half timestep. There is one velocity remap per full timestep.
+Saved self-consistent and external electric fields are evaluated at the end of
+the step. This option supports `poisson` and `poisson-boltzmann`; `ampere` and
+`hampere` retain their existing `leapfrog` requirement.
+
+The second-order description applies to the collisionless electrostatic step.
+The existing collision, filter, and transverse-wave coupling is unchanged; choosing
+`strang` does not raise the order of those separate updates.
+
+`lagrange7` uses eight velocity samples to interpolate a degree-7 polynomial. It
+supports species-specific uniform grids (including asymmetric bounds), requires
+at least eight velocity cells per species, and works with the existing `grid.parallel`
+options. It can also be selected independently with the other time integrators.
+The stencil uses `1e-30` for samples outside the velocity grid and returns `1e-30`
+for departure points outside the first/last cell centers, without periodic wraparound.
+Keep populated structures clear of the velocity edges. The interpolation is unlimited:
+it can produce negative values near unresolved structure and does not renormalize
+mass lost through the boundaries. Gradients with respect to displacement are
+piecewise smooth as the stencil changes between cells.
 
 ### species (Multispecies Configuration)
 

--- a/docs/source/solvers/vlasov1d/overview.md
+++ b/docs/source/solvers/vlasov1d/overview.md
@@ -68,6 +68,23 @@ where $A$ is the advection operator. This is a much faster solver than the cubic
 
 2. **`cubic-spline`** - This is a semi-Lagrangian solver that uses a cubic-spline interpolator to advect the distribution function in velocity space. Use this if you have trouble with the exponential solver.
 
+3. **`lagrange7`** - An eight-point, degree-7 semi-Lagrangian velocity interpolator
+   for reducing interpolation error in resolved structures. It uses nonperiodic
+   velocity boundaries, supports multispecies grids and sharding, and requires at
+   least eight velocity cells per species. It does not enforce positivity.
+
+### Time Integration
+
+**`strang`** provides explicit spatial-half / velocity-full / spatial-half splitting,
+with the self-consistent field computed after the first half-stream and external
+forcing evaluated at the midpoint. It uses one velocity remap per timestep and
+returns the distribution and electric field at the same final time. Select it with
+`poisson` or `poisson-boltzmann`; it can be paired with any velocity pusher.
+
+The existing `leapfrog` and `sixth` options remain available. See the
+[configuration reference](config.md#strang-splitting-with-degree-7-velocity-interpolation)
+for the scope of the second-order update and boundary behavior.
+
 ### Spatial Advection
 
 1. **`exponential`** - This is the only solver that is available. We only have periodic boundaries implemented in space (for the plasma) so this is perfectly fine. It is also very fast.
@@ -91,6 +108,7 @@ where $A$ is the advection operator. This is a much faster solver than the cubic
 | $x$ (distribution and electrostatic field) | **Periodic** | Spatial advection and the Poisson/Ampère solves are spectral, so periodicity is structural rather than a choice. |
 | $v$ (`edfdv: exponential`) | **Periodic** | An artifact of doing the velocity push spectrally. It wraps the forward tail onto the $-v$ edge, so it is only safe when $f \approx 0$ at both velocity edges. |
 | $v$ (`edfdv: cubic-spline`) | Semi-Lagrangian interpolation | Does not assume periodicity; use it when the tails are populated. |
+| $v$ (`edfdv: lagrange7`) | Semi-Lagrangian interpolation | Exterior stencil samples and departure points use `1e-30`; no wraparound or mass renormalization. |
 | $v$ (collision operator) | **Zero-flux** | Applied at both velocity edges, which is what makes the Fokker-Planck operators conserve density exactly. |
 | $x$ (transverse vector potential $a$) | **Absorbing**, 2nd order | The transverse wave equation is solved by finite differences on a grid with two boundary cells, independently of the periodic plasma domain. |
 
@@ -158,7 +176,7 @@ Each pusher is wrapped in `jax.shard_map` over a one-dimensional mesh of `jax.de
 
 | Axis | Operators | Why no halo is needed |
 |---|---|---|
-| `"x"` | `edfdv` (`exponential` and `cubic-spline`) and the collision operator (Fokker-Planck + Krook) | Both are pointwise in $x$ — an independent velocity-space solve per spatial cell |
+| `"x"` | `edfdv` (`exponential`, `cubic-spline`, and `lagrange7`) and the collision operator (Fokker-Planck + Krook) | Both are pointwise in $x$ — an independent velocity-space solve per spatial cell |
 | `"v"` | `vdfdx` (`exponential`) | The spectral $x$-advection is an independent phase rotation per velocity |
 
 Because the two axes are different, `["x", "v"]` makes XLA insert an all-to-all between the velocity

--- a/tests/test_vlasov1d/test_strang.py
+++ b/tests/test_vlasov1d/test_strang.py
@@ -1,0 +1,127 @@
+"""Implementation checks for explicit Strang splitting and its wrapper."""
+
+from pathlib import Path
+
+import jax
+import numpy as np
+import pytest
+import yaml
+from jax import numpy as jnp
+
+from adept._vlasov1d.modules import BaseVlasov1D
+from adept._vlasov1d.solvers.vector_field import StrangIntegrator, VlasovMaxwell
+
+
+def _build(field="poisson", edfdv="lagrange7"):
+    filename = "boltzmann_iaw.yaml" if field == "poisson-boltzmann" else "resonance.yaml"
+    cfg = yaml.safe_load((Path(__file__).parent / "configs" / filename).read_text())
+    cfg["terms"].update(time="strang", field=field, edfdv=edfdv)
+    cfg["terms"]["fokker_planck"]["is_on"] = False
+    cfg["terms"]["krook"]["is_on"] = False
+    cfg["drivers"] = {"ex": {}, "ey": {}}
+    cfg["grid"].update(nx=32, nv=128, dt=0.2, tmax=0.8)
+    if cfg["terms"].get("species"):
+        for species in cfg["terms"]["species"]:
+            species["nv"] = 128
+    cfg["save"] = {"fields": {"t": {"nt": 3}}}
+    module = BaseVlasov1D(cfg)
+    module.write_units()
+    module.get_derived_quantities()
+    module.get_solver_quantities()
+    module.init_state_and_args()
+    return module
+
+
+def test_strang_constant_acceleration_matches_characteristics():
+    """The two half-streams center a constant kick correctly in both x and v."""
+    module = _build()
+    grid = module.simulation.grid
+    step = StrangIntegrator(module.cfg, grid)
+    x = grid.x
+    v = module.cfg["grid"]["species_grids"]["electron"]["v"]
+    k = 2 * jnp.pi / (grid.xmax - grid.xmin)
+    distribution = lambda x, v: (1 + 0.1 * jnp.cos(k * x)) * (1 + 0.02 * v**2)
+    f = {"electron": distribution(x[:, None], v[None, :])}
+    zeros = jnp.zeros_like(x)
+    step.field_solve = lambda **kwargs: (zeros, zeros)
+    external_e = jnp.full_like(x, 0.3)
+    _, actual = step(f, jnp.zeros(grid.nx + 2), [external_e, external_e], zeros)
+    accel = -0.3  # electron q/m
+    expected = distribution(
+        x[:, None] - v[None, :] * grid.dt + 0.5 * accel * grid.dt**2,
+        v[None, :] - accel * grid.dt,
+    )
+    np.testing.assert_allclose(actual["electron"][:, 8:-8], expected[:, 8:-8], atol=2e-11, rtol=2e-11)
+
+
+def test_strang_wrapper_uses_midpoint_forcing_and_saves_endpoint_driver():
+    """A time-linear force gives the exact impulse; saved de is at the new time."""
+    module = _build()
+    grid = module.simulation.grid
+    wrapper = VlasovMaxwell(module.cfg, grid, module.simulation.drivers)
+    zeros = jnp.zeros_like(grid.x)
+    wrapper.vpfp.vlasov_poisson.field_solve = lambda **kwargs: (zeros, zeros)
+    wrapper.total_dex = lambda t, args: jnp.full_like(grid.x, t)
+    v = module.cfg["grid"]["species_grids"]["electron"]["v"]
+    state = dict(module.state)
+    state["electron"] = jnp.broadcast_to(1 + 0.02 * v**2, (grid.nx, v.size))
+    t = 0.7
+    result = jax.jit(wrapper)(t, state, {})
+    shift = -grid.dt * (t + grid.dt / 2)
+    expected = jnp.broadcast_to(1 + 0.02 * (v - shift) ** 2, state["electron"].shape)
+    np.testing.assert_allclose(result["electron"][:, 8:-8], expected[:, 8:-8], atol=2e-12, rtol=2e-12)
+    np.testing.assert_allclose(result["de"], t + grid.dt, atol=1e-14)
+
+
+@pytest.mark.parametrize("field", ["poisson", "poisson-boltzmann"])
+def test_strang_returns_field_from_final_distribution(field):
+    """The saved self-consistent field is synchronized with the returned f."""
+    module = _build(field)
+    grid = module.simulation.grid
+    step = StrangIntegrator(module.cfg, grid)
+    k = 2 * jnp.pi / (grid.xmax - grid.xmin)
+    f = {
+        name: module.state[name] * (1 + 0.05 * jnp.cos(k * grid.x))[:, None]
+        for name in module.cfg["grid"]["species_grids"]
+    }
+    zeros = jnp.zeros_like(grid.x)
+    a = jnp.zeros(grid.nx + 2)
+    e, f_new = step(f, a, [zeros, zeros], zeros)
+    _, expected = step.field_solve(f_dict=f_new, a=a, prev_ex=None, dt=None)
+    np.testing.assert_allclose(e, expected, atol=1e-14)
+    assert jnp.max(jnp.abs(e)) > 0
+
+
+@pytest.mark.parametrize("field", ["poisson", "poisson-boltzmann"])
+@pytest.mark.parametrize("edfdv", ["lagrange7", "cubic-spline", "exponential"])
+def test_strang_solver_smoke(field, edfdv):
+    """Both electrostatic closures can run through the public solver lifecycle."""
+    module = _build(field, edfdv)
+    module.init_diffeqsolve()
+    result = module({})["solver result"]
+    assert int(result.stats["num_steps"]) > 0
+    for values in jax.tree.leaves(result.ys):
+        assert np.all(np.isfinite(values))
+
+
+@pytest.mark.parametrize("field", ["ampere", "hampere"])
+def test_strang_rejects_unsupported_field_evolution(field):
+    with pytest.raises(NotImplementedError, match="strang requires field"):
+        StrangIntegrator({"terms": {"field": field}}, None)
+
+
+def test_strang_sharded_matches_serial():
+    """Both x-sharded kicks and v-sharded half-streams compose correctly."""
+    module = _build()
+    grid = module.simulation.grid
+    sharded_cfg = {**module.cfg, "grid": {**module.cfg["grid"], "parallel": ("x", "v")}}
+    serial = StrangIntegrator(module.cfg, grid)
+    sharded = StrangIntegrator(sharded_cfg, grid)
+    k = 2 * jnp.pi / (grid.xmax - grid.xmin)
+    f = {"electron": module.state["electron"] * (1 + 0.05 * jnp.cos(k * grid.x))[:, None]}
+    zeros = jnp.zeros_like(grid.x)
+    args = (f, jnp.zeros(grid.nx + 2), [zeros, zeros], zeros)
+    expected = jax.jit(serial)(*args)
+    actual = jax.jit(sharded)(*args)
+    for a, b in zip(jax.tree.leaves(actual), jax.tree.leaves(expected), strict=True):
+        np.testing.assert_allclose(a, b, atol=2e-12, rtol=2e-12)

--- a/tests/test_vlasov1d/test_velocity_lagrange7.py
+++ b/tests/test_vlasov1d/test_velocity_lagrange7.py
@@ -1,0 +1,113 @@
+"""Focused checks for the uniform-grid degree-7 velocity remap."""
+
+import jax
+import numpy as np
+import pytest
+from jax import numpy as jnp
+
+from adept._vlasov1d.solvers.pushers.vlasov import (
+    VelocityLagrange7,
+    _uniform_cubic_interp,
+    _uniform_lagrange7_interp,
+)
+
+
+@pytest.mark.parametrize("vmin, vmax", [(-4.0, 4.0), (-2.0, 6.0)])
+def test_lagrange7_translates_degree7_polynomial(vmin, vmax):
+    """Fractional shifts reproduce a degree-7 polynomial where the stencil fits."""
+    nv = 64
+    dv = (vmax - vmin) / nv
+    v = jnp.linspace(vmin + dv / 2, vmax - dv / 2, nv)
+    shifts = dv * jnp.array([-2.2, -0.4, 0.0, 0.3, 1.75])
+
+    def polynomial(v):
+        return 1 + 0.2 * v - 0.03 * v**3 + 0.0001 * v**7
+
+    f = jnp.broadcast_to(polynomial(v), (len(shifts), nv))
+    actual = jax.jit(_uniform_lagrange7_interp)(f, shifts, dv)
+    expected = polynomial(v[None, :] - shifts[:, None])
+    np.testing.assert_allclose(actual[:, 8:-8], expected[:, 8:-8], atol=2e-12, rtol=2e-12)
+
+
+def test_lagrange7_integer_shifts_and_exterior_queries():
+    """Knots are exact, outflow is discarded, and nothing wraps into the other tail."""
+    nv, dv = 16, 0.25
+    shifts = jnp.array([-1, 0, 2, -100, 100, 1e20])
+    f = jnp.arange(len(shifts) * nv, dtype=jnp.float64).reshape(len(shifts), nv)
+    actual = _uniform_lagrange7_interp(f, shifts * dv, dv)
+    expected = np.full(f.shape, 1e-30)
+    for row, shift in enumerate(np.asarray(shifts)):
+        for cell in range(nv):
+            source = cell - int(shift)
+            if 0 <= source < nv:
+                expected[row, cell] = f[row, source]
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_lagrange7_fractional_boundary_stencil_uses_exterior_floor():
+    """A half-cell boundary query uses floor-filled ghosts, not wrapped or clamped data."""
+    f = jnp.arange(1, 17, dtype=jnp.float64)[None, :]
+    # Exact eight-point Lagrange weights at a half-cell departure point.
+    weights = np.array([-5, 49, -245, 1225, 1225, -245, 49, -5]) / 2048
+    actual = _uniform_lagrange7_interp(f, jnp.array([0.5]), 1.0)
+    expected_first_interior = weights @ np.array([1e-30, 1e-30, 1e-30, 1, 2, 3, 4, 5])
+    assert actual[0, 0] == 1e-30
+    np.testing.assert_allclose(actual[0, 1], expected_first_interior, atol=1e-15)
+
+
+def test_lagrange7_preserves_smooth_structure_better_than_local_cubic():
+    """The new stencil has less error on a resolved, translated Fourier mode."""
+    v = jnp.arange(128, dtype=jnp.float64)
+    f = jnp.cos(2 * jnp.pi * v / 8)[None, :]
+    expected = jnp.cos(2 * jnp.pi * (v - 0.5) / 8)[None, :]
+    high_order = _uniform_lagrange7_interp(f, jnp.array([0.5]), 1.0)
+    cubic = _uniform_cubic_interp(f, jnp.array([0.5]), 1.0)
+    error = lambda values: jnp.linalg.norm((values - expected)[:, 8:-8])
+    assert error(high_order) < error(cubic) / 50
+
+
+def test_lagrange7_gradients_match_directional_finite_difference():
+    """JIT/autodiff propagate changes in the distribution and displacement."""
+    f, direction, weights = jax.random.normal(jax.random.key(42), (3, 4, 32), dtype=jnp.float64)
+    shifts = jnp.array([-0.37, 0.18, 1.23, -1.15])
+    shift_direction = jnp.array([0.1, -0.2, 0.05, 0.3])
+
+    def objective(values, offsets):
+        return jnp.sum(weights * _uniform_lagrange7_interp(values, offsets, 0.25))
+
+    df, ds = jax.jit(jax.grad(objective, argnums=(0, 1)))(f, shifts)
+    tangent = jnp.sum(df * direction) + jnp.sum(ds * shift_direction)
+    eps = 1e-6
+    finite_difference = (
+        objective(f + eps * direction, shifts + eps * shift_direction)
+        - objective(f - eps * direction, shifts - eps * shift_direction)
+    ) / (2 * eps)
+    np.testing.assert_allclose(tangent, finite_difference, atol=1e-7, rtol=1e-7)
+
+
+def test_lagrange7_multispecies_force_and_sharding():
+    """Each species uses its own grid and q/m, including the ponderomotive force."""
+    nx = 4 * jax.device_count()
+    grids = {}
+    params = {"electron": {"charge": -1.0, "mass": 1.0}, "ion": {"charge": 2.0, "mass": 4.0}}
+    f_dict = {}
+    for name, vmin, vmax, nv in [("electron", -4.0, 8.0, 96), ("ion", -1.0, 2.0, 48)]:
+        dv = (vmax - vmin) / nv
+        v = jnp.linspace(vmin + dv / 2, vmax - dv / 2, nv)
+        grids[name] = {"v": v, "dv": dv}
+        f_dict[name] = jnp.broadcast_to(1 + 0.2 * v + 0.03 * v**2, (nx, nv))
+
+    e, pond, dt = jnp.linspace(-0.2, 0.3, nx), jnp.linspace(0.01, 0.04, nx), 0.17
+    actual = VelocityLagrange7(grids, params)(f_dict, e, pond, dt)
+    parallel = VelocityLagrange7(grids, params, parallel=True)(f_dict, e, pond, dt)
+    for name in params:
+        q, m = params[name]["charge"], params[name]["mass"]
+        departure = grids[name]["v"][None, :] - (q * e / m + q**2 * pond / m**2)[:, None] * dt
+        expected = 1 + 0.2 * departure + 0.03 * departure**2
+        np.testing.assert_allclose(actual[name][:, 8:-8], expected[:, 8:-8], atol=2e-12, rtol=2e-12)
+        np.testing.assert_allclose(parallel[name], actual[name], atol=2e-12, rtol=2e-12)
+
+
+def test_lagrange7_rejects_undersized_grid():
+    with pytest.raises(ValueError, match="at least eight"):
+        _uniform_lagrange7_interp(jnp.ones((2, 7)), jnp.zeros(2), 1.0)


### PR DESCRIPTION
Add an opt-in Vlasov-1D combination that uses a higher-order velocity remap and one velocity interpolation per timestep:

```yaml
terms:
  time: strang
  edfdv: lagrange7
```

`strang` performs spatial half-stepping around a full velocity push, with midpoint external forcing and endpoint electric-field diagnostics. It supports both Poisson and Poisson–Boltzmann fields. `lagrange7` adds an eight-point, degree-7 interpolant with nonperiodic velocity boundaries, per-species grids and forces, JAX gradients, and the existing sharding interface. The two options can be selected independently.

Existing integrators and production configurations are unchanged. This is upstream solver support only; no downstream turbulence changes or method-comparison campaign are included. The degree-7 interpolant is unlimited, and Strang's second-order scope is the collisionless electrostatic update; the existing collision/filter/transverse coupling is unchanged.

Validation: 35 focused and regression tests passed locally, including midpoint forcing, synchronized fields, all velocity pushers with both Strang field solvers, nonperiodic boundaries, gradients, multispecies forces, legacy cubic behavior, and combined x/v sharding on four simulated CPU devices. All applicable pre-commit hooks and diff checks passed.
