### PR TITLE
refactor(core): route ergoExo through prepared runtime

### DIFF
--- a/adept/_base_.py
+++ b/adept/_base_.py
@@ -223,6 +223,9 @@ class ergoExo:
 
         self.ran_setup = False
         self.cfg = None
+        self._compat_execution = None
+        self.execution_backend = "legacy"
+        self.compatibility_fallback_reason = "setup has not completed"
 
     def setup(self, cfg: dict, adept_module: ADEPTModule = None) -> dict[str, Module]:
         """
@@ -349,6 +352,7 @@ class ergoExo:
         return this_module(cfg)
 
     def _setup_(self, cfg: dict, td: str, adept_module: ADEPTModule = None, log: bool = True) -> dict[str, Module]:
+        from adept._compat import LegacyPreparedExecution
         from adept.utils import log_params
 
         # Snapshot the config as provided, before the module mutates it in
@@ -356,6 +360,9 @@ class ergoExo:
         # is the original config; the processed cfg lands in derived_config.yaml
         # and the logged params.
         original_cfg = deepcopy(cfg)
+        self._compat_execution = None
+        self.execution_backend = "legacy"
+        self.compatibility_fallback_reason = "setup did not complete"
 
         if adept_module is None:
             self.adept_module = self._get_adept_module_(cfg)
@@ -391,9 +398,34 @@ class ergoExo:
         self.adept_module.init_diffeqsolve()
         modules = self.adept_module.init_modules()
 
+        self._compat_execution, self.compatibility_fallback_reason = LegacyPreparedExecution.try_create(
+            original_cfg,
+            legacy_module=self.adept_module,
+            custom_module=adept_module is not None,
+        )
+        if self._compat_execution is not None:
+            self.execution_backend = "prepared"
+
         self.ran_setup = True
 
         return modules
+
+    def _execute_simulation(self, modules: dict | None, args: dict | None) -> dict:
+        if self._compat_execution is not None:
+            reason = self._compat_execution.fallback_reason(
+                state=self.adept_module.state,
+                legacy_args=self.adept_module.args,
+                modules=modules,
+                args=args,
+            )
+            if reason is None:
+                self.execution_backend = "prepared"
+                self.compatibility_fallback_reason = None
+                return self._compat_execution.execute()
+            self.compatibility_fallback_reason = reason
+
+        self.execution_backend = "legacy"
+        return filter_jit(self.adept_module.__call__)(modules, args)
 
     def __call__(
         self, modules: dict | None = None, args: dict | None = None, export=True
@@ -426,7 +458,7 @@ class ergoExo:
             run_id=self.mlflow_run_id, nested=self.mlflow_nested, log_system_metrics=True
         ) as mlflow_run:
             t0 = time.time()
-            run_output = filter_jit(self.adept_module.__call__)(modules, args)
+            run_output = self._execute_simulation(modules, args)
             mlflow.log_metrics({"run_time": round(time.time() - t0, 4)})  # logs the run time to mlflow
 
             t0 = time.time()
@@ -467,6 +499,8 @@ class ergoExo:
             or passed in during the initialization
         """
         assert self.ran_setup, "You must run self.setup() before running the simulation"
+        self.execution_backend = "legacy"
+        self.compatibility_fallback_reason = "val_and_grad remains on ADEPTModule.vg during the transition"
         with mlflow.start_run(
             run_id=self.mlflow_run_id, nested=self.mlflow_nested, log_system_metrics=True
         ) as mlflow_run:

--- a/adept/_compat.py
+++ b/adept/_compat.py
@@ -1,0 +1,164 @@
+"""Compatibility adapters between ``ergoExo`` and prepared simulations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+import numpy as np
+from diffrax import Solution
+
+from adept.core import PreparedSimulation, SimulationSpec, run_prepared, solver_registry
+
+_SUPPORTED_SOLVERS = frozenset({"tf-1d", "pic-1d"})
+
+
+def _legacy_seed(config: dict[str, Any]) -> int:
+    """Recover the primary seed used by legacy solver initialization."""
+
+    if config["solver"] != "pic-1d":
+        return 0
+
+    for species in config.get("terms", {}).get("species", ()):
+        for component_name in species.get("density_components", ()):
+            component = config.get("density", {}).get(component_name, {})
+            if "noise_seed" in component:
+                return int(component["noise_seed"])
+    return 0
+
+
+def _tree_leaf_signature(tree: Any) -> tuple[Any, tuple[int, ...]]:
+    return jax.tree.structure(tree), tuple(id(leaf) for leaf in jax.tree.leaves(tree))
+
+
+def _states_equal(left: Any, right: Any) -> bool:
+    if jax.tree.structure(left) != jax.tree.structure(right):
+        return False
+    return all(
+        np.array_equal(np.asarray(left_leaf), np.asarray(right_leaf))
+        for left_leaf, right_leaf in zip(jax.tree.leaves(left), jax.tree.leaves(right), strict=True)
+    )
+
+
+def _config_fallback_reason(config: dict[str, Any]) -> str | None:
+    solver = config["solver"]
+    if solver == "tf-1d":
+        save_names = set(config.get("save", {}))
+        unsupported = sorted(save_names - {"t", "x", "kx"})
+        if unsupported:
+            return f"tf-1d saves {unsupported!r} are not supported by the prepared compatibility path"
+        if "t" not in save_names or not save_names.intersection({"x", "kx"}):
+            return "tf-1d full-state saves are not supported by the prepared compatibility path"
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyPreparedExecution:
+    """Run a prepared simulation while preserving the legacy result contract."""
+
+    prepared: PreparedSimulation[Any, Any, Any, Any, Any]
+    key: Any
+    solver: str
+    t0: Any
+    t1: Any
+    max_steps: Any
+    state_leaf_signature: tuple[Any, tuple[int, ...]]
+    args_leaf_signature: tuple[Any, tuple[int, ...]]
+
+    @classmethod
+    def try_create(
+        cls,
+        config: dict[str, Any],
+        *,
+        legacy_module: Any,
+        custom_module: bool,
+    ) -> tuple[LegacyPreparedExecution | None, str | None]:
+        """Create an adapter when the new path can preserve legacy behavior."""
+
+        if custom_module:
+            return None, "custom ADEPTModule injection requires the legacy execution path"
+
+        solver = config["solver"]
+        if solver not in _SUPPORTED_SOLVERS:
+            return None, f"solver {solver!r} is not yet enabled for the prepared compatibility path"
+
+        if reason := _config_fallback_reason(config):
+            return None, reason
+
+        seed = _legacy_seed(config)
+        try:
+            prepared = solver_registry.prepare(SimulationSpec.from_legacy_config(config), key=seed)
+        except ValueError as error:
+            return None, f"the prepared {solver} builder rejected this legacy configuration: {error}"
+
+        if not _states_equal(prepared.state, legacy_module.state):
+            return None, "prepared initialization did not reproduce the legacy initial state"
+
+        # Keep one initial-state tree alive and make subsequent replacement detectable.
+        legacy_module.state = prepared.state
+        time_quantities = legacy_module.time_quantities
+        return (
+            cls(
+                prepared=prepared,
+                key=jax.random.key(seed),
+                solver=solver,
+                t0=time_quantities["t0"],
+                t1=time_quantities["t1"],
+                max_steps=time_quantities["max_steps"],
+                state_leaf_signature=_tree_leaf_signature(legacy_module.state),
+                args_leaf_signature=_tree_leaf_signature(legacy_module.args),
+            ),
+            None,
+        )
+
+    def fallback_reason(self, *, state: Any, legacy_args: Any, modules: Any, args: Any) -> str | None:
+        """Explain why one invocation cannot use the prepared execution path."""
+
+        if args is not None:
+            return "explicit legacy args require the legacy execution path"
+        if modules is not None and (not isinstance(modules, dict) or modules):
+            return "trainable legacy modules require the legacy execution path"
+        if _tree_leaf_signature(state) != self.state_leaf_signature:
+            return "legacy state replacement requires the legacy execution path"
+        if _tree_leaf_signature(legacy_args) != self.args_leaf_signature:
+            return "legacy args replacement requires the legacy execution path"
+        return None
+
+    def execute(self) -> dict[str, Solution]:
+        """Execute via the host runtime and restore ``output['solver result']``."""
+
+        completed = run_prepared(self.prepared, key=self.key)
+        raw_result = completed.raw_result
+        if self.solver == "tf-1d":
+            # TF1D historically used one SaveAt schedule shared by all saved trees.
+            times = next(iter(raw_result.times.values()))
+            stats = raw_result.stats
+        else:
+            # PIC1D historically used named SubSaveAt schedules.
+            times = raw_result.times
+            num_steps = raw_result.stats["num_steps"]
+            stats = {
+                "max_steps": self.max_steps,
+                "num_accepted_steps": num_steps,
+                "num_rejected_steps": num_steps * 0,
+                "num_steps": num_steps,
+            }
+
+        solution = Solution(
+            t0=self.t0,
+            t1=self.t1,
+            ts=times,
+            ys=raw_result.observations,
+            interpolation=None,
+            stats=stats,
+            result=raw_result.status,
+            solver_state=None,
+            controller_state=None,
+            made_jump=None,
+            event_mask=None,
+        )
+        return {"solver result": solution}
+
+
+__all__ = ["LegacyPreparedExecution"]

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -58,5 +58,6 @@ usage/observations
 usage/checkpoints
 usage/run_plans
 usage/host_runtime
+usage/legacy_compatibility
 usage/initialization
 ```

--- a/docs/source/usage/explicit_programs.md
+++ b/docs/source/usage/explicit_programs.md
@@ -179,9 +179,10 @@ adapter = LegacyVGAdapter(
 
 The adapter emits a migration warning and returns `output["solver result"]` alongside
 the structured objective. It does not create an MLflow run or emulate mutation of
-captured module attributes. New code should call `value_and_grad` directly. A later
-compatibility façade will route supported `ergoExo` behavior through these contracts;
-until then, existing `ergoExo` and `ADEPTModule` callers continue on the legacy path.
+captured module attributes. New code should call `value_and_grad` directly. The first
+compatibility-façade slice now routes supported `ergoExo` forward runs through these
+contracts. See [Legacy API compatibility](legacy_compatibility.md) for the current
+routing and fallback rules.
 
 For host-side execution, tracking, failure policies, and verified artifact storage, see
 [Host-side tracking and artifacts](host_runtime.md).

--- a/docs/source/usage/host_runtime.md
+++ b/docs/source/usage/host_runtime.md
@@ -151,5 +151,6 @@ strict because a run with missing declared outputs must not appear successfully
 archived.
 
 The existing `ergoExo` and `ADEPTModule` entry points retain their current MLflow
-behavior during this phase. They will move onto these services through the later
-compatibility façade rather than changing behavior in place.
+behavior during this phase. Eligible TF1D and PIC1D forward solves now use this host
+runtime underneath the compatibility façade; legacy MLflow and post-processing remain
+the public boundary. See [Legacy API compatibility](legacy_compatibility.md).

--- a/docs/source/usage/legacy_compatibility.md
+++ b/docs/source/usage/legacy_compatibility.md
@@ -1,0 +1,38 @@
+# Legacy API compatibility
+
+`ergoExo` and `ADEPTModule` remain supported and are not deprecated in this release.
+The compatibility façade preserves their setup, return values, MLflow lifecycle,
+configuration artifacts, and solver-specific post-processing while solver internals
+move onto the explicit architecture.
+
+## Current routing
+
+Supported TF1D and electrostatic PIC1D forward runs are prepared through
+`SimulationSpec` and the solver registry, then executed by `run_prepared`. The façade
+converts the structured result back into the historical
+`{"solver result": diffrax.Solution}` shape before invoking the existing post-processor.
+This routing does not change the three-value return from `ergoExo.__call__`.
+
+The façade opts into prepared execution only when preparation reproduces the legacy
+initial state exactly. It uses the legacy path when any compatibility-sensitive input
+is present, including:
+
+- a custom `ADEPTModule`;
+- explicit `args` or non-empty trainable modules;
+- replacement of the module state or stored arguments after setup;
+- TF1D learned trapping closures or unsupported save layouts;
+- PIC1D transverse or stochastic drivers, off-grid saves, or an initialization that
+  differs from the legacy seeded state;
+- a solver without an explicit façade adapter, including Vlasov1D and LPSE2D today; or
+- `ergoExo.val_and_grad`, which continues to call `ADEPTModule.vg`.
+
+No failed prepared solve is silently rerun. Fallback decisions happen before numerical
+execution. After setup or a run, `exo.execution_backend` is either `"prepared"` or
+`"legacy"`; `exo.compatibility_fallback_reason` explains a legacy selection.
+
+## New integrations
+
+New code should use `SimulationSpec`, `solver_registry.prepare`, and `run_prepared`
+directly. Existing applications can keep using `ergoExo` while solvers migrate. The
+next compatibility slices will add builders for the primary Vlasov1D and LPSE2D paths
+before removal or deprecation of the legacy API is considered.

--- a/tests/test_base/test_ergoExo.py
+++ b/tests/test_base/test_ergoExo.py
@@ -1,14 +1,171 @@
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
 import yaml
+from diffrax import Solution
 
 from adept import ergoExo
+
+
+def _tf1d_config() -> dict:
+    path = Path(__file__).parents[1] / "test_tf1d" / "configs" / "resonance.yaml"
+    with path.open() as config_file:
+        config = yaml.safe_load(config_file)
+    config["grid"].update(nx=8, xmax=4.0, tmax=0.1)
+    config["save"]["t"].update(tmax=0.125, nt=6)
+    config["save"]["x"].update(xmax=4.0, nx=8)
+    config["save"].pop("kx")
+    config["drivers"]["ex"]["0"].update(
+        a0=0.01,
+        k0=np.pi / 2.0,
+        w0=1.0,
+        t_c=0.05,
+        t_w=0.1,
+        t_r=0.01,
+        x_c=2.0,
+        x_w=4.0,
+        x_r=0.1,
+    )
+    return config
+
+
+def _pic1d_config() -> dict:
+    return {
+        "units": {"normalizing_temperature": "1eV", "normalizing_density": "1e21/cc"},
+        "density": {
+            "quasineutrality": True,
+            "species-background": {
+                "noise_seed": 42,
+                "noise_type": "gaussian",
+                "noise_val": 0.0,
+                "v0": 0.0,
+                "T0": 1.0,
+                "m": 2.0,
+                "basis": "uniform",
+                "baseline": 1.0,
+            },
+        },
+        "grid": {
+            "dt": 0.05,
+            "nx": 8,
+            "tmin": 0.0,
+            "tmax": 0.1,
+            "xmin": 0.0,
+            "xmax": 2.0 * np.pi,
+            "ppc": 8,
+            "particle_shape": "tsc",
+        },
+        "save": {"fields": {"t": {"tmin": 0.0, "tmax": 0.1, "nt": 3}}},
+        "solver": "pic-1d",
+        "mlflow": {"experiment": "unused", "run": "unused"},
+        "drivers": {"ex": {}, "ey": {}},
+        "diagnostics": {},
+        "terms": {
+            "field": "poisson",
+            "time": "leapfrog",
+            "species": [
+                {
+                    "name": "electron",
+                    "charge": -1.0,
+                    "mass": 1.0,
+                    "density_components": ["species-background"],
+                    "loading": "quiet",
+                    "vmax_load": 8.0,
+                }
+            ],
+        },
+    }
+
+
+def _setup_without_logging(exo: ergoExo, config: dict, tmp_path: Path) -> dict:
+    return exo._setup_(deepcopy(config), str(tmp_path), log=False)
 
 
 def test_reuse_config_dict():
     with open("tests/test_base/configs/example.yaml") as file:
         cfg = yaml.safe_load(file)
+    original = deepcopy(cfg)
 
     exo = ergoExo()
     exo.setup(cfg)
+    assert cfg == original
+    assert exo.execution_backend == "legacy"
+    assert "not yet enabled" in exo.compatibility_fallback_reason
 
     exo = ergoExo()
     exo.setup(cfg)
+    assert cfg == original
+    assert exo.execution_backend == "legacy"
+
+
+def test_tf1d_forward_run_uses_prepared_compatibility_path(tmp_path):
+    exo = ergoExo()
+    modules = _setup_without_logging(exo, _tf1d_config(), tmp_path)
+
+    assert exo.execution_backend == "prepared"
+    assert exo.compatibility_fallback_reason is None
+
+    output = exo._execute_simulation(modules, None)
+    solution = output["solver result"]
+
+    assert isinstance(solution, Solution)
+    assert solution.ts.shape == (6,)
+    assert set(solution.ys) == {"x"}
+    assert exo.execution_backend == "prepared"
+
+
+def test_pic1d_forward_run_preserves_named_solution_shape(tmp_path):
+    exo = ergoExo()
+    modules = _setup_without_logging(exo, _pic1d_config(), tmp_path)
+
+    output = exo._execute_simulation(modules, None)
+    solution = output["solver result"]
+
+    assert isinstance(solution, Solution)
+    assert set(solution.ts) == {"fields", "default"}
+    assert set(solution.ys) == {"fields", "default"}
+    assert set(solution.stats) == {"max_steps", "num_accepted_steps", "num_rejected_steps", "num_steps"}
+    assert exo.execution_backend == "prepared"
+
+
+def test_replaced_legacy_state_falls_back_before_execution(tmp_path):
+    exo = ergoExo()
+    modules = _setup_without_logging(exo, _tf1d_config(), tmp_path)
+    exo.adept_module.state = deepcopy(exo.adept_module.state)
+
+    output = exo._execute_simulation(modules, None)
+
+    assert isinstance(output["solver result"], Solution)
+    assert exo.execution_backend == "legacy"
+    assert exo.compatibility_fallback_reason == "legacy state replacement requires the legacy execution path"
+
+
+def test_unsupported_pic1d_feature_selects_legacy_fallback(tmp_path):
+    config = _pic1d_config()
+    config["drivers"]["ey"] = {
+        "laser": {
+            "params": {"a0": 0.1, "k0": 1.0, "w0": 1.0, "dw0": 0.0},
+            "source_type": "extended",
+            "envelope": {
+                "time": {"center": 0.05, "rise": 0.01, "width": 0.1},
+                "space": {"center": np.pi, "rise": 0.1, "width": 2.0 * np.pi},
+            },
+        }
+    }
+    exo = ergoExo()
+
+    _setup_without_logging(exo, config, tmp_path)
+
+    assert exo.execution_backend == "legacy"
+    assert "transverse ey drivers" in exo.compatibility_fallback_reason
+
+
+def test_custom_module_injection_selects_legacy_fallback(tmp_path):
+    from adept.tf1d import BaseTwoFluid1D
+
+    exo = ergoExo()
+    exo._setup_(deepcopy(_tf1d_config()), str(tmp_path), adept_module=BaseTwoFluid1D, log=False)
+
+    assert exo.execution_backend == "legacy"
+    assert exo.compatibility_fallback_reason == "custom ADEPTModule injection requires the legacy execution path"

--- a/tests/test_tf1d/test_landau_damping.py
+++ b/tests/test_tf1d/test_landau_damping.py
@@ -44,7 +44,7 @@ def test_single_resonance():
         kx = (
             np.fft.fftfreq(
                 mod_defaults["save"]["x"]["nx"],
-                d=mod_defaults["save"]["x"]["ax"][2] - mod_defaults["save"]["x"]["ax"][1],
+                d=exo.cfg["save"]["x"]["ax"][2] - exo.cfg["save"]["x"]["ax"][1],
             )
             * 2.0
             * np.pi

--- a/tests/test_tf1d/test_resonance.py
+++ b/tests/test_tf1d/test_resonance.py
@@ -43,9 +43,7 @@ def test_single_resonance(gamma):
     result = result["solver result"]
 
     kx = (
-        np.fft.fftfreq(
-            mod_defaults["save"]["x"]["nx"], d=mod_defaults["save"]["x"]["ax"][2] - mod_defaults["save"]["x"]["ax"][1]
-        )
+        np.fft.fftfreq(mod_defaults["save"]["x"]["nx"], d=exo.cfg["save"]["x"]["ax"][2] - exo.cfg["save"]["x"]["ax"][1])
         * 2.0
         * np.pi
     )


### PR DESCRIPTION
## Summary

- add an `ergoExo` compatibility adapter that prepares and executes eligible TF1D and electrostatic PIC1D forward runs through `SimulationSpec`, the solver registry, and `run_prepared`
- reconstruct the historical `{"solver result": diffrax.Solution}` contract, including TF1D/PIC1D time layouts and PIC step statistics, while leaving MLflow, artifacts, and solver post-processing unchanged
- fall back before execution for custom modules, explicit or replaced legacy state/arguments, trainable modules, unsupported features/save layouts, and every solver without an explicit façade adapter
- keep `val_and_grad` on `ADEPTModule.vg`, expose the selected backend and fallback reason, and document the transition without adding deprecation warnings

## Scope

This is the first independently mergeable slice of #356. It does not deprecate or remove `ergoExo`/`ADEPTModule`, and it does not auto-route future solver registrations. Vlasov1D and LPSE2D remain on the legacy path until their dedicated builders and result adapters land.

## Verification

- 22 focused façade, builder, and PIC physics tests passed
- 21 façade/builder/TF1D public-interface tests passed, including the corrected config-immutability assertions
- 169 base/architecture/TF1D/PIC1D tests passed before manually stopping at the first long legacy `resonance_search` optimization case; the four remaining PIC physics tests were then run separately and passed
- full-suite sampling reached 410 passed / 9 skipped before exposing the stale TF1D test assumption corrected here
- repository pre-commit checks passed on every changed file
- Sphinx documentation build passed with warnings treated as errors

Advances #356.